### PR TITLE
fix: use correct field name for trainee delete

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.11.0"
+version = "0.11.1"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/repository/TraineeProfileRepository.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/repository/TraineeProfileRepository.java
@@ -34,4 +34,6 @@ public interface TraineeProfileRepository extends MongoRepository<TraineeProfile
 
   @Query("{ 'personalDetails.email' : ?0 }")
   List<TraineeProfile> findAllByTraineeEmail(String email);
+
+  void deleteByTraineeTisId(String traineeTisId);
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -114,6 +114,6 @@ public class TraineeProfileService {
    * @param traineeTisId The TIS ID of the trainee to delete the profile for.
    */
   public void deleteTraineeProfileByTraineeTisId(String traineeTisId) {
-    repository.deleteById(traineeTisId);
+    repository.deleteByTraineeTisId(traineeTisId);
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -342,6 +342,6 @@ class TraineeProfileServiceTest {
   @Test
   void shouldDeleteProfileById() {
     service.deleteTraineeProfileByTraineeTisId("1");
-    verify(repository).deleteById("1");
+    verify(repository).deleteByTraineeTisId("1");
   }
 }


### PR DESCRIPTION
The trainee profile delete endpoint tried to delete by `_id` field, but
should use `traineeTisID`.

TIS21-2549