### PR TITLE
chore: Add dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
     reviewers:
       - Health-Education-England/full-stack
       - Health-Education-England/operations


### PR DESCRIPTION
Set up the default dependabot configuration, with weekly analysis of
both gradle and GHA and suitable teams asked for review.

TIS21-1356