### PR TITLE
feat: Add endpoint to sync qualifications

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.5.0"
+version = "0.6.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/QualificationResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/QualificationResource.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.api;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import uk.nhs.hee.trainee.details.dto.QualificationDto;
+import uk.nhs.hee.trainee.details.mapper.QualificationMapper;
+import uk.nhs.hee.trainee.details.model.Qualification;
+import uk.nhs.hee.trainee.details.service.QualificationService;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/qualification")
+public class QualificationResource {
+
+  private QualificationService service;
+  private QualificationMapper mapper;
+
+  public QualificationResource(QualificationService service, QualificationMapper mapper) {
+    this.service = service;
+    this.mapper = mapper;
+  }
+
+  /**
+   * Update the person details for the trainee, creates the parent profile if it does not already
+   * exist.
+   *
+   * @param traineeTisId The ID of the trainee to update.
+   * @param dto          The person details to update with.
+   * @return The updated or created Qualification.
+   */
+  @PatchMapping("/{traineeTisId}")
+  public ResponseEntity<QualificationDto> updateQualification(
+      @PathVariable(name = "traineeTisId") String traineeTisId,
+      @RequestBody @Validated QualificationDto dto) {
+    log.trace("Update basic details of trainee with TIS ID {}", traineeTisId);
+    Qualification entity = mapper.toEntity(dto);
+    Optional<Qualification> optionalEntity = service
+        .updateQualificationByTisId(traineeTisId, entity);
+    entity = optionalEntity
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Trainee not found."));
+    return ResponseEntity.ok(mapper.toDto(entity));
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/QualificationDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/QualificationDto.java
@@ -21,24 +21,19 @@
 
 package uk.nhs.hee.trainee.details.dto;
 
-import java.util.List;
+import java.time.LocalDate;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
 import lombok.Data;
-import uk.nhs.hee.trainee.details.dto.validation.Create;
 
 /**
- * A DTO for TraineeProfile entity Holds the fields for all the information of the trainee.
+ * A DTO for Qualification entity, holds the fields for qualification information of the trainee.
  */
 @Data
-public class TraineeProfileDto {
+public class QualificationDto {
 
-  @Null(groups = Create.class)
-  private String id;
-  @NotNull(groups = Create.class)
-  private String traineeTisId;
-  private PersonalDetailsDto personalDetails;
-  private List<QualificationDto> qualifications;
-  private List<ProgrammeMembershipDto> programmeMemberships;
-  private List<PlacementDto> placements;
+  @NotNull
+  private String tisId;
+  private String qualification;
+  private LocalDate dateAttained;
+  private String medicalSchool;
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/QualificationMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/QualificationMapper.java
@@ -19,26 +19,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.dto;
+package uk.nhs.hee.trainee.details.mapper;
 
-import java.util.List;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
-import lombok.Data;
-import uk.nhs.hee.trainee.details.dto.validation.Create;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import uk.nhs.hee.trainee.details.dto.QualificationDto;
+import uk.nhs.hee.trainee.details.model.Qualification;
 
-/**
- * A DTO for TraineeProfile entity Holds the fields for all the information of the trainee.
- */
-@Data
-public class TraineeProfileDto {
+@Mapper(componentModel = "spring")
+public interface QualificationMapper {
 
-  @Null(groups = Create.class)
-  private String id;
-  @NotNull(groups = Create.class)
-  private String traineeTisId;
-  private PersonalDetailsDto personalDetails;
-  private List<QualificationDto> qualifications;
-  private List<ProgrammeMembershipDto> programmeMemberships;
-  private List<PlacementDto> placements;
+  QualificationDto toDto(Qualification entity);
+
+  Qualification toEntity(QualificationDto dto);
+
+  void updateQualification(@MappingTarget Qualification target, Qualification source);
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetails.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetails.java
@@ -35,9 +35,9 @@ public class PersonalDetails {
   private String personOwner; // PersonOwner
   private LocalDate dateOfBirth; // PersonalDetails
   private String gender; // PersonalDetails
-  private String qualification; // TODO: Qualifcation
-  private LocalDate dateAttained; // TODO: Qualifcation
-  private String medicalSchool; // TODO: Qualifcation
+  private String qualification; // TODO: Remove when FE can handle sub-collection.
+  private LocalDate dateAttained; // TODO: Remove when FE can handle sub-collection.
+  private String medicalSchool; // TODO: Remove when FE can handle sub-collection.
   private String telephoneNumber; // ContactDetails
   private String mobileNumber; // ContactDetails
   private String email; // ContactDetails

--- a/src/main/java/uk/nhs/hee/trainee/details/model/Qualification.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/Qualification.java
@@ -19,26 +19,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.dto;
+package uk.nhs.hee.trainee.details.model;
 
-import java.util.List;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
+import java.time.LocalDate;
 import lombok.Data;
-import uk.nhs.hee.trainee.details.dto.validation.Create;
 
-/**
- * A DTO for TraineeProfile entity Holds the fields for all the information of the trainee.
- */
 @Data
-public class TraineeProfileDto {
+public class Qualification {
 
-  @Null(groups = Create.class)
-  private String id;
-  @NotNull(groups = Create.class)
-  private String traineeTisId;
-  private PersonalDetailsDto personalDetails;
-  private List<QualificationDto> qualifications;
-  private List<ProgrammeMembershipDto> programmeMemberships;
-  private List<PlacementDto> placements;
+  private String tisId;
+  private String qualification; // Qualification
+  private LocalDate dateAttained; // Qualification
+  private String medicalSchool; // Qualification
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/model/TraineeProfile.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/TraineeProfile.java
@@ -40,6 +40,7 @@ public class TraineeProfile {
   @Field(value = "traineeTisId")
   private String traineeTisId;
   private PersonalDetails personalDetails;
+  private List<Qualification> qualifications = new ArrayList<>();
   private List<ProgrammeMembership> programmeMemberships = new ArrayList<>();
   private List<Placement> placements = new ArrayList<>();
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/QualificationService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/QualificationService.java
@@ -19,26 +19,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.dto;
+package uk.nhs.hee.trainee.details.service;
 
-import java.util.List;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Null;
-import lombok.Data;
-import uk.nhs.hee.trainee.details.dto.validation.Create;
+import java.util.Optional;
+import uk.nhs.hee.trainee.details.model.Qualification;
 
-/**
- * A DTO for TraineeProfile entity Holds the fields for all the information of the trainee.
- */
-@Data
-public class TraineeProfileDto {
+public interface QualificationService {
 
-  @Null(groups = Create.class)
-  private String id;
-  @NotNull(groups = Create.class)
-  private String traineeTisId;
-  private PersonalDetailsDto personalDetails;
-  private List<QualificationDto> qualifications;
-  private List<ProgrammeMembershipDto> programmeMemberships;
-  private List<PlacementDto> placements;
+  /**
+   * Update the qualification for the trainee with the given TIS ID.
+   *
+   * @param tisId         The TIS id of the trainee.
+   * @param qualification The qualification to update for the trainee.
+   * @return The updated qualification or empty if a trainee with the ID was not found.
+   */
+  Optional<Qualification> updateQualificationByTisId(String tisId, Qualification qualification);
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/impl/QualificationServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/impl/QualificationServiceImpl.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.service.impl;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.trainee.details.mapper.QualificationMapper;
+import uk.nhs.hee.trainee.details.model.Qualification;
+import uk.nhs.hee.trainee.details.model.TraineeProfile;
+import uk.nhs.hee.trainee.details.service.QualificationService;
+import uk.nhs.hee.trainee.details.service.TraineeProfileService;
+
+@Service
+public class QualificationServiceImpl implements QualificationService {
+
+  private final TraineeProfileService service;
+  private QualificationMapper mapper;
+
+  QualificationServiceImpl(TraineeProfileService service, QualificationMapper mapper) {
+    this.service = service;
+    this.mapper = mapper;
+  }
+
+  @Override
+  public Optional<Qualification> updateQualificationByTisId(String tisId,
+      Qualification qualification) {
+    TraineeProfile traineeProfile = service.getTraineeProfileByTraineeTisId(tisId);
+
+    if (traineeProfile == null) {
+      return Optional.empty();
+    }
+
+    List<Qualification> existingQualifications = traineeProfile.getQualifications();
+
+    for (Qualification existingQualification : existingQualifications) {
+
+      if (existingQualification.getTisId().equals(qualification.getTisId())) {
+        mapper.updateQualification(existingQualification, qualification);
+        service.save(traineeProfile);
+        return Optional.of(existingQualification);
+      }
+    }
+
+    existingQualifications.add(qualification);
+    service.save(traineeProfile);
+    return Optional.of(qualification);
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/service/impl/TraineeProfileServiceImpl.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/impl/TraineeProfileServiceImpl.java
@@ -21,8 +21,11 @@
 
 package uk.nhs.hee.trainee.details.service.impl;
 
+import java.util.Comparator;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.trainee.details.dto.enumeration.Status;
+import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.Qualification;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 import uk.nhs.hee.trainee.details.service.TraineeProfileService;
@@ -38,7 +41,30 @@ public class TraineeProfileServiceImpl implements TraineeProfileService {
 
   @Override
   public TraineeProfile getTraineeProfileByTraineeTisId(String traineeTisId) {
-    return repository.findByTraineeTisId(traineeTisId);
+    TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
+
+    if (traineeProfile != null) {
+      traineeProfile.getQualifications()
+          .sort(Comparator.comparing(Qualification::getDateAttained).reversed());
+
+      { // TODO: Remove when FE can handle collection of qualifications directly.
+        if (!traineeProfile.getQualifications().isEmpty()) {
+          Qualification qualification = traineeProfile.getQualifications().get(0);
+          PersonalDetails personalDetails = traineeProfile.getPersonalDetails();
+
+          if (personalDetails == null) {
+            personalDetails = new PersonalDetails();
+            traineeProfile.setPersonalDetails(personalDetails);
+          }
+
+          personalDetails.setQualification(qualification.getQualification());
+          personalDetails.setDateAttained(qualification.getDateAttained());
+          personalDetails.setMedicalSchool(qualification.getMedicalSchool());
+        }
+      }
+    }
+
+    return traineeProfile;
   }
 
   @Override

--- a/src/test/java/uk/nhs/hee/trainee/details/api/QualificationResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/QualificationResourceTest.java
@@ -1,0 +1,131 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.api;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.nhs.hee.trainee.details.dto.QualificationDto;
+import uk.nhs.hee.trainee.details.mapper.QualificationMapper;
+import uk.nhs.hee.trainee.details.model.Qualification;
+import uk.nhs.hee.trainee.details.service.QualificationService;
+
+@ContextConfiguration(classes = {QualificationMapper.class})
+@ExtendWith(SpringExtension.class)
+@WebMvcTest(QualificationResource.class)
+class QualificationResourceTest {
+
+  @Autowired
+  private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+
+  @Autowired
+  private ObjectMapper mapper;
+
+  private MockMvc mockMvc;
+
+  @MockBean
+  private QualificationService service;
+
+  @BeforeEach
+  void setUp() {
+    QualificationMapper mapper = Mappers.getMapper(QualificationMapper.class);
+    QualificationResource resource = new QualificationResource(service, mapper);
+    mockMvc = MockMvcBuilders.standaloneSetup(resource)
+        .setMessageConverters(jacksonMessageConverter)
+        .build();
+  }
+
+  @Test
+  void shouldReturnBadRequestWhenIdIsNull() throws Exception {
+    when(service.updateQualificationByTisId(eq("40"), eq(new Qualification())))
+        .thenReturn(Optional.empty());
+
+    mockMvc.perform(patch("/api/qualification/{traineeTisId}", 40)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(mapper.writeValueAsBytes(new QualificationDto())))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void shouldReturnNotFoundStatusWhenTraineeNotFound() throws Exception {
+    when(service.updateQualificationByTisId(eq("40"), eq(new Qualification())))
+        .thenReturn(Optional.empty());
+
+    QualificationDto dto = new QualificationDto();
+    dto.setTisId("tisIdValue");
+
+    mockMvc.perform(patch("/api/qualification/{traineeTisId}", 40)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(mapper.writeValueAsBytes(dto)))
+        .andExpect(status().isNotFound())
+        .andExpect(status().reason("Trainee not found."));
+  }
+
+  @Test
+  void shouldUpdateQualificationWhenTraineeFound() throws Exception {
+    LocalDate dateAttained = LocalDate.now();
+
+    Qualification qualification = new Qualification();
+    qualification.setTisId("tisIdValue");
+    qualification.setQualification("qualificationValue");
+    qualification.setDateAttained(dateAttained);
+    qualification.setMedicalSchool("medicalSchoolValue");
+
+    when(service.updateQualificationByTisId(eq("40"), any(Qualification.class)))
+        .thenReturn(Optional.of(qualification));
+
+    QualificationDto dto = new QualificationDto();
+    dto.setTisId("tisIdValue");
+
+    mockMvc.perform(patch("/api/qualification/{traineeTisId}", 40)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content(mapper.writeValueAsBytes(dto)))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.tisId").value(is("tisIdValue")))
+        .andExpect(jsonPath("$.qualification").value(is("qualificationValue")))
+        .andExpect(jsonPath("$.dateAttained").value(is(dateAttained.toString())))
+        .andExpect(jsonPath("$.medicalSchool").value(is("medicalSchoolValue")));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/service/impl/QualificationServiceImplTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/impl/QualificationServiceImplTest.java
@@ -1,0 +1,160 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.service.impl;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import uk.nhs.hee.trainee.details.mapper.QualificationMapper;
+import uk.nhs.hee.trainee.details.model.Qualification;
+import uk.nhs.hee.trainee.details.model.TraineeProfile;
+import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
+import uk.nhs.hee.trainee.details.service.QualificationService;
+
+class QualificationServiceImplTest {
+
+  private static final LocalDate DATE = LocalDate.EPOCH;
+  private static final String QUALIFICATION = "qualification-";
+  private static final String MEDICAL_SCHOOL = "medicalSchool-";
+  private static final String TRAINEE_TIS_ID = "40";
+  private static final String MODIFIED_SUFFIX = "post";
+  private static final String ORIGINAL_SUFFIX = "pre";
+  private static final String NEW_QUALIFICATION_ID = "1";
+  private static final String EXISTING_QUALIFICATION_ID = "2";
+
+  private QualificationService service;
+  private TraineeProfileRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = mock(TraineeProfileRepository.class);
+    TraineeProfileServiceImpl profileService = new TraineeProfileServiceImpl(repository);
+    service = new QualificationServiceImpl(profileService,
+        Mappers.getMapper(QualificationMapper.class));
+  }
+
+  @Test
+  void shouldNotUpdateQualificationWhenTraineeIdNotFound() {
+    Optional<Qualification> qualification = service
+        .updateQualificationByTisId("notFound", new Qualification());
+
+    assertThat("Unexpected optional isEmpty flag.", qualification.isEmpty(), is(true));
+    verify(repository).findByTraineeTisId("notFound");
+    verifyNoMoreInteractions(repository);
+  }
+
+  @Test
+  void shouldAddQualificationWhenTraineeFoundAndNoQualificationsExists() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+    when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
+
+    Optional<Qualification> qualification = service.updateQualificationByTisId(TRAINEE_TIS_ID,
+        createQualification(NEW_QUALIFICATION_ID, MODIFIED_SUFFIX, 100));
+
+    assertThat("Unexpected optional isEmpty flag.", qualification.isEmpty(), is(false));
+
+    Qualification expectedQualification = new Qualification();
+    expectedQualification.setTisId(NEW_QUALIFICATION_ID);
+    expectedQualification.setQualification(QUALIFICATION + MODIFIED_SUFFIX);
+    expectedQualification.setDateAttained(DATE.plusDays(100));
+    expectedQualification.setMedicalSchool(MEDICAL_SCHOOL + MODIFIED_SUFFIX);
+
+    assertThat("Unexpected qualification.", qualification.get(), is(expectedQualification));
+  }
+
+  @Test
+  void shouldAddQualificationWhenTraineeFoundAndQualificationNotExists() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.getQualifications()
+        .add(createQualification(EXISTING_QUALIFICATION_ID, ORIGINAL_SUFFIX, 0));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+    when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
+
+    Optional<Qualification> qualification = service.updateQualificationByTisId(TRAINEE_TIS_ID,
+        createQualification(NEW_QUALIFICATION_ID, MODIFIED_SUFFIX, 100));
+
+    assertThat("Unexpected optional isEmpty flag.", qualification.isEmpty(), is(false));
+
+    Qualification expectedQualification = new Qualification();
+    expectedQualification.setTisId(NEW_QUALIFICATION_ID);
+    expectedQualification.setQualification(QUALIFICATION + MODIFIED_SUFFIX);
+    expectedQualification.setDateAttained(DATE.plusDays(100));
+    expectedQualification.setMedicalSchool(MEDICAL_SCHOOL + MODIFIED_SUFFIX);
+
+    assertThat("Unexpected qualification.", qualification.get(), is(expectedQualification));
+  }
+
+  @Test
+  void shouldUpdateQualificationWhenTraineeFoundAndQualificationExists() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.getQualifications()
+        .add(createQualification(EXISTING_QUALIFICATION_ID, ORIGINAL_SUFFIX, 0));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+    when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
+
+    Optional<Qualification> qualification = service.updateQualificationByTisId(TRAINEE_TIS_ID,
+        createQualification(EXISTING_QUALIFICATION_ID, MODIFIED_SUFFIX, 100));
+
+    assertThat("Unexpected optional isEmpty flag.", qualification.isEmpty(), is(false));
+
+    Qualification expectedQualification = createQualification(EXISTING_QUALIFICATION_ID,
+        ORIGINAL_SUFFIX, 0);
+    expectedQualification.setTisId(EXISTING_QUALIFICATION_ID);
+    expectedQualification.setQualification(QUALIFICATION + MODIFIED_SUFFIX);
+    expectedQualification.setDateAttained(DATE.plusDays(100));
+    expectedQualification.setMedicalSchool(MEDICAL_SCHOOL + MODIFIED_SUFFIX);
+
+    assertThat("Unexpected qualification.", qualification.get(), is(expectedQualification));
+  }
+
+  /**
+   * Create an instance of Qualification with default dummy values.
+   *
+   * @param tisId              The TIS ID to set on the qualification.
+   * @param stringSuffix       The suffix to use for string values.
+   * @param dateAdjustmentDays The number of days to add to dates.
+   * @return The dummy entity.
+   */
+  private Qualification createQualification(String tisId, String stringSuffix,
+      int dateAdjustmentDays) {
+    Qualification qualification = new Qualification();
+    qualification.setTisId(tisId);
+    qualification.setQualification(QUALIFICATION + stringSuffix);
+    qualification.setDateAttained(DATE.plusDays(dateAdjustmentDays));
+    qualification.setMedicalSchool(MEDICAL_SCHOOL + stringSuffix);
+
+    return qualification;
+  }
+}


### PR DESCRIPTION
Qualifications should be stored in a sub-collection when synced. The
trainee profile will be populated with the latest qualification until a
later point, when the FE is expected to take the latest from the
qualifications collection.

TISNEW-5238