### PR TITLE
chore: Let Spring Boot determine Lombok version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,8 @@ dependencies {
   testImplementation "org.springframework.boot:spring-boot-starter-test"
 
   // Lombok
-  compileOnly "org.projectlombok:lombok:1.18.10"
-  annotationProcessor "org.projectlombok:lombok:1.18.10"
+  compileOnly "org.projectlombok:lombok"
+  annotationProcessor "org.projectlombok:lombok"
 
   // Mapstruct
   implementation "org.mapstruct:mapstruct:1.3.1.Final"


### PR DESCRIPTION
The Spring Boot plugin can manage the version of Lombok, remove the
specific versions from the dependency declaration to allow that to
happen.

NO-TICKET