### PR TITLE
fix: use the git repository name as the prod service name

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -297,6 +297,6 @@ jobs:
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
-          service: trainee-details
+          service: ${{ github.event.repository.name }}
           cluster: trainee-prod
           wait-for-service-stability: true


### PR DESCRIPTION
The preprod service has been left without the `tis` prefix.

TIS21-1020: Create production pipelines