### PR TITLE
chore: migrate from adopt to temurin in workflows

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v2.5.0
         with:
           cache: gradle
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Build with Gradle
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@v2.5.0
         with:
           cache: gradle
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Run Gradle checks
@@ -81,7 +81,7 @@ jobs:
         uses: actions/setup-java@v2.5.0
         with:
           cache: gradle
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Run Gradle tests
@@ -112,7 +112,7 @@ jobs:
         uses: actions/setup-java@v2.5.0
         with:
           cache: gradle
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Run quality analysis


### PR DESCRIPTION
The AdoptOpenJDK project has moved and rebranded to Adoptium, with
Temurin being the naming of the JDK binaries produced by the Adoptium
project.

TIS21-SHED