### PR TITLE
chore: Set up checkstyle sonar reporting

### DIFF
--- a/.github/workflows/analyze-with-sonarqube.yml
+++ b/.github/workflows/analyze-with-sonarqube.yml
@@ -15,6 +15,8 @@ jobs:
           java-version: 11
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+      - name: Run Checks
+        run: ./gradlew check
       - name: Run SonarQube
         run: ./gradlew sonarqube
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -48,12 +48,11 @@ dependencies {
 checkstyle {
   toolVersion = "8.26"
   config = resources.text.fromArchiveEntry(configurations.checkstyle[0], 'google_checks.xml')
-  maxErrors = 0
-  maxWarnings = 0
 }
 
 jacocoTestReport {
   reports {
+    html.enabled true
     xml.enabled true
   }
 }
@@ -64,6 +63,9 @@ sonarqube {
     property "sonar.login", System.getenv("SONAR_TOKEN")
     property "sonar.organization", "health-education-england"
     property "sonar.projectKey", "Health-Education-England_TIS-TRAINEE-DETAILS"
+
+    property "sonar.java.checkstyle.reportPaths",
+      "build/reports/checkstyle/main.xml,build/reports/checkstyle/test.xml"
   }
 }
 


### PR DESCRIPTION
Run Gradle's check task during the pipeline so that sonar can upload the
checkstyle reports.

TISNEW-3874