### PR TITLE
fix: Handle null qualification dates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.8.3"
+version = "0.8.4"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -48,8 +48,9 @@ public class TraineeProfileService {
     TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
 
     if (traineeProfile != null) {
-      traineeProfile.getQualifications()
-          .sort(Comparator.comparing(Qualification::getDateAttained).reversed());
+      traineeProfile.getQualifications().sort(Comparator.comparing(
+          Qualification::getDateAttained, Comparator.nullsLast(Comparator.reverseOrder()))
+      );
 
       // TODO: Remove when FE can handle collection of qualifications directly.
       if (!traineeProfile.getQualifications().isEmpty()) {

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -234,6 +234,31 @@ class TraineeProfileServiceTest {
   }
 
   @Test
+  void shouldSortQualificationsWithNullsLast() {
+    Qualification qualification1 = new Qualification();
+    Qualification qualification2 = new Qualification();
+    qualification2.setDateAttained(LocalDate.now().plusDays(100));
+    Qualification qualification3 = new Qualification();
+    qualification3.setDateAttained(LocalDate.now().minusDays(100));
+
+    List<Qualification> qualifications = Arrays
+        .asList(qualification1, qualification2, qualification3);
+    traineeProfile = new TraineeProfile();
+    traineeProfile.setQualifications(qualifications);
+
+    when(repository.findByTraineeTisId(DEFAULT_TIS_ID_1)).thenReturn(traineeProfile);
+
+    service.getTraineeProfileByTraineeTisId(DEFAULT_TIS_ID_1);
+
+    assertThat("Unexpected qualification, check order is correct.",
+        traineeProfile.getQualifications().get(0), is(qualification2));
+    assertThat("Unexpected qualification, check order is correct.",
+        traineeProfile.getQualifications().get(1), is(qualification3));
+    assertThat("Unexpected qualification, check order is correct.",
+        traineeProfile.getQualifications().get(2), is(qualification1));
+  }
+
+  @Test
   void shouldPopulatePersonalDetailsWithLatestQualification() {
     Qualification qualification1 = new Qualification();
     qualification1.setDateAttained(LocalDate.now());


### PR DESCRIPTION
The sort applied to qualifications does not handle the qualification
date being null, add a `nullLast` condition to place any qualifications
with nulls dates at the end of the list without throwing errors.

TIS21-1624