### PR TITLE
fix: use url decoded for base64 token

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.13.3"
+version = "0.13.4"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
@@ -73,7 +73,7 @@ public class TraineeProfileResource {
     log.info("Trainee Profile of authenticated user.");
 
     String[] tokenSections = token.split("\\.");
-    byte[] payloadBytes = Base64.getDecoder()
+    byte[] payloadBytes = Base64.getUrlDecoder()
         .decode(tokenSections[1].getBytes(StandardCharsets.UTF_8));
     String tisId;
 


### PR DESCRIPTION
The authentication token is encoded to base64 using a URLEncoder, this
means that `/` is replaced with `_` which isn't properly handled.
Use a base64 URLDecoder to decode the token so that these characters are
handled properly.

TIS21-3353