### PR TITLE
chore: Add Sentry env vars to task definition

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -16,6 +16,10 @@
         {
           "name": "AWS_REGION",
           "value": "eu-west-2"
+        },
+        {
+          "name": "SENTRY_ENVIRONMENT",
+          "value": "stage"
         }
       ],
       "logConfiguration": {
@@ -42,6 +46,10 @@
         {
           "name": "DB_PASSWORD",
           "valueFrom": "arn:aws:ssm:eu-west-2:430723991443:parameter/tis-trainee-db-password"
+        },
+        {
+          "name": "SENTRY_DSN",
+          "valueFrom": "tis-trainee-details-sentry-dsn"
         }
       ]
     }

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
   // Swagger
   implementation "io.springfox:springfox-swagger2:2.9.2"
   implementation "io.springfox:springfox-swagger-ui:2.9.2"
+
+  // Sentry reporting
+  compile "io.sentry:sentry-spring:1.7.30"
 }
 
 checkstyle {

--- a/src/main/java/uk/nhs/hee/trainee/details/config/SentryConfiguration.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/SentryConfiguration.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import io.sentry.spring.SentryExceptionResolver;
+import io.sentry.spring.SentryServletContextInitializer;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Configuration
+public class SentryConfiguration {
+
+  @Bean
+  public HandlerExceptionResolver sentryExceptionResolver() {
+    return new SentryExceptionResolver();
+  }
+
+  @Bean
+  public ServletContextInitializer sentryServletContextInitilizer() {
+    return new SentryServletContextInitializer();
+  }
+}


### PR DESCRIPTION
Add the SENTRY_DSN and SENTRY_ENVIRONMENT environmental variables to the
task definition file. These values will be populated via the parameter
store in AWS.

NO-TICKET