### PR TITLE
fix: remove spring data debug logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.9.2"
+version = "0.9.3"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,8 +11,6 @@ spring:
 logging:
   level:
     root: INFO
-    org.springframework.data: DEBUG
-    uk.nhs.hee.tis.trainee.details: TRACE
 
 sentry:
   dsn: ${SENTRY_DSN:}


### PR DESCRIPTION
Change the logging level for `org.springframework.data` to `INFO` instead of `DEBUG`

NO-TICKET