### PR TITLE
chore: add spring-boot-starter-actuator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   // Spring Boot
   implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
   implementation "org.springframework.boot:spring-boot-starter-web"
+  implementation "org.springframework.boot:spring-boot-starter-actuator"
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 
   // Lombok


### PR DESCRIPTION
By addding this dependency, it automatically exposes two endpoints `/health` and `/info`. 
For `/info`, because there isn't any info configured for this project, it will just return a empty array.

Atm, we just need the `/health` endpoint, if we need to expose others, they can be configured later.

The whole api is `http://localhost:8023/actuator/health`.