### PR TITLE
chore: remove springfox-swagger dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,5 @@ You can run this project without going through the build with
 
 To run the tests use: `./gradlew clean test`
 
-## Accessing Swagger API 
-
-Paste this URI to the browser http://localhost:8203/swagger-ui.html
-
 ## License
 This project is license under [The MIT License (MIT)](LICENSE)

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.11.2"
+version = "0.11.3"
 sourceCompatibility = "11"
 
 configurations {
@@ -42,10 +42,6 @@ dependencies {
   // Mapstruct
   implementation "org.mapstruct:mapstruct:1.4.2.Final"
   annotationProcessor "org.mapstruct:mapstruct-processor:1.4.2.Final"
-
-  // Swagger
-  implementation "io.springfox:springfox-swagger2:3.0.0"
-  implementation "io.springfox:springfox-swagger-ui:3.0.0"
 
   // Sentry reporting
   implementation "io.sentry:sentry-spring-boot-starter:5.6.0"

--- a/src/main/java/uk/nhs/hee/trainee/details/TisTraineeDetailsApplication.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/TisTraineeDetailsApplication.java
@@ -21,56 +21,13 @@
 
 package uk.nhs.hee.trainee.details;
 
-import static springfox.documentation.builders.PathSelectors.regex;
-
-import java.util.Collections;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @SpringBootApplication
-@EnableSwagger2
 public class TisTraineeDetailsApplication {
 
-  private static final Logger log = LoggerFactory.getLogger(TisTraineeDetailsApplication.class);
-
   public static void main(String[] args) {
-    log.info("INSIDE TisTraineeDetailsApplication main() METHOD");
     SpringApplication.run(TisTraineeDetailsApplication.class);
-  }
-
-  /**
-   * Configure swagger.
-   *
-   * @return The swagger configuration {@link Docket}.
-   */
-  @Bean
-  public Docket swaggerConfiguration() {
-
-    return new Docket(DocumentationType.SWAGGER_2)
-        .select()
-        .paths(regex("/api.*"))
-        .apis(RequestHandlerSelectors.basePackage("uk.nhs.hee.trainee.details"))
-        .build()
-        .apiInfo(apiDetails());
-  }
-
-  private ApiInfo apiDetails() {
-    return new ApiInfo(
-        "Trainee UI API",
-        "The TIS-TRAINEE-DETAILS microservice's APIs",
-        "1.0",
-        "These will be consumed by React or other microservices",
-        new springfox.documentation.service.Contact("Contact", "TIS Dev Team", "aaaa@hee.nhs.uk"),
-        "API Licence",
-        "TIS",
-        Collections.emptyList());
   }
 }


### PR DESCRIPTION
`springfox-swagger` is not currently compatible with the latest
Spring(Boot) versions. Given that none of our APIs are actually properly
annotated for Swagger the easiest fix for the runtime issue is to remove
the swagger dependencies.

NO-TICKET