### PR TITLE
chore: remove JUnit vintage exclusion from deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,6 @@ dependencies {
   implementation "org.springframework.boot:spring-boot-starter-validation"
 
   testImplementation "org.springframework.boot:spring-boot-starter-test"
-  testImplementation("org.springframework.boot:spring-boot-starter-test") {
-    exclude group: "org.junit.vintage", module: "junit-vintage-engine"
-  }
 
   // Lombok
   compileOnly "org.projectlombok:lombok"


### PR DESCRIPTION
JUnit vintage engine is no longer included in the spring boot test starter, so no longer needs an explicit exclusion.

TIS21-SHED