### PR TITLE
chore: Add checkout step to dockerize job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
       - name: Download build artifact
         uses: actions/download-artifact@v2-preview
         with:


### PR DESCRIPTION
As the repo was not checked out the Dockerfile was not accessible.

TISNEW-3848