### PR TITLE
chore: Get registry name from ECR login

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,6 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build, tag and push image to Amazon ECR
-        id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
@@ -63,16 +62,6 @@ jobs:
         run: |
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          echo "::set-output name=image-uri::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-
-      - name: Write image uri
-        run: echo ${{ steps.build-image.outputs.image-uri }} > image-uri.txt
-
-      - name: Upload image uri
-        uses: actions/upload-artifact@v1
-        with:
-          name: image-uri
-          path: image-uri.txt
 
   deploy:
     name: Deploy
@@ -83,32 +72,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Download image uri
-        uses: actions/download-artifact@v1
-        with:
-          name: image-uri
-          path: ./
-
-      - name: Read image uri
-        id: read-image-uri
-        run: |
-          imageUri=`cat image-uri.txt`
-          echo "::set-output name=image-uri::$imageUri"
-
-      - name: Fill in the new image ID in the Amazon ECS task definition
-        id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
-        with:
-          task-definition: .aws/task-definition.json
-          container-name: ${{ github.event.repository.name }}
-          image: ${{ steps.read-image-uri.outputs.image-uri }}
-
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ github.event.repository.name }}
+          IMAGE_TAG: ${{ github.sha }}
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: .aws/task-definition.json
+          container-name: ${{ github.event.repository.name }}
+          image: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1


### PR DESCRIPTION
Currently a build artifact is used to pass through a plain text image
uri, get the registry name from logging in to ECR instead.

TISNEW-3848