### PR TITLE
fix: retain existing owner when TIS set to null

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.13.2"
+version = "0.13.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
@@ -23,12 +23,14 @@ package uk.nhs.hee.trainee.details.service;
 
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 
+@Slf4j
 @Service
 public class PersonalDetailsService {
 
@@ -102,7 +104,16 @@ public class PersonalDetailsService {
    */
   public Optional<PersonalDetails> updatePersonOwnerByTisId(String tisId,
       PersonalDetails personalDetails) {
-    return updatePersonalDetailsByTisId(tisId, personalDetails, mapper::updatePersonOwner);
+    BiConsumer<TraineeProfile, PersonalDetails> updateFunction;
+
+    if (personalDetails.getPersonOwner() == null) {
+      log.info("Person owner null for profile ID '{}', retaining existing owner.", tisId);
+      updateFunction = (profile, details) -> {};
+    } else {
+      updateFunction = mapper::updatePersonOwner;
+    }
+
+    return updatePersonalDetailsByTisId(tisId, personalDetails, updateFunction);
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
@@ -352,7 +352,29 @@ class PersonalDetailsServiceTest {
   }
 
   @Test
-  void shouldUpdatePersonOwnerDetailsWhenTraineeIdFound() {
+  void shouldNotUpdatePersonOwnerDetailsWhenTraineeIdFoundAndNewOwnerNull() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setPersonalDetails(createPersonalDetails(ORIGINAL_SUFFIX, 0));
+
+    when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
+    when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
+
+    PersonalDetails newPersonalDetails = createPersonalDetails(MODIFIED_SUFFIX, 100);
+    newPersonalDetails.setPersonOwner(null);
+
+    Optional<PersonalDetails> personalDetails = service
+        .updatePersonOwnerByTisId("40", newPersonalDetails);
+
+    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(false));
+
+    PersonalDetails expectedPersonalDetails = createPersonalDetails(ORIGINAL_SUFFIX, 0);
+    expectedPersonalDetails.setPersonOwner(PERSON_OWNER + ORIGINAL_SUFFIX);
+
+    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+  }
+
+  @Test
+  void shouldUpdatePersonOwnerDetailsWhenTraineeIdFoundAndNewOwnerNotNull() {
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setPersonalDetails(createPersonalDetails(ORIGINAL_SUFFIX, 0));
 


### PR DESCRIPTION
The person owner attribute is used to determine who a user should
contact for support, in the scenario where the person owner is removed
or otherwise nulled in TIS the user should be directed towards their
last LO for support. To allow this the last known person owner value
should be retained when it is removed in TIS.

TIS21-2858