### PR TITLE
fix: return 204 when qualification delete called

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.11.1"
+version = "0.11.2"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/QualificationResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/QualificationResource.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.ResponseEntity.HeadersBuilder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -78,16 +77,13 @@ public class QualificationResource {
    *
    * @param traineeTisId    The trainee ID to delete the qualification of.
    * @param qualificationId The qualification ID to delete from the trainee.
-   * @return A 204 if successful, else a 404.
+   * @return Response code 204 if successful.
    */
   @DeleteMapping("/{traineeTisId}/{qualificationId}")
   public ResponseEntity<Void> deleteQualification(@PathVariable String traineeTisId,
       @PathVariable String qualificationId) {
     log.trace("Delete qualification {} from trainee {}.", qualificationId, traineeTisId);
-    boolean updated = service.deleteQualification(traineeTisId, qualificationId);
-
-    HeadersBuilder<? extends HeadersBuilder<?>> response =
-        updated ? ResponseEntity.noContent() : ResponseEntity.notFound();
-    return response.build();
+    service.deleteQualification(traineeTisId, qualificationId);
+    return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/QualificationService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/QualificationService.java
@@ -77,22 +77,17 @@ public class QualificationService {
    *
    * @param traineeTisId    The trainee ID to delete the qualification of.
    * @param qualificationId The qualification ID to delete from the trainee.
-   * @return true if a deletion occurred, else false.
    */
-  public boolean deleteQualification(String traineeTisId, String qualificationId) {
+  public void deleteQualification(String traineeTisId, String qualificationId) {
     TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
 
-    if (traineeProfile == null) {
-      return false;
+    if (traineeProfile != null) {
+      List<Qualification> qualifications = traineeProfile.getQualifications();
+      boolean updated = qualifications.removeIf(q -> q.getTisId().equals(qualificationId));
+
+      if (updated) {
+        repository.save(traineeProfile);
+      }
     }
-
-    List<Qualification> qualifications = traineeProfile.getQualifications();
-    boolean updated = qualifications.removeIf(q -> q.getTisId().equals(qualificationId));
-
-    if (updated) {
-      repository.save(traineeProfile);
-    }
-
-    return updated;
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/api/QualificationResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/QualificationResourceTest.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.trainee.details.api;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -132,19 +133,10 @@ class QualificationResourceTest {
 
   @Test
   void shouldReturnNoContentWhenQualificationDeleted() throws Exception {
-    when(service.deleteQualification("40", "140")).thenReturn(true);
-
     mockMvc.perform(delete("/api/qualification/{traineeTisId}/{qualificationId}", 40, 140)
         .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNoContent());
-  }
 
-  @Test
-  void shouldReturnNotFoundWhenQualificationNotFound() throws Exception {
-    when(service.deleteQualification("40", "140")).thenReturn(false);
-
-    mockMvc.perform(delete("/api/qualification/{traineeTisId}/{qualificationId}", 40, 140)
-        .contentType(MediaType.APPLICATION_JSON))
-        .andExpect(status().isNotFound());
+    verify(service).deleteQualification("40", "140");
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/QualificationServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/QualificationServiceTest.java
@@ -141,9 +141,8 @@ class QualificationServiceTest {
 
   @Test
   void shouldNotDeleteQualificationWhenTraineeNotFound() {
-    boolean deleted = service.deleteQualification("traineeNotFound", "qualificationNotFound");
+    service.deleteQualification("traineeNotFound", "qualificationNotFound");
 
-    assertThat("Unexpected deleted state.", deleted, is(false));
     verify(repository, never()).save(any());
   }
 
@@ -155,9 +154,8 @@ class QualificationServiceTest {
 
     when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
 
-    boolean deleted = service.deleteQualification(TRAINEE_TIS_ID, NEW_QUALIFICATION_ID);
+    service.deleteQualification(TRAINEE_TIS_ID, NEW_QUALIFICATION_ID);
 
-    assertThat("Unexpected deleted state.", deleted, is(false));
     verify(repository, never()).save(any());
   }
 
@@ -169,9 +167,8 @@ class QualificationServiceTest {
 
     when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
 
-    boolean deleted = service.deleteQualification(TRAINEE_TIS_ID, EXISTING_QUALIFICATION_ID);
+    service.deleteQualification(TRAINEE_TIS_ID, EXISTING_QUALIFICATION_ID);
 
-    assertThat("Unexpected deleted state.", deleted, is(true));
     verify(repository).save(any());
   }
 


### PR DESCRIPTION
If the qualification is not found by trainee and qualification IDs then
a 404 is returned, however this failure then hits the DLQ.
A `204 No Content` response is valid in the case of an object already
being deleted and should be used instead so that it can be categorised
as a success instead of failure.

TIS21-2549