### PR TITLE
fix: Updating a trainee skeleton causes a NPE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.3.0"
+version = "0.3.1"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/PersonalDetailsMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/PersonalDetailsMapper.java
@@ -21,10 +21,7 @@
 
 package uk.nhs.hee.trainee.details.mapper;
 
-import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 
@@ -34,25 +31,4 @@ public interface PersonalDetailsMapper {
   PersonalDetailsDto toDto(PersonalDetails entity);
 
   PersonalDetails toEntity(PersonalDetailsDto dto);
-
-  @BeanMapping(ignoreByDefault = true)
-  @Mapping(target = "title", source = "title")
-  @Mapping(target = "forenames", source = "forenames")
-  @Mapping(target = "knownAs", source = "knownAs")
-  @Mapping(target = "surname", source = "surname")
-  @Mapping(target = "maidenName", source = "maidenName")
-  @Mapping(target = "telephoneNumber", source = "telephoneNumber")
-  @Mapping(target = "mobileNumber", source = "mobileNumber")
-  @Mapping(target = "email", source = "email")
-  @Mapping(target = "address1", source = "address1")
-  @Mapping(target = "address2", source = "address2")
-  @Mapping(target = "address3", source = "address3")
-  @Mapping(target = "address4", source = "address4")
-  @Mapping(target = "postCode", source = "postCode")
-  void updateContactDetails(@MappingTarget PersonalDetails target, PersonalDetails source);
-
-  @BeanMapping(ignoreByDefault = true)
-  @Mapping(target = "dateOfBirth", source = "dateOfBirth")
-  @Mapping(target = "gender", source = "gender")
-  void updatePersonalInfo(@MappingTarget PersonalDetails target, PersonalDetails source);
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
@@ -21,9 +21,12 @@
 
 package uk.nhs.hee.trainee.details.mapper;
 
-import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
 import uk.nhs.hee.trainee.details.dto.TraineeProfileDto;
+import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
 @Mapper(componentModel = "spring")
@@ -31,6 +34,26 @@ public interface TraineeProfileMapper {
 
   TraineeProfileDto toDto(TraineeProfile traineeProfile);
 
-  @InheritInverseConfiguration
   TraineeProfile toEntity(TraineeProfileDto traineeProfileDto);
+
+  @BeanMapping(ignoreByDefault = true)
+  @Mapping(target = "personalDetails.title", source = "title")
+  @Mapping(target = "personalDetails.forenames", source = "forenames")
+  @Mapping(target = "personalDetails.knownAs", source = "knownAs")
+  @Mapping(target = "personalDetails.surname", source = "surname")
+  @Mapping(target = "personalDetails.maidenName", source = "maidenName")
+  @Mapping(target = "personalDetails.telephoneNumber", source = "telephoneNumber")
+  @Mapping(target = "personalDetails.mobileNumber", source = "mobileNumber")
+  @Mapping(target = "personalDetails.email", source = "email")
+  @Mapping(target = "personalDetails.address1", source = "address1")
+  @Mapping(target = "personalDetails.address2", source = "address2")
+  @Mapping(target = "personalDetails.address3", source = "address3")
+  @Mapping(target = "personalDetails.address4", source = "address4")
+  @Mapping(target = "personalDetails.postCode", source = "postCode")
+  void updateContactDetails(@MappingTarget TraineeProfile target, PersonalDetails source);
+
+  @BeanMapping(ignoreByDefault = true)
+  @Mapping(target = "personalDetails.dateOfBirth", source = "dateOfBirth")
+  @Mapping(target = "personalDetails.gender", source = "gender")
+  void updatePersonalInfo(@MappingTarget TraineeProfile target, PersonalDetails source);
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/impl/PersonalDetailsServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/impl/PersonalDetailsServiceImpl.java
@@ -23,7 +23,7 @@ package uk.nhs.hee.trainee.details.service.impl;
 
 import java.util.Optional;
 import org.springframework.stereotype.Service;
-import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
+import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
@@ -33,9 +33,9 @@ import uk.nhs.hee.trainee.details.service.TraineeProfileService;
 public class PersonalDetailsServiceImpl implements PersonalDetailsService {
 
   private final TraineeProfileService profileService;
-  private PersonalDetailsMapper mapper;
+  private TraineeProfileMapper mapper;
 
-  PersonalDetailsServiceImpl(TraineeProfileService profileService, PersonalDetailsMapper mapper) {
+  PersonalDetailsServiceImpl(TraineeProfileService profileService, TraineeProfileMapper mapper) {
     this.profileService = profileService;
     this.mapper = mapper;
   }
@@ -49,7 +49,7 @@ public class PersonalDetailsServiceImpl implements PersonalDetailsService {
       return Optional.empty();
     }
 
-    mapper.updateContactDetails(traineeProfile.getPersonalDetails(), personalDetails);
+    mapper.updateContactDetails(traineeProfile, personalDetails);
     return Optional.of(profileService.save(traineeProfile).getPersonalDetails());
   }
 
@@ -60,7 +60,7 @@ public class PersonalDetailsServiceImpl implements PersonalDetailsService {
     if (traineeProfile == null) {
       return Optional.empty();
     }
-    mapper.updatePersonalInfo(traineeProfile.getPersonalDetails(), personalDetails);
+    mapper.updatePersonalInfo(traineeProfile, personalDetails);
     return Optional.of(profileService.save(traineeProfile).getPersonalDetails());
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/impl/PersonalDetailsServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/impl/PersonalDetailsServiceImplTest.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
-import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
+import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
@@ -84,7 +84,7 @@ class PersonalDetailsServiceImplTest {
     repository = mock(TraineeProfileRepository.class);
     TraineeProfileServiceImpl profileService = new TraineeProfileServiceImpl(repository);
     service = new PersonalDetailsServiceImpl(profileService,
-        Mappers.getMapper(PersonalDetailsMapper.class));
+        Mappers.getMapper(TraineeProfileMapper.class));
   }
 
   @Test
@@ -129,6 +129,36 @@ class PersonalDetailsServiceImplTest {
   }
 
   @Test
+  void shouldPopulateContactDetailsWhenTraineeSkeletonFound() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+
+    when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
+    when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
+
+    Optional<PersonalDetails> personalDetails = service
+        .updateContactDetailsByTisId("40", createPersonalDetails("post", 100));
+
+    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(false));
+
+    PersonalDetails expectedPersonalDetails = new PersonalDetails();
+    expectedPersonalDetails.setTitle(TITLE + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setForenames(FORENAMES + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setKnownAs(KNOWN_AS + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setSurname(SURNAME + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setMaidenName(MAIDEN_NAME + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setTelephoneNumber(TELEPHONE_NUMBER + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setMobileNumber(MOBILE_NUMBER + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setEmail(EMAIL + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setAddress1(ADDRESS_1 + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setAddress2(ADDRESS_2 + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setAddress3(ADDRESS_3 + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setAddress4(ADDRESS_4 + MODIFIED_SUFFIX);
+    expectedPersonalDetails.setPostCode(POST_CODE + MODIFIED_SUFFIX);
+
+    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+  }
+
+  @Test
   void shouldNotUpdatePersonalInfoWhenTraineeIdNotFound() {
     PersonalDetails personalDetailsMock = mock(PersonalDetails.class);
     Optional<PersonalDetails> personalDetails = service
@@ -154,6 +184,26 @@ class PersonalDetailsServiceImplTest {
     assertTrue(personalDetails.isPresent(), "Expected a PersonalDetails to be returned");
 
     PersonalDetails expectedPersonalDetails = createPersonalDetails(ORIGINAL_SUFFIX, 0);
+    expectedPersonalDetails.setDateOfBirth(DATE.plusDays(ONE_HUNDRED));
+    expectedPersonalDetails.setGender(GENDER + MODIFIED_SUFFIX);
+
+    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+  }
+
+  @Test
+  void shouldPopulatePersonalInfoWhenTraineeSkeletonFound() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+    when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
+
+    Optional<PersonalDetails> personalDetails = service
+        .updatePersonalInfoByTisId(
+            TRAINEE_TIS_ID, createPersonalDetails(MODIFIED_SUFFIX, ONE_HUNDRED));
+
+    assertTrue(personalDetails.isPresent(), "Expected a PersonalDetails to be returned");
+
+    PersonalDetails expectedPersonalDetails = new PersonalDetails();
     expectedPersonalDetails.setDateOfBirth(DATE.plusDays(ONE_HUNDRED));
     expectedPersonalDetails.setGender(GENDER + MODIFIED_SUFFIX);
 


### PR DESCRIPTION
The update mapper for PersonalDetails attempts to update the existing
PersonalDetails for the TraineeProfile. In the case of a skeleton
profile being created this will be null and the update will throw a
NullPointerException.
Update the mappers in such a way that it will automatically create and
set the PersonalDetails field in the TraineeProfile as part of the
update if it is null.

TISNEW-3833