### PR TITLE
chore: Remove redundant test dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,10 +44,6 @@ dependencies {
   // Swagger
   implementation "io.springfox:springfox-swagger2:2.9.2"
   implementation "io.springfox:springfox-swagger-ui:2.9.2"
-
-  // test
-  testImplementation('org.junit.jupiter:junit-jupiter-engine:5.2.0')
-  testImplementation('org.mockito:mockito-junit-jupiter:2.23.0')
 }
 
 checkstyle {


### PR DESCRIPTION
The test dependendies are provided by the Spring Boot test starter and
do no need to be declared separately.

NO-TICKET