### PR TITLE
chore: Update pipeline to deploy ECR image

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -1,0 +1,40 @@
+{
+  "containerDefinitions": [
+    {
+      "name": "tis-trainee-details",
+      "image": "430723991443.dkr.ecr.eu-west-2.amazonaws.com/tis-trainee-details:eceec14565f633ce0ccc4ad2cfd812bf3ff469d4",
+      "portMappings": [
+        {
+          "containerPort": 8203,
+          "hostPort": 8203
+        }
+      ],
+      "environment": [
+        {
+          "name": "TITLE",
+          "value": "tis-trainee-details"
+        },
+        {
+          "name": "AWS_REGION",
+          "value": "eu-west-2"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "awslogs-tis-trainee-details",
+          "awslogs-region": "eu-west-2",
+          "awslogs-stream-prefix": "awslogs-tis-trainee-details"
+        }
+      }
+    }
+  ],
+  "executionRoleArn": "ecsTaskExecutionRole",
+  "family": "tis-trainee-details",
+  "requiresCompatibilities": [
+    "FARGATE"
+  ],
+  "networkMode": "awsvpc",
+  "cpu": "256",
+  "memory": "1024"
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,6 +55,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build, tag and push image to Amazon ECR
+        id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
@@ -62,3 +63,57 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          echo "::set-output name=image-uri::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+      - name: Write image uri
+        run: ${{ steps.build-image.outputs.image-uri }} > image-uri.txt
+
+      - name: Upload image uri
+        uses: actions/upload-artifact@v1
+        with:
+          name: image-uri
+          path: image-uri.txt
+
+  deploy:
+    name: Deploy
+    needs: dockerize
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Download image uri
+        uses: actions/download-artifact@v1
+        with:
+          name: image-uri
+
+      - name: Read image uri
+        id: read-image-uri
+        run:
+          image-uri = `cat image-uri.txt`
+          echo "::set-output name=image-uri::$image-uri"
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: ${{ github.event.repository.name }}
+          image: ${{ steps.read-image-uri.outputs.image-uri }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: eu-west-2
+
+      - name: Deploy Amazon ECS task definition
+        env:
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ github.event.repository.name }}
+          cluster: ${{ github.event.repository.name }}
+          wait-for-service-stability: true


### PR DESCRIPTION
Create task-definition.json with default values for deploying an ECR
image, the image URI will be overwritten by a pipeline action.

Update deploy.yml to store the image-uri from the dockerize job and add
a deploy step to deploy the image in ECR to ECS.

TISNEW-3848