### PR TITLE
feat: add unique index on traineeTisId

### DIFF
--- a/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
@@ -46,6 +46,7 @@ import org.springframework.data.mongodb.core.index.IndexOperations;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
 class MongoConfigurationTest {
+  private static final String NON_UNIQUE_INDEX_NAME = "traineeTisId_notUnique";
 
   private MongoConfiguration configuration;
 
@@ -82,9 +83,9 @@ class MongoConfigurationTest {
 
   @Test
   void shouldReplaceNonUniqueIndexForTraineeTisIdWithUniqueIndex() {
-    String NON_UNIQUE_INDEX_NAME = "traineeTisId_notUnique";
     IndexField indexField = IndexField.create("traineeTisId", Sort.Direction.ASC);
-    IndexInfo indexInfo = new IndexInfo(List.of(indexField), NON_UNIQUE_INDEX_NAME, false, false, "");
+    IndexInfo indexInfo = new IndexInfo(List.of(indexField),
+        NON_UNIQUE_INDEX_NAME, false, false, "");
 
     IndexOperations indexOperations = mock(IndexOperations.class);
     when(template.indexOps(TraineeProfile.class)).thenReturn(indexOperations);

--- a/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -73,5 +74,11 @@ class MongoConfigurationTest {
         .flatMap(i -> i.getIndexKeys().keySet().stream())
         .collect(Collectors.toList());
     assertThat("Unexpected index.", indexKeys, hasItems("traineeTisId", "personalDetails.email"));
+
+    Optional<IndexDefinition> idxTraineeTisId = indexes.stream()
+        .filter(i -> i.getIndexKeys().containsKey("traineeTisId")).findFirst();
+    assertThat("traineeTisId index is missing", idxTraineeTisId.isPresent(), is(true));
+    assertThat("traineeTisId index is not unique",
+        idxTraineeTisId.get().getIndexOptions().getBoolean("unique"), is(true));
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
@@ -36,8 +36,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.index.IndexDefinition;
+import org.springframework.data.mongodb.core.index.IndexField;
+import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
@@ -74,6 +77,23 @@ class MongoConfigurationTest {
         .flatMap(i -> i.getIndexKeys().keySet().stream())
         .collect(Collectors.toList());
     assertThat("Unexpected index.", indexKeys, hasItems("traineeTisId", "personalDetails.email"));
+  }
+
+  @Test
+  void shouldReplaceNonUniqueIndexForTraineeTisIdWithUniqueIndex() {
+    IndexField indexField = IndexField.create("traineeTisId", Sort.Direction.ASC);
+    IndexInfo indexInfo = new IndexInfo(List.of(indexField), "traineeTisId_1", false, false, "");
+
+    IndexOperations indexOperations = mock(IndexOperations.class);
+    when(template.indexOps(TraineeProfile.class)).thenReturn(indexOperations);
+    when(indexOperations.getIndexInfo()).thenReturn(List.of(indexInfo));
+
+    configuration.initIndexes();
+
+    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.forClass(IndexDefinition.class);
+    verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
+
+    List<IndexDefinition> indexes = indexCaptor.getAllValues();
 
     Optional<IndexDefinition> idxTraineeTisId = indexes.stream()
         .filter(i -> i.getIndexKeys().containsKey("traineeTisId")).findFirst();


### PR DESCRIPTION
This might be straying a bit into Mongock territory, so very happy to
refactor to use that if desired (it was actually how I implemented it at
first, but this way seems more concise).

Note that if Mongock is used, the MongoConfiguration should have
the ensureIndex() removed for traineeTisId, since this can throw an
exception if the existing index on that field has a different unique
value or has a different name, before Mongock can rework things.

TIS21-2923: Duplicate profile for trainee