### PR TITLE
fix: Force email to lower case

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.9.1"
+version = "0.9.2"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsDto.java
@@ -21,8 +21,10 @@
 
 package uk.nhs.hee.trainee.details.dto;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.time.LocalDate;
 import lombok.Data;
+import uk.nhs.hee.trainee.details.dto.deserializer.LowerCaseDeserializer;
 
 /**
  * A DTO for PersonalDetails entity, holds the fields for personal information of the trainee.
@@ -43,6 +45,7 @@ public class PersonalDetailsDto {
   private String medicalSchool;
   private String telephoneNumber;
   private String mobileNumber;
+  @JsonDeserialize(using = LowerCaseDeserializer.class)
   private String email;
   private String address1;
   private String address2;

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/deserializer/LowerCaseDeserializer.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/deserializer/LowerCaseDeserializer.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.dto.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import java.io.IOException;
+
+/**
+ * A deserializer that converts strings to lower case.
+ */
+public class LowerCaseDeserializer extends StdDeserializer<String> {
+
+  public LowerCaseDeserializer() {
+    super(String.class);
+  }
+
+  @Override
+  public String deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+    return _parseString(parser, context).toLowerCase();
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -80,7 +80,7 @@ public class TraineeProfileService {
    * @return The trainee TIS IDs.
    */
   public List<String> getTraineeTisIdsByByEmail(String email) {
-    List<TraineeProfile> traineeProfile = repository.findAllByTraineeEmail(email);
+    List<TraineeProfile> traineeProfile = repository.findAllByTraineeEmail(email.toLowerCase());
     return traineeProfile.stream()
         .map(TraineeProfile::getTraineeTisId)
         .collect(Collectors.toList());

--- a/src/test/java/uk/nhs/hee/trainee/details/api/ContactDetailsResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/ContactDetailsResourceTest.java
@@ -92,6 +92,7 @@ class ContactDetailsResourceTest {
     PersonalDetails personalDetails = new PersonalDetails();
     personalDetails.setForenames("John");
     personalDetails.setSurname("Doe");
+    personalDetails.setEmail("email@email.com");
 
     when(service.updateContactDetailsByTisId(eq("40"), any(PersonalDetails.class)))
         .thenReturn(Optional.of(personalDetails));
@@ -102,6 +103,7 @@ class ContactDetailsResourceTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.forenames").value(is("John")))
-        .andExpect(jsonPath("$.surname").value(is("Doe")));
+        .andExpect(jsonPath("$.surname").value(is("Doe")))
+        .andExpect(jsonPath("$.email").value(is("email@email.com")));
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsDtoTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsDtoTest.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.dto;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+
+@JsonTest
+class PersonalDetailsDtoTest {
+
+  @Autowired
+  private JacksonTester<PersonalDetailsDto> jacksonTester;
+
+  @Test
+  void shouldDeserializeEmailToLowerCase() throws IOException {
+    String json = "{\"email\": \"UPPER.lower@UpperCamel.lowerCamel\"}";
+
+    PersonalDetailsDto dto = jacksonTester.parseObject(json);
+    assertThat("Unexpected email.", dto.getEmail(), is("upper.lower@uppercamel.lowercamel"));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/dto/deserializer/LowerCaseDeserializerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/dto/deserializer/LowerCaseDeserializerTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.dto.deserializer;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class LowerCaseDeserializerTest {
+
+  private LowerCaseDeserializer deserializer;
+
+  @BeforeEach
+  void setUp() {
+    deserializer = new LowerCaseDeserializer();
+  }
+
+  @Test
+  void shouldDeserializeToLowerCase() throws IOException {
+    JsonParser parser = mock(JsonParser.class);
+    when(parser.hasToken(JsonToken.VALUE_STRING)).thenReturn(true);
+    when(parser.getText()).thenReturn("UPPER_CASE");
+
+    String deserialized = deserializer.deserialize(parser, null);
+    assertThat("Unexpected string casing.", deserialized, is("upper_case"));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -323,5 +324,17 @@ class TraineeProfileServiceTest {
     List<String> traineeTisIds = service.getTraineeTisIdsByByEmail(PERSON_EMAIL);
 
     assertThat("Unexpected number of trainee TIS IDs.", traineeTisIds.size(), is(0));
+  }
+
+  @Test
+  void shouldFindProfilesByLowerCaseEmail() {
+    ArgumentCaptor<String> emailCaptor = ArgumentCaptor.forClass(String.class);
+    when(repository.findAllByTraineeEmail(emailCaptor.capture()))
+        .thenReturn(Collections.emptyList());
+
+    service.getTraineeTisIdsByByEmail("UPPER.lower@UpperCamel.lowerCamel");
+
+    String email = emailCaptor.getValue();
+    assertThat("Unexpected email.", email, is("upper.lower@uppercamel.lowercamel"));
   }
 }


### PR DESCRIPTION
During self sign up a match must be made against a TraineeProfile using
the sign up email address.
Due to limitation on DocumentDBs ability to query with case insensivity
any incoming emails should be set to lower cased before persisting or
querying with them.

TIS21-2436