### PR TITLE
fix: duplicate Trainee profiles for the same email issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.12.1"
+version = "0.12.2"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
@@ -105,7 +105,7 @@ public class TraineeProfileResource {
    */
   @GetMapping("/trainee-ids")
   public ResponseEntity<List<String>> getTraineeIds(@RequestParam String email) {
-    List<String> traineeIds = service.getTraineeTisIdsByByEmail(email);
+    List<String> traineeIds = service.getTraineeTisIdsByEmail(email);
 
     if (traineeIds.isEmpty()) {
       return ResponseEntity.notFound().build();

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -83,9 +83,7 @@ public class TraineeProfileService {
     List<TraineeProfile> traineeProfiles = repository.findAllByTraineeEmail(email.toLowerCase());
 
     return traineeProfiles.stream()
-        .filter(traineeProfile ->
-            (isValidGmcGdc(traineeProfile.getPersonalDetails().getGmcNumber())
-            || isValidGmcGdc(traineeProfile.getPersonalDetails().getGdcNumber())))
+        .filter(traineeProfile -> isValidGmc(traineeProfile.getPersonalDetails().getGmcNumber()))
         .map(TraineeProfile::getTraineeTisId)
         .collect(Collectors.toList());
   }
@@ -122,14 +120,17 @@ public class TraineeProfileService {
   }
 
   /**
-   * Check if the GMC or GDC number is valid.
+   * Check if the GMC number is valid.
    *
-   * @param gmcGdcNumber The GMC or GDC number for checking.
+   * @param gmcNumber The GMC number for checking.
    * @return boolean "true" if the number is valid; "false" if not valid.
    */
-  private Boolean isValidGmcGdc(String gmcGdcNumber) {
-    return gmcGdcNumber != null
-        && !gmcGdcNumber.isEmpty()
-        && gmcGdcNumber.matches("\\d+");
+  private Boolean isValidGmc(String gmcNumber) {
+    if (gmcNumber == null) {
+      return false;
+    }
+
+    // A valid GMC number can consist of 7 numeric or L + 6 numeric
+    return gmcNumber.matches("^(\\d{7}|L\\d{6})$");
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -124,18 +124,18 @@ public class TraineeProfileService {
   /**
    * Check if the GMC or GDC number is valid.
    *
-   * @param GmcGdcNumber The GMC or GDC number for checking.
+   * @param gmcGdcNumber The GMC or GDC number for checking.
    * @return boolean "true" if the number is valid; "false" if not valid.
    */
-  private Boolean isValidGmcGdc(String GmcGdcNumber) {
-    if (GmcGdcNumber == null) {
+  private Boolean isValidGmcGdc(String gmcGdcNumber) {
+    if (gmcGdcNumber == null) {
       return false;
     }
 
-    return !GmcGdcNumber.isEmpty()
-        && !GmcGdcNumber.equalsIgnoreCase("unknown")
-        && !GmcGdcNumber.equalsIgnoreCase("n/a")
-        && !GmcGdcNumber.equalsIgnoreCase("na")
-        && !GmcGdcNumber.toLowerCase().startsWith("delete");
+    return !gmcGdcNumber.isEmpty()
+        && !gmcGdcNumber.equalsIgnoreCase("unknown")
+        && !gmcGdcNumber.equalsIgnoreCase("n/a")
+        && !gmcGdcNumber.equalsIgnoreCase("na")
+        && !gmcGdcNumber.toLowerCase().startsWith("delete");
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -128,14 +128,8 @@ public class TraineeProfileService {
    * @return boolean "true" if the number is valid; "false" if not valid.
    */
   private Boolean isValidGmcGdc(String gmcGdcNumber) {
-    if (gmcGdcNumber == null) {
-      return false;
-    }
-
-    return !gmcGdcNumber.isEmpty()
-        && !gmcGdcNumber.equalsIgnoreCase("unknown")
-        && !gmcGdcNumber.equalsIgnoreCase("n/a")
-        && !gmcGdcNumber.equalsIgnoreCase("na")
-        && !gmcGdcNumber.toLowerCase().startsWith("delete");
+    return gmcGdcNumber != null
+        && !gmcGdcNumber.isEmpty()
+        && gmcGdcNumber.matches("\\d+");
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -80,8 +80,12 @@ public class TraineeProfileService {
    * @return The trainee TIS IDs.
    */
   public List<String> getTraineeTisIdsByByEmail(String email) {
-    List<TraineeProfile> traineeProfile = repository.findAllByTraineeEmail(email.toLowerCase());
-    return traineeProfile.stream()
+    List<TraineeProfile> traineeProfiles = repository.findAllByTraineeEmail(email.toLowerCase());
+
+    return traineeProfiles.stream()
+        .filter(traineeProfile ->
+            (isValidGmcGdc(traineeProfile.getPersonalDetails().getGmcNumber())
+            || isValidGmcGdc(traineeProfile.getPersonalDetails().getGdcNumber())))
         .map(TraineeProfile::getTraineeTisId)
         .collect(Collectors.toList());
   }
@@ -115,5 +119,23 @@ public class TraineeProfileService {
    */
   public void deleteTraineeProfileByTraineeTisId(String traineeTisId) {
     repository.deleteByTraineeTisId(traineeTisId);
+  }
+
+  /**
+   * Check if the GMC or GDC number is valid.
+   *
+   * @param GmcGdcNumber The GMC or GDC number for checking.
+   * @return boolean "true" if the number is valid; "false" if not valid.
+   */
+  private Boolean isValidGmcGdc(String GmcGdcNumber) {
+    if (GmcGdcNumber == null) {
+      return false;
+    }
+
+    return !GmcGdcNumber.isEmpty()
+        && !GmcGdcNumber.equalsIgnoreCase("unknown")
+        && !GmcGdcNumber.equalsIgnoreCase("n/a")
+        && !GmcGdcNumber.equalsIgnoreCase("na")
+        && !GmcGdcNumber.toLowerCase().startsWith("delete");
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -79,11 +79,24 @@ public class TraineeProfileService {
    * @param email The email address of the trainee.
    * @return The trainee TIS IDs.
    */
-  public List<String> getTraineeTisIdsByByEmail(String email) {
+  public List<String> getTraineeTisIdsByEmail(String email) {
     List<TraineeProfile> traineeProfiles = repository.findAllByTraineeEmail(email.toLowerCase());
 
+    // if there are multiple profiles found by email,
+    // do filtering to find the best profile with the valid GMC
+    if (traineeProfiles.size() > 1) {
+      List<TraineeProfile> filteredProfiles =  traineeProfiles.stream()
+          .filter(traineeProfile -> isValidGmc(traineeProfile.getPersonalDetails().getGmcNumber()))
+          .collect(Collectors.toList());
+
+      // return all filtered valid profile if there are one or more
+      // otherwise, return all profiles found by email
+      if (!filteredProfiles.isEmpty()) {
+        traineeProfiles = filteredProfiles;
+      }
+    }
+
     return traineeProfiles.stream()
-        .filter(traineeProfile -> isValidGmc(traineeProfile.getPersonalDetails().getGmcNumber()))
         .map(TraineeProfile::getTraineeTisId)
         .collect(Collectors.toList());
   }

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -309,7 +309,7 @@ class TraineeProfileResourceTest {
 
   @Test
   void shouldReturnTraineeIdWhenProfileFoundByEmail() throws Exception {
-    when(service.getTraineeTisIdsByByEmail(PERSON_EMAIL))
+    when(service.getTraineeTisIdsByEmail(PERSON_EMAIL))
         .thenReturn(List.of(DEFAULT_TIS_ID_1, "id2"));
 
     mockMvc.perform(get("/api/trainee-profile/trainee-ids")
@@ -323,7 +323,7 @@ class TraineeProfileResourceTest {
 
   @Test
   void shouldReturnNotFoundWhenProfileNotFoundByEmail() throws Exception {
-    when(service.getTraineeTisIdsByByEmail(PERSON_EMAIL)).thenReturn(Collections.emptyList());
+    when(service.getTraineeTisIdsByEmail(PERSON_EMAIL)).thenReturn(Collections.emptyList());
 
     mockMvc.perform(get("/api/trainee-profile/trainee-ids")
         .param("email", PERSON_EMAIL)

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -39,6 +39,8 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -358,70 +360,29 @@ class TraineeProfileServiceTest {
   }
 
   @Test
-  void shouldFilterOutUnknownGmcGdcWhenProfileFoundByEmail() {
-    PersonalDetails personalDetails2 = new PersonalDetails();
-    personalDetails2.setGmcNumber("unknown");
-    traineeProfile2.setPersonalDetails(personalDetails2);
-
-    PersonalDetails personalDetails3 = new PersonalDetails();
-    personalDetails3.setGdcNumber("UNKNOWN");
-    traineeProfile3.setPersonalDetails(personalDetails3);
-
-    when(repository.findAllByTraineeEmail(PERSON_EMAIL))
-        .thenReturn(List.of(traineeProfile, traineeProfile2, traineeProfile3));
-
-    List<String> traineeTisIds = service.getTraineeTisIdsByByEmail(PERSON_EMAIL);
-
-    assertThat("Unexpected number of trainee TIS IDs.", traineeTisIds.size(), is(1));
-    assertThat("Unexpected trainee TIS IDs.", traineeTisIds, hasItems(DEFAULT_TIS_ID_1));
-  }
-
-  @Test
-  void shouldFilterOutDeletedGmcGdcWhenProfileFoundByEmail() {
-    PersonalDetails personalDetails2 = new PersonalDetails();
-    personalDetails2.setGmcNumber("Delete4");
-    traineeProfile2.setPersonalDetails(personalDetails2);
-
-    PersonalDetails personalDetails3 = new PersonalDetails();
-    personalDetails3.setGdcNumber("delete2");
-    traineeProfile3.setPersonalDetails(personalDetails3);
-
-    when(repository.findAllByTraineeEmail(PERSON_EMAIL))
-        .thenReturn(List.of(traineeProfile, traineeProfile2, traineeProfile3));
-
-    List<String> traineeTisIds = service.getTraineeTisIdsByByEmail(PERSON_EMAIL);
-
-    assertThat("Unexpected number of trainee TIS IDs.", traineeTisIds.size(), is(1));
-    assertThat("Unexpected trainee TIS IDs.", traineeTisIds, hasItems(DEFAULT_TIS_ID_1));
-  }
-
-  @Test
-  void shouldFilterOutNaGmcGdcWhenProfileFoundByEmail() {
-    PersonalDetails personalDetails2 = new PersonalDetails();
-    personalDetails2.setGmcNumber("N/A");
-    traineeProfile2.setPersonalDetails(personalDetails2);
-
-    PersonalDetails personalDetails3 = new PersonalDetails();
-    personalDetails3.setGdcNumber("na");
-    traineeProfile3.setPersonalDetails(personalDetails3);
-
-    when(repository.findAllByTraineeEmail(PERSON_EMAIL))
-        .thenReturn(List.of(traineeProfile, traineeProfile2, traineeProfile3));
-
-    List<String> traineeTisIds = service.getTraineeTisIdsByByEmail(PERSON_EMAIL);
-
-    assertThat("Unexpected number of trainee TIS IDs.", traineeTisIds.size(), is(1));
-    assertThat("Unexpected trainee TIS IDs.", traineeTisIds, hasItems(DEFAULT_TIS_ID_1));
-  }
-
-  @Test
-  void shouldFilterOutNullOrEmptyGmcGdcWhenProfileFoundByEmail() {
+  void shouldFilterOutNullGmcGdcWhenProfileFoundByEmail() {
     PersonalDetails personalDetails2 = new PersonalDetails();
     personalDetails2.setGmcNumber(null);
     traineeProfile2.setPersonalDetails(personalDetails2);
 
+    when(repository.findAllByTraineeEmail(PERSON_EMAIL))
+        .thenReturn(List.of(traineeProfile, traineeProfile2));
+
+    List<String> traineeTisIds = service.getTraineeTisIdsByByEmail(PERSON_EMAIL);
+
+    assertThat("Unexpected number of trainee TIS IDs.", traineeTisIds.size(), is(1));
+    assertThat("Unexpected trainee TIS IDs.", traineeTisIds, hasItems(DEFAULT_TIS_ID_1));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"unknown", "UNKNOWN", "Delete4", "delete2", "N/A", "na", ""})
+  void shouldFilterOutInvalidGmcGdcWhenProfileFoundByEmail(String arg) {
+    PersonalDetails personalDetails2 = new PersonalDetails();
+    personalDetails2.setGmcNumber(arg);
+    traineeProfile2.setPersonalDetails(personalDetails2);
+
     PersonalDetails personalDetails3 = new PersonalDetails();
-    personalDetails3.setGdcNumber("");
+    personalDetails3.setGdcNumber(arg);
     traineeProfile3.setPersonalDetails(personalDetails3);
 
     when(repository.findAllByTraineeEmail(PERSON_EMAIL))

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -332,7 +332,8 @@ class TraineeProfileServiceTest {
     List<String> traineeTisIds = service.getTraineeTisIdsByByEmail(PERSON_EMAIL);
 
     assertThat("Unexpected number of trainee TIS IDs.", traineeTisIds.size(), is(3));
-    assertThat("Unexpected trainee TIS IDs.", traineeTisIds, hasItems(DEFAULT_TIS_ID_1, DEFAULT_TIS_ID_2, DEFAULT_TIS_ID_3));
+    assertThat("Unexpected trainee TIS IDs.", traineeTisIds,
+        hasItems(DEFAULT_TIS_ID_1, DEFAULT_TIS_ID_2, DEFAULT_TIS_ID_3));
   }
 
   @Test
@@ -450,7 +451,8 @@ class TraineeProfileServiceTest {
     List<String> traineeTisIds = service.getTraineeTisIdsByByEmail(PERSON_EMAIL);
 
     assertThat("Unexpected number of trainee TIS IDs.", traineeTisIds.size(), is(2));
-    assertThat("Unexpected trainee TIS IDs.", traineeTisIds, hasItems(DEFAULT_TIS_ID_1, DEFAULT_TIS_ID_3));
+    assertThat("Unexpected trainee TIS IDs.", traineeTisIds,
+        hasItems(DEFAULT_TIS_ID_1, DEFAULT_TIS_ID_3));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -375,7 +375,7 @@ class TraineeProfileServiceTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"unknown", "UNKNOWN", "Delete4", "delete2", "N/A", "na", ""})
+  @ValueSource(strings = {"unknown", "UNKNOWN", "Delete4", "delete2", "N/A", "na", "p123456", ""})
   void shouldFilterOutInvalidGmcGdcWhenProfileFoundByEmail(String arg) {
     PersonalDetails personalDetails2 = new PersonalDetails();
     personalDetails2.setGmcNumber(arg);


### PR DESCRIPTION
by filtering out invalid GMC profiles

Duplicate profile with the same email and their GMC numbers: [Link](https://healtheducationengland.sharepoint.com/:x:/s/TISys/EQWkau13QGdHkPYeZpu8exEBOdTyDAx3j7F_GahpssM7YA)

The logic is based on the following rules:
- TSS does not include dental ATM, so the validation of GDC is not considered
- if there is only one profile found by email, always return that single one even if it does not have valid GMC no.
- when multiple profiles are found, if there is no profile having a valid GMC no, return all profiles found by email

TIS21-3094: To identify common trends on duplicate records. Investigate the issue with the same email address being used on multiple records.