### PR TITLE
feat: Allow sync of public health number

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.4.1"
+version = "0.5.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
+import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
+import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/basic-details")
+public class BasicDetailsResource {
+
+  private PersonalDetailsService service;
+  private PersonalDetailsMapper mapper;
+
+  public BasicDetailsResource(PersonalDetailsService service, PersonalDetailsMapper mapper) {
+    this.service = service;
+    this.mapper = mapper;
+  }
+
+  /**
+   * Update the person details for the trainee, creates the parent profile if it does not already
+   * exist.
+   *
+   * @param tisId The ID of the trainee to update.
+   * @param dto   The person details to update with.
+   * @return The updated or created PersonalDetails.
+   */
+  @PatchMapping("/{tisId}")
+  public ResponseEntity<PersonalDetailsDto> updateBasicDetails(
+      @PathVariable(name = "tisId") String tisId, @RequestBody PersonalDetailsDto dto) {
+    log.trace("Update basic details of trainee with TIS ID {}", tisId);
+    PersonalDetails entity = mapper.toEntity(dto);
+    entity = service.createProfileOrUpdateBasicDetailsByTisId(tisId, entity);
+    return ResponseEntity.ok(mapper.toDto(entity));
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
@@ -29,16 +29,12 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
 import uk.nhs.hee.trainee.details.dto.TraineeProfileDto;
-import uk.nhs.hee.trainee.details.dto.validation.Create;
 import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapper;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.service.TraineeProfileService;
@@ -59,24 +55,6 @@ public class TraineeProfileResource {
     this.service = service;
     this.mapper = mapper;
     this.objectMapper = objectMapper;
-  }
-
-  /**
-   * Create a trainee profile with the given data. The traineeTisId field is required.
-   *
-   * @param dto The trainee profile data to insert.
-   * @return The inserted profile, or any pre-existing profile for the trainee's TIS ID.
-   */
-  @PostMapping
-  public ResponseEntity<TraineeProfileDto> createTraineeProfile(
-      @RequestBody @Validated(Create.class) TraineeProfileDto dto) {
-    TraineeProfile entity = service.getTraineeProfileByTraineeTisId(dto.getTraineeTisId());
-
-    if (entity == null) {
-      entity = service.save(mapper.toEntity(dto));
-    }
-
-    return ResponseEntity.ok(mapper.toDto(entity));
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
@@ -37,6 +37,10 @@ public interface TraineeProfileMapper {
   TraineeProfile toEntity(TraineeProfileDto traineeProfileDto);
 
   @BeanMapping(ignoreByDefault = true)
+  @Mapping(target = "personalDetails.publicHealthNumber", source = "publicHealthNumber")
+  void updateBasicDetails(@MappingTarget TraineeProfile target, PersonalDetails source);
+
+  @BeanMapping(ignoreByDefault = true)
   @Mapping(target = "personalDetails.title", source = "title")
   @Mapping(target = "personalDetails.forenames", source = "forenames")
   @Mapping(target = "personalDetails.knownAs", source = "knownAs")

--- a/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetails.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetails.java
@@ -27,36 +27,36 @@ import lombok.Data;
 @Data
 public class PersonalDetails {
 
-  private String surname;
-  private String forenames;
-  private String knownAs;
-  private String maidenName;
-  private String title;
-  private String personOwner;
-  private LocalDate dateOfBirth;
-  private String gender;
-  private String qualification;
-  private LocalDate dateAttained;
-  private String medicalSchool;
-  private String telephoneNumber;
-  private String mobileNumber;
-  private String email;
-  private String address1;
-  private String address2;
-  private String address3;
-  private String address4;
-  private String postCode;
-  private String gmcNumber;
-  private String gmcStatus;
-  private String gdcNumber;
-  private String gdcStatus;
-  private String publicHealthNumber;
-  private String eeaResident;
-  private String permitToWork;
-  private String settled;
-  private LocalDate visaIssued;
-  private String detailsNumber;
-  private String prevRevalBody;
-  private LocalDate currRevalDate;
-  private LocalDate prevRevalDate;
+  private String surname; // ContactDetails
+  private String forenames; // ContactDetails
+  private String knownAs; // ContactDetails
+  private String maidenName; // ContactDetails
+  private String title; // ContactDetails
+  private String personOwner; // PersonOwner
+  private LocalDate dateOfBirth; // PersonalDetails
+  private String gender; // PersonalDetails
+  private String qualification; // TODO: Qualifcation
+  private LocalDate dateAttained; // TODO: Qualifcation
+  private String medicalSchool; // TODO: Qualifcation
+  private String telephoneNumber; // ContactDetails
+  private String mobileNumber; // ContactDetails
+  private String email; // ContactDetails
+  private String address1; // ContactDetails
+  private String address2; // ContactDetails
+  private String address3; // ContactDetails
+  private String address4; // ContactDetails
+  private String postCode; // ContactDetails
+  private String gmcNumber; // GmcDetails
+  private String gmcStatus; // GmcDetails
+  private String gdcNumber; // GdcDetails
+  private String gdcStatus; // GdcDetails
+  private String publicHealthNumber; // Person
+  private String eeaResident; // TODO:
+  private String permitToWork; // TODO:
+  private String settled; // TODO:
+  private LocalDate visaIssued; // TODO:
+  private String detailsNumber; // TODO:
+  private String prevRevalBody; // TODO:
+  private LocalDate currRevalDate; // TODO:
+  private LocalDate prevRevalDate; // TODO:
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
@@ -27,6 +27,17 @@ import uk.nhs.hee.trainee.details.model.PersonalDetails;
 public interface PersonalDetailsService {
 
   /**
+   * Update the basic details for the trainee with the given TIS ID, or create a new profile if the
+   * trainee does not exist.
+   *
+   * @param tisId           The TIS id of the trainee.
+   * @param personalDetails The personal details to add to the trainee.
+   * @return The updated or created personal details.
+   */
+  PersonalDetails createProfileOrUpdateBasicDetailsByTisId(String tisId,
+      PersonalDetails personalDetails);
+
+  /**
    * Update the GDC details for the trainee with the given TIS ID.
    *
    * @param tisId           The TIS id of the trainee.

--- a/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.api;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
+import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
+import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
+
+@ContextConfiguration(classes = {PersonalDetailsMapper.class})
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(ContactDetailsResource.class)
+class BasicDetailsResourceTest {
+
+  @Autowired
+  private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+
+  @Autowired
+  private ObjectMapper mapper;
+
+  private MockMvc mockMvc;
+
+  @MockBean
+  private PersonalDetailsService service;
+
+  @BeforeEach
+  void setUp() {
+    PersonalDetailsMapper mapper = Mappers.getMapper(PersonalDetailsMapper.class);
+    BasicDetailsResource resource = new BasicDetailsResource(service, mapper);
+    mockMvc = MockMvcBuilders.standaloneSetup(resource)
+        .setMessageConverters(jacksonMessageConverter)
+        .build();
+  }
+
+  @Test
+  void shouldUpdateBasicDetailsWhenTraineeFound() throws Exception {
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setPublicHealthNumber("phnValue");
+
+    when(service.createProfileOrUpdateBasicDetailsByTisId(eq("40"), any(PersonalDetails.class)))
+        .thenReturn(personalDetails);
+
+    mockMvc.perform(patch("/api/basic-details/{tisId}", 40)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(mapper.writeValueAsBytes(new PersonalDetailsDto())))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.publicHealthNumber").value(is("phnValue")));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -21,10 +21,8 @@
 
 package uk.nhs.hee.trainee.details.api;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -49,7 +47,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import uk.nhs.hee.trainee.details.dto.TraineeProfileDto;
 import uk.nhs.hee.trainee.details.dto.enumeration.Status;
 import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapper;
 import uk.nhs.hee.trainee.details.model.Curriculum;
@@ -210,74 +207,6 @@ class TraineeProfileResourceTest {
     placement.setPlacementTisId(PLACEMENT_TISID);
     placement.setSite(PLACEMENT_SITE);
     placement.setStatus(PLACEMENT_STATUS);
-  }
-
-  @Test
-  void postShouldCreateNewProfile() throws Exception {
-    TraineeProfileDto dto = new TraineeProfileDto();
-    dto.setTraineeTisId("tisId");
-
-    when(service.save(any(TraineeProfile.class))).then(invocation -> {
-      TraineeProfile entity = invocation.getArgument(0);
-      entity.setId("newId");
-      return entity;
-    });
-
-    this.mockMvc.perform(post("/api/trainee-profile")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsBytes(dto)))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value("newId"))
-        .andExpect(jsonPath("$.traineeTisId").value("tisId"));
-  }
-
-  @Test
-  void postShouldReturnExistingProfile() throws Exception {
-    TraineeProfileDto dto = new TraineeProfileDto();
-    dto.setTraineeTisId("tisId");
-
-    when(service.getTraineeProfileByTraineeTisId("tisId")).thenReturn(traineeProfile);
-
-    this.mockMvc.perform(post("/api/trainee-profile")
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(objectMapper.writeValueAsBytes(dto)))
-        .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-        .andExpect(jsonPath("$.id").value(DEFAULT_ID_1))
-        .andExpect(jsonPath("$.traineeTisId").value(DEFAULT_TIS_ID_1))
-        .andExpect(jsonPath("$.personalDetails.surname").value(PERSON_SURNAME))
-        .andExpect(jsonPath("$.personalDetails.forenames").value(PERSON_FORENAME))
-        .andExpect(jsonPath("$.personalDetails.knownAs").value(PERSON_KNOWNAS))
-        .andExpect(jsonPath("$.personalDetails.maidenName").value(PERSON_MAIDENNAME))
-        .andExpect(jsonPath("$.personalDetails.title").value(PERSON_TITLE))
-        .andExpect(jsonPath("$.personalDetails.personOwner").value(PERSON_PERSONOWNER))
-        .andExpect(jsonPath("$.personalDetails.dateOfBirth").value(PERSON_DATEOFBIRTH.toString()))
-        .andExpect(jsonPath("$.personalDetails.gender").value(PERSON_GENDER))
-        .andExpect(jsonPath("$.personalDetails.qualification").value(PERSON_QUALIFICATION))
-        .andExpect(jsonPath("$.personalDetails.dateAttained").value(PERSON_DATEATTAINED.toString()))
-        .andExpect(jsonPath("$.personalDetails.medicalSchool").value(PERSON_MEDICALSCHOOL))
-        .andExpect(jsonPath("$.personalDetails.telephoneNumber").value(PERSON_TELEPHONENUMBER))
-        .andExpect(jsonPath("$.personalDetails.mobileNumber").value(PERSON_MOBILE))
-        .andExpect(jsonPath("$.personalDetails.email").value(PERSON_EMAIL))
-        .andExpect(jsonPath("$.personalDetails.address1").value(PERSON_ADDRESS1))
-        .andExpect(jsonPath("$.personalDetails.address2").value(PERSON_ADDRESS2))
-        .andExpect(jsonPath("$.personalDetails.address3").value(PERSON_ADDRESS3))
-        .andExpect(jsonPath("$.personalDetails.address4").value(PERSON_ADDRESS4))
-        .andExpect(jsonPath("$.personalDetails.postCode").value(PERSON_POSTCODE))
-        .andExpect(jsonPath("$.personalDetails.gmcNumber").value(PERSON_GMC))
-        .andExpect(jsonPath("$.programmeMemberships[*].programmeTisId").value(PROGRAMME_TISID))
-        .andExpect(jsonPath("$.programmeMemberships[*].programmeName").value(PROGRAMME_NAME))
-        .andExpect(jsonPath("$.programmeMemberships[*].programmeNumber").value(PROGRAMME_NUMBER))
-        .andExpect(jsonPath("$.programmeMemberships[*].curricula[*].curriculumTisId")
-            .value(CURRICULUM_TISID))
-        .andExpect(jsonPath("$.programmeMemberships[*].curricula[*].curriculumName")
-            .value(CURRICULUM_NAME))
-        .andExpect(jsonPath("$.programmeMemberships[*].curricula[*].curriculumSubType")
-            .value(CURRICULUM_SUBTYPE))
-        .andExpect(jsonPath("$.placements[*].placementTisId").value(PLACEMENT_TISID))
-        .andExpect(jsonPath("$.placements[*].site").value(PLACEMENT_SITE))
-        .andExpect(jsonPath("$.placements[*].status").value(PLACEMENT_STATUS.toString()));
   }
 
   @Test


### PR DESCRIPTION
The public health number needs to be synced from the person table. Due
to the requirement of creating a skeleton and public health number
from the same table the existing POST endpoint should be removed in
favour of a new `PATCH: basic-details` endpoint.

TISNEW-5238