### PR TITLE
chore: Add id to ECR login step of pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,6 +48,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: Log in to Amazon ECR
+        id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build, tag and push image to Amazon ECR


### PR DESCRIPTION
An ID is referenced in the docker build/push step to get the ECR
registry, but the ID was not declared on the correct step.

TISNEW-3848