### PR TITLE
feat: Add missing placement fields to DTO/model

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.7.0"
+version = "0.8.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/PlacementDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/PlacementDto.java
@@ -41,5 +41,8 @@ public class PlacementDto {
   private String grade;
   private String specialty;
   private String placementType;
+  private String employingBody;
+  private String trainingBody;
+  private String wholeTimeEquivalent;
   private Status status;
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/model/Placement.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/Placement.java
@@ -36,5 +36,8 @@ public class Placement {
   private String grade;
   private String specialty;
   private String placementType;
+  private String employingBody;
+  private String trainingBody;
+  private String wholeTimeEquivalent;
   private Status status;
 }


### PR DESCRIPTION
Add `employingBody`, `trainingBody` and `wholeTimeEquivalent` to the
placement DTO and model types.

TIS21-1032