### PR TITLE
refactor: Set context path

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 #server port
 server.port=8203
+server.servlet.context-path=/trainee
 #mongodb
 spring.data.mongodb.uri=mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:trainee}
 #logging


### PR DESCRIPTION
AWS ALB is unable to rewrite paths, so to avoid a separate nginx
instance the service must have its own context path.

TISNEW-3848