### PR TITLE
fix: raise logging level for API endpoint entry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.12.0"
+version = "0.12.1"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
@@ -57,7 +57,7 @@ public class BasicDetailsResource {
   @PatchMapping("/{tisId}")
   public ResponseEntity<PersonalDetailsDto> updateBasicDetails(
       @PathVariable(name = "tisId") String tisId, @RequestBody PersonalDetailsDto dto) {
-    log.trace("Update basic details of trainee with TIS ID {}", tisId);
+    log.info("Update basic details of trainee with TIS ID {}", tisId);
     PersonalDetails entity = mapper.toEntity(dto);
     entity = service.createProfileOrUpdateBasicDetailsByTisId(tisId, entity);
     return ResponseEntity.ok(mapper.toDto(entity));

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ContactDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ContactDetailsResource.java
@@ -60,7 +60,7 @@ public class ContactDetailsResource {
   public ResponseEntity<PersonalDetailsDto> updateContactDetails(
       @PathVariable(name = "tisId") String tisId,
       @RequestBody PersonalDetailsDto dto) {
-    log.trace("Update contact details of trainee with TIS ID {}", tisId);
+    log.info("Update contact details of trainee with TIS ID {}", tisId);
     PersonalDetails entity = mapper.toEntity(dto);
     Optional<PersonalDetails> optionalEntity = service.updateContactDetailsByTisId(tisId, entity);
     entity = optionalEntity

--- a/src/main/java/uk/nhs/hee/trainee/details/api/GdcDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/GdcDetailsResource.java
@@ -59,7 +59,7 @@ public class GdcDetailsResource {
   @PatchMapping("/{tisId}")
   public ResponseEntity<PersonalDetailsDto> updateGdcDetails(
       @PathVariable(name = "tisId") String tisId, @RequestBody PersonalDetailsDto dto) {
-    log.trace("Update GDC details of trainee with TIS ID {}", tisId);
+    log.info("Update GDC details of trainee with TIS ID {}", tisId);
     PersonalDetails entity = mapper.toEntity(dto);
     Optional<PersonalDetails> optionalEntity = service.updateGdcDetailsByTisId(tisId, entity);
     entity = optionalEntity

--- a/src/main/java/uk/nhs/hee/trainee/details/api/GmcDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/GmcDetailsResource.java
@@ -59,7 +59,7 @@ public class GmcDetailsResource {
   @PatchMapping("/{tisId}")
   public ResponseEntity<PersonalDetailsDto> updateGmcDetails(
       @PathVariable(name = "tisId") String tisId, @RequestBody PersonalDetailsDto dto) {
-    log.trace("Update GMC details of trainee with TIS ID {}", tisId);
+    log.info("Update GMC details of trainee with TIS ID {}", tisId);
     PersonalDetails entity = mapper.toEntity(dto);
     Optional<PersonalDetails> optionalEntity = service.updateGmcDetailsByTisId(tisId, entity);
     entity = optionalEntity

--- a/src/main/java/uk/nhs/hee/trainee/details/api/PersonOwnerResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/PersonOwnerResource.java
@@ -59,7 +59,7 @@ public class PersonOwnerResource {
   @PatchMapping("/{tisId}")
   public ResponseEntity<PersonalDetailsDto> updatePersonOwner(
       @PathVariable(name = "tisId") String tisId, @RequestBody PersonalDetailsDto dto) {
-    log.trace("Update person owner of trainee with TIS ID {}", tisId);
+    log.info("Update person owner of trainee with TIS ID {}", tisId);
     PersonalDetails entity = mapper.toEntity(dto);
     Optional<PersonalDetails> optionalEntity = service.updatePersonOwnerByTisId(tisId, entity);
     entity = optionalEntity

--- a/src/main/java/uk/nhs/hee/trainee/details/api/PersonalInfoResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/PersonalInfoResource.java
@@ -60,7 +60,7 @@ public class PersonalInfoResource {
   public ResponseEntity<PersonalDetailsDto> updatePersonalInfo(
       @PathVariable(name = "tisId") String tisId,
       @RequestBody PersonalDetailsDto dto) {
-    log.trace("Update contact details of trainee with TIS ID {}", tisId);
+    log.info("Update contact details of trainee with TIS ID {}", tisId);
     PersonalDetails entity = mapper.toEntity(dto);
     Optional<PersonalDetails> optionalEntity = service.updatePersonalInfoByTisId(tisId, entity);
     entity = optionalEntity

--- a/src/main/java/uk/nhs/hee/trainee/details/api/PlacementResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/PlacementResource.java
@@ -63,7 +63,7 @@ public class PlacementResource {
   public ResponseEntity<PlacementDto> updateQualification(
       @PathVariable(name = "traineeTisId") String traineeTisId,
       @RequestBody @Validated PlacementDto dto) {
-    log.trace("Update placement of trainee with TIS ID {}", traineeTisId);
+    log.info("Update placement of trainee with TIS ID {}", traineeTisId);
     Placement entity = mapper.toEntity(dto);
     Optional<Placement> optionalEntity = service.updatePlacementForTrainee(traineeTisId, entity);
     entity = optionalEntity
@@ -82,7 +82,7 @@ public class PlacementResource {
   public ResponseEntity<Boolean> deletePlacement(
       @PathVariable(name = "traineeTisId") String traineeTisId,
       @PathVariable(name = "placementTisId") String placementTisId) {
-    log.trace("Delete placement with TIS ID {} of trainee with TIS ID {}",
+    log.info("Delete placement with TIS ID {} of trainee with TIS ID {}",
         placementTisId, traineeTisId);
     try {
       boolean foundTraineeAndPlacement =

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
@@ -65,7 +65,7 @@ public class ProgrammeMembershipResource {
   public ResponseEntity<ProgrammeMembershipDto> updateQualification(
       @PathVariable(name = "traineeTisId") String traineeTisId,
       @RequestBody @Validated ProgrammeMembershipDto dto) {
-    log.trace("Update programme membership of trainee with TIS ID {}", traineeTisId);
+    log.info("Update programme membership of trainee with TIS ID {}", traineeTisId);
     ProgrammeMembership entity = mapper.toEntity(dto);
     Optional<ProgrammeMembership> optionalEntity = service
         .updateProgrammeMembershipForTrainee(traineeTisId, entity);
@@ -83,7 +83,7 @@ public class ProgrammeMembershipResource {
   @DeleteMapping("/{traineeTisId}")
   public ResponseEntity<Boolean> deleteProgrammeMemberships(
       @PathVariable(name = "traineeTisId") String traineeTisId) {
-    log.trace("Delete all programme memberships of trainee with TIS ID {}", traineeTisId);
+    log.info("Delete all programme memberships of trainee with TIS ID {}", traineeTisId);
     try {
       boolean foundTrainee = service.deleteProgrammeMembershipsForTrainee(traineeTisId);
       if (!foundTrainee) {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/QualificationResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/QualificationResource.java
@@ -63,7 +63,7 @@ public class QualificationResource {
   public ResponseEntity<QualificationDto> updateQualification(
       @PathVariable(name = "traineeTisId") String traineeTisId,
       @RequestBody @Validated QualificationDto dto) {
-    log.trace("Update qualifications of trainee with TIS ID {}", traineeTisId);
+    log.info("Update qualifications of trainee with TIS ID {}", traineeTisId);
     Qualification entity = mapper.toEntity(dto);
     Optional<Qualification> optionalEntity = service
         .updateQualificationByTisId(traineeTisId, entity);
@@ -82,7 +82,7 @@ public class QualificationResource {
   @DeleteMapping("/{traineeTisId}/{qualificationId}")
   public ResponseEntity<Void> deleteQualification(@PathVariable String traineeTisId,
       @PathVariable String qualificationId) {
-    log.trace("Delete qualification {} from trainee {}.", qualificationId, traineeTisId);
+    log.info("Delete qualification {} from trainee {}.", qualificationId, traineeTisId);
     service.deleteQualification(traineeTisId, qualificationId);
     return ResponseEntity.noContent().build();
   }

--- a/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
@@ -70,7 +70,7 @@ public class TraineeProfileResource {
   @GetMapping
   public ResponseEntity<TraineeProfileDto> getTraineeProfile(
       @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
-    log.trace("Trainee Profile of authenticated user.");
+    log.info("Trainee Profile of authenticated user.");
 
     String[] tokenSections = token.split("\\.");
     byte[] payloadBytes = Base64.getDecoder()


### PR DESCRIPTION
The logging when an API endpoint is triggered is currently `trace` but
the default logging output is `info`. As a result the service does not
currently log anything.
Raise the API entry logging level to `info`.

TIS21-SHED