### PR TITLE
chore: Update task-definition to connect to DB

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -26,7 +26,25 @@
           "awslogs-region": "eu-west-2",
           "awslogs-stream-prefix": "awslogs-tis-trainee-details"
         }
-      }
+      },
+      "secrets": [
+        {
+          "name": "DB_HOST",
+          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-trainee-db-host"
+        },
+        {
+          "name": "DB_PORT",
+          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-trainee-db-port"
+        },
+        {
+          "name": "DB_USER",
+          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-trainee-db-user"
+        },
+        {
+          "name": "DB_PASSWORD",
+          "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-trainee-db-password"
+        }
+      ]
     }
   ],
   "executionRoleArn": "ecsTaskExecutionRole",


### PR DESCRIPTION
The service needs several env vars to be passed to connect to the
document db instance, the values for these are stored in AWS. Use the
secrets section to declared the environmental variables to be used.

TISNEW-3848