### PR TITLE
Chore: use bootBuildImage instead of dockerfile

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -219,7 +219,8 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+          ./gradlew bootBuildImage -x bootJar --imageName=$ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push --all-tags $ECR_REGISTRY/$ECR_REPOSITORY
 
   deploy-pre-prod:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM openjdk:11-slim
-EXPOSE 8203
-COPY build/libs/*.jar app.jar
-CMD ["java", "-jar", "app.jar"]


### PR DESCRIPTION
The bump to org.springframework.boot 2.5+ means that running 'gradlew
assemble' creates both the fatjar and the jar without dependencies
(*-plain.jar).

The problem is that the Dockerfile attempts to copy both files
to app.jar, so Dockerize fails with:

Step 3/4 : COPY build/libs/*.jar app.jar
When using COPY with more than one source file, the destination must be a directory and end with a /
Error: Process completed with exit code 1.