### PR TITLE
feat: Get trainee TIS ID from the token

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.1.0"
+version = "0.2.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
@@ -21,10 +21,16 @@
 
 package uk.nhs.hee.trainee.details.api;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
@@ -33,11 +39,12 @@ import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapper;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.service.TraineeProfileService;
 
+@Slf4j
 @RestController
 @RequestMapping("/api")
 public class TraineeProfileResource {
 
-  private static final Logger log = LoggerFactory.getLogger(TraineeProfileResource.class);
+  private static final String TIS_ID_ATTRIBUTE = "custom:tisId";
 
   private TraineeProfileService traineeProfileService;
   private TraineeProfileMapper traineeProfileMapper;
@@ -48,37 +55,40 @@ public class TraineeProfileResource {
     this.traineeProfileMapper = traineeProfileMapper;
   }
 
-
   /**
-   * Get a trainee profile record with a given ID.
+   * Get a trainee's profile.
    *
-   * @param traineeProfileId The ID of the trainee profile to get.
+   * @param token The authorization token from the request header.
    * @return The {@link PersonalDetailsDto} representing the trainee profile.
    */
-  @GetMapping("/trainee-profile/{id}")
-  public TraineeProfileDto getTraineeProfileById(
-      @PathVariable(name = "id") String traineeProfileId) {
-    log.trace("Trainee Profile of a trainee by traineeProfileId {}", traineeProfileId);
-    TraineeProfile traineeProfile = traineeProfileService.getTraineeProfile(traineeProfileId);
-    traineeProfile = traineeProfileService.hidePastProgrammes(traineeProfile);
-    traineeProfile = traineeProfileService.hidePastPlacements(traineeProfile);
-    return traineeProfileMapper.toDto(traineeProfile);
-  }
+  @GetMapping("/trainee-profile")
+  public ResponseEntity<TraineeProfileDto> getTraineeProfile(
+      @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+    log.trace("Trainee Profile of authenticated user.");
 
-  /**
-   * Get a trainee's trainee profile based on the trainee's ID.
-   *
-   * @param traineeId The trainee's TIS ID.
-   * @return The {@link PersonalDetailsDto} representing the trainee profile.
-   */
-  @GetMapping("/trainee-profile/trainee/{traineeId}")
-  public TraineeProfileDto getTraineeProfileByTraineeId(
-      @PathVariable(name = "traineeId") String traineeId) {
-    log.trace("Trainee Profile of a trainee by traineeId {}", traineeId);
-    TraineeProfile traineeProfile = traineeProfileService
-        .getTraineeProfileByTraineeTisId(traineeId);
+    String[] tokenSections = token.split("\\.");
+    byte[] payloadBytes = Base64.getDecoder()
+        .decode(tokenSections[1].getBytes(StandardCharsets.UTF_8));
+    String tisId;
+
+    try {
+      ObjectMapper mapper = new ObjectMapper();
+      Map payload = mapper.readValue(payloadBytes, Map.class);
+      tisId = (String) payload.get(TIS_ID_ATTRIBUTE);
+    } catch (IOException e) {
+      log.warn("Unable to read tisId from token.", e);
+      return ResponseEntity.badRequest().build();
+    }
+
+    TraineeProfile traineeProfile = traineeProfileService.getTraineeProfileByTraineeTisId(tisId);
+
+    if (traineeProfile == null) {
+      log.warn("Trainee profile not found for id {}.", tisId);
+      return ResponseEntity.notFound().build();
+    }
+
     traineeProfile = traineeProfileService.hidePastProgrammes(traineeProfile);
     traineeProfile = traineeProfileService.hidePastPlacements(traineeProfile);
-    return traineeProfileMapper.toDto(traineeProfile);
+    return ResponseEntity.ok(traineeProfileMapper.toDto(traineeProfile));
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
@@ -48,11 +48,13 @@ public class TraineeProfileResource {
 
   private TraineeProfileService traineeProfileService;
   private TraineeProfileMapper traineeProfileMapper;
+  private ObjectMapper objectMapper;
 
   public TraineeProfileResource(TraineeProfileService traineeProfileService,
-      TraineeProfileMapper traineeProfileMapper) {
+      TraineeProfileMapper traineeProfileMapper, ObjectMapper objectMapper) {
     this.traineeProfileService = traineeProfileService;
     this.traineeProfileMapper = traineeProfileMapper;
+    this.objectMapper = objectMapper;
   }
 
   /**
@@ -72,8 +74,7 @@ public class TraineeProfileResource {
     String tisId;
 
     try {
-      ObjectMapper mapper = new ObjectMapper();
-      Map payload = mapper.readValue(payloadBytes, Map.class);
+      Map payload = objectMapper.readValue(payloadBytes, Map.class);
       tisId = (String) payload.get(TIS_ID_ATTRIBUTE);
     } catch (IOException e) {
       log.warn("Unable to read tisId from token.", e);

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -25,8 +25,6 @@ import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
 public interface TraineeProfileService {
 
-  TraineeProfile getTraineeProfile(String id);
-
   TraineeProfile getTraineeProfileByTraineeTisId(String traineeTisId);
 
   TraineeProfile save(TraineeProfile traineeProfile);

--- a/src/main/java/uk/nhs/hee/trainee/details/service/impl/TraineeProfileServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/impl/TraineeProfileServiceImpl.java
@@ -36,23 +36,23 @@ public class TraineeProfileServiceImpl implements TraineeProfileService {
     this.repository = repository;
   }
 
-  public TraineeProfile getTraineeProfile(String id) {
-    return repository.findById(id).orElse(null);
-  }
-
+  @Override
   public TraineeProfile getTraineeProfileByTraineeTisId(String traineeTisId) {
     return repository.findByTraineeTisId(traineeTisId);
   }
 
+  @Override
   public TraineeProfile save(TraineeProfile traineeProfile) {
     return repository.save(traineeProfile);
   }
 
+  @Override
   public TraineeProfile hidePastProgrammes(TraineeProfile traineeProfile) {
     traineeProfile.getProgrammeMemberships().removeIf(c -> c.getStatus() == Status.PAST);
     return traineeProfile;
   }
 
+  @Override
   public TraineeProfile hidePastPlacements(TraineeProfile traineeProfile) {
     traineeProfile.getPlacements().removeIf(c -> c.getStatus() == Status.PAST);
     return traineeProfile;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,7 +2,7 @@
 server.port=8203
 server.servlet.context-path=/trainee
 #mongodb
-spring.data.mongodb.uri=mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:trainee}
+spring.data.mongodb.uri=mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:trainee}?authSource=admin
 #logging
 logging.level.org.springframework.data=debug
 logging.level.root=INFO

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -26,6 +26,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -104,6 +105,9 @@ class TraineeProfileResourceTest {
   @Autowired
   private MappingJackson2HttpMessageConverter jacksonMessageConverter;
 
+  @Autowired
+  private ObjectMapper objectMapper;
+
   private MockMvc mockMvc;
 
   @MockBean
@@ -122,7 +126,7 @@ class TraineeProfileResourceTest {
   void setup() {
     TraineeProfileMapper mapper = Mappers.getMapper(TraineeProfileMapper.class);
     TraineeProfileResource traineeProfileResource = new TraineeProfileResource(
-        traineeProfileServiceMock, mapper);
+        traineeProfileServiceMock, mapper, objectMapper);
     this.mockMvc = MockMvcBuilders.standaloneSetup(traineeProfileResource)
         .setMessageConverters(jacksonMessageConverter)
         .build();

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.Lists;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Optional;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -180,15 +179,6 @@ class TraineeProfileServiceTest {
     placement2.setPlacementTisId(PLACEMENT_TISID2);
     placement2.setSite(PLACEMENT_SITE2);
     placement2.setStatus(PLACEMENT_STATUS2);
-  }
-
-  @Test
-  void getTraineeProfileShouldReturnTraineeProfile() {
-    when(traineeProfileRepositoryMock.findById(DEFAULT_ID_1))
-        .thenReturn(Optional.of(traineeProfile));
-    TraineeProfile returnedTraineeProfile = traineeProfileServiceImpl
-        .getTraineeProfile(DEFAULT_ID_1);
-    Assert.assertEquals(returnedTraineeProfile, traineeProfile);
   }
 
   @Test


### PR DESCRIPTION
Currently the trainee's TIS ID is provided as part of the request URL,
as this needs to be locked down to only allow the logged in user to see
their own details the ID should be taken from the authorization token
instead.

TISNEW-3833