### PR TITLE
fix: Add index to the email field

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.9.0"
+version = "0.9.1"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/config/MongoConfiguration.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/MongoConfiguration.java
@@ -45,5 +45,6 @@ public class MongoConfiguration {
   public void initIndexes() {
     IndexOperations traineeProfileIndexOps = template.indexOps(TraineeProfile.class);
     traineeProfileIndexOps.ensureIndex(new Index().on("traineeTisId", Direction.ASC));
+    traineeProfileIndexOps.ensureIndex(new Index().on("personalDetails.email", Direction.ASC));
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
@@ -67,12 +67,11 @@ class MongoConfigurationTest {
     verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
 
     List<IndexDefinition> indexes = indexCaptor.getAllValues();
-    assertThat("Unexpected number of indexes.", indexes.size(), is(1));
+    assertThat("Unexpected number of indexes.", indexes.size(), is(2));
 
     List<String> indexKeys = indexes.stream()
         .flatMap(i -> i.getIndexKeys().keySet().stream())
         .collect(Collectors.toList());
-    assertThat("Unexpected index.", indexKeys,
-        hasItems("traineeTisId"));
+    assertThat("Unexpected index.", indexKeys, hasItems("traineeTisId", "personalDetails.email"));
   }
 }


### PR DESCRIPTION
Queries against the email field are incredibly slow, add an index on
that field so the profiles can be queries and returned quickly.

TIS21-1711