### PR TITLE
fix: Trainee Id set in to record ID

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.6.1"
+version = "0.6.2"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
@@ -55,7 +55,7 @@ public class PersonalDetailsService {
 
     if (updatedDetails.isEmpty()) {
       TraineeProfile traineeProfile = new TraineeProfile();
-      traineeProfile.setId(tisId);
+      traineeProfile.setTraineeTisId(tisId);
       mapper.updateBasicDetails(traineeProfile, personalDetails);
       TraineeProfile savedProfile = repository.save(traineeProfile);
       return savedProfile.getPersonalDetails();

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.trainee.details.service;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -101,7 +102,8 @@ class PersonalDetailsServiceTest {
     assertThat("Unexpected personal details.", personalDetails, is(expectedPersonalDetails));
 
     TraineeProfile traineeProfile = profileCaptor.getValue();
-    assertThat("Unexpected TIS id.", traineeProfile.getId(), is("notFound"));
+    assertThat("Unexpected id.", traineeProfile.getId(), nullValue());
+    assertThat("Unexpected trainee TIS id.", traineeProfile.getTraineeTisId(), is("notFound"));
   }
 
   @Test


### PR DESCRIPTION
The trainee's TIS id is being mistakenly set as the record id instead of
in to the traineeTisId field. This is causing duplicate key errors when
updating records as the profile can never be found by TIS ID.

NO-TICKET