### PR TITLE
test: Extract token generation to a utility class

### DIFF
--- a/src/test/java/uk/nhs/hee/trainee/details/TestJwtUtil.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/TestJwtUtil.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2022 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * A utility for generating test JWT tokens.
+ */
+public class TestJwtUtil {
+
+  public static final String TIS_ID_ATTRIBUTE = "custom:tisId";
+
+  /**
+   * Generate a token with the given payload.
+   *
+   * @param payload The payload to inject in to the token.
+   * @return The generated token.
+   */
+  public static String generateToken(String payload) {
+    String encodedPayload = Base64.getUrlEncoder()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    return String.format("aGVhZGVy.%s.c2lnbmF0dXJl", encodedPayload);
+  }
+
+  /**
+   * Generate a token with the TIS ID attribute as the payload.
+   *
+   * @param traineeTisId The TIS ID to inject in to the payload.
+   * @return The generated token.
+   */
+  public static String generateTokenForTisId(String traineeTisId) {
+    String payload = String.format("{\"%s\":\"%s\"}", TIS_ID_ATTRIBUTE, traineeTisId);
+    return generateToken(payload);
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -30,10 +30,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,6 +48,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.nhs.hee.trainee.details.TestJwtUtil;
 import uk.nhs.hee.trainee.details.dto.enumeration.Status;
 import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapper;
 import uk.nhs.hee.trainee.details.model.Curriculum;
@@ -63,8 +62,6 @@ import uk.nhs.hee.trainee.details.service.TraineeProfileService;
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = TraineeProfileResource.class)
 class TraineeProfileResourceTest {
-
-  private static final String TIS_ID_ATTRIBUTE = "custom:tisId";
 
   private static final String DEFAULT_ID_1 = "DEFAULT_ID_1";
   private static final String DEFAULT_TIS_ID_1 = "123";
@@ -221,10 +218,7 @@ class TraineeProfileResourceTest {
 
   @Test
   void getShouldReturnBadRequestWhenPayloadNotMap() throws Exception {
-    String payload = "[]";
-    String encodedPayload = Base64.getUrlEncoder()
-        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
-    String token = String.format("aGVhZGVy.%s.c2lnbmF0dXJl", encodedPayload);
+    String token = TestJwtUtil.generateToken("[]");
 
     this.mockMvc.perform(get("/api/trainee-profile")
             .contentType(MediaType.APPLICATION_JSON)
@@ -234,10 +228,7 @@ class TraineeProfileResourceTest {
 
   @Test
   void getShouldReturnNotFoundWhenTisIdNotInToken() throws Exception {
-    String payload = "{}";
-    String encodedPayload = Base64.getUrlEncoder()
-        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
-    String token = String.format("aGVhZGVy.%s.c2lnbmF0dXJl", encodedPayload);
+    String token = TestJwtUtil.generateToken("{}");
 
     this.mockMvc.perform(get("/api/trainee-profile")
             .contentType(MediaType.APPLICATION_JSON)
@@ -247,10 +238,7 @@ class TraineeProfileResourceTest {
 
   @Test
   void getShouldReturnNotFoundWhenTisIdNotExists() throws Exception {
-    String payload = String.format("{\"%s\":\"40\"}", TIS_ID_ATTRIBUTE);
-    String encodedPayload = Base64.getUrlEncoder()
-        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
-    String token = String.format("aGVhZGVy.%s.c2lnbmF0dXJl", encodedPayload);
+    String token = TestJwtUtil.generateTokenForTisId("40");
 
     this.mockMvc.perform(get("/api/trainee-profile")
             .contentType(MediaType.APPLICATION_JSON)
@@ -260,10 +248,7 @@ class TraineeProfileResourceTest {
 
   @Test
   void getShouldReturnTraineeProfileWhenTisIdExists() throws Exception {
-    String payload = String.format("{\"%s\":\"%s\"}", TIS_ID_ATTRIBUTE, DEFAULT_TIS_ID_1);
-    String encodedPayload = Base64.getUrlEncoder()
-        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
-    String token = String.format("aGVhZGVy.%s.c2lnbmF0dXJl", encodedPayload);
+    String token = TestJwtUtil.generateTokenForTisId(DEFAULT_TIS_ID_1);
 
     when(service.getTraineeProfileByTraineeTisId(DEFAULT_TIS_ID_1)).thenReturn(traineeProfile);
     when(service.hidePastProgrammes(traineeProfile)).thenReturn(traineeProfile);


### PR DESCRIPTION
Refactor TraineeProfileResourceTest to move the JWT token generation code to a new TestJwtUtil class.
Allows reuse of code for upcoming tests that will also need to generate tokens in this way.

TIS21-3685