### PR TITLE
Feat/sign placements and programmes

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -29,6 +29,10 @@
           "valueFrom": "/tis/trainee/${environment}/queue-url/profile-created"
         },
         {
+          "name": "SIGNATURE_SECRET_KEY",
+          "valueFrom": "/tis/trainee/${environment}/signature/secret-key"
+        },
+        {
           "name": "DSP_CLIENT_ID",
           "valueFrom": "/tis/trainee/${environment}/dsp/client-id"
         },

--- a/src/main/java/uk/nhs/hee/trainee/details/TisTraineeDetailsApplication.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/TisTraineeDetailsApplication.java
@@ -24,9 +24,11 @@ package uk.nhs.hee.trainee.details;
 import io.mongock.runner.springboot.EnableMongock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @EnableMongock
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class TisTraineeDetailsApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/uk/nhs/hee/trainee/details/config/SignatureConfigurationProperties.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/SignatureConfigurationProperties.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import uk.nhs.hee.trainee.details.dto.signature.SignedDto;
+
+/**
+ * Configuration properties for DTO signatures.
+ */
+@ConstructorBinding
+@ConfigurationProperties(prefix = "application.signature")
+public final class SignatureConfigurationProperties {
+
+  @Getter
+  private final String secretKey;
+  private final Map<String, Duration> expireAfter;
+
+  /**
+   * Create a configuration profiles object for signature configuration values.
+   *
+   * @param secretKey   The secret key to use when generating a HMAC signature.
+   * @param expireAfter A map where the value is a DTO class name and the value is how long, in
+   *                    minutes, the signature for that DTO should be valid.
+   */
+  public SignatureConfigurationProperties(String secretKey, Map<String, Long> expireAfter) {
+    this.secretKey = secretKey;
+    this.expireAfter = expireAfter.entrySet().stream()
+        .collect(Collectors.toMap(Entry::getKey, e -> Duration.ofMinutes(e.getValue())));
+  }
+
+  /**
+   * Get the duration after which to expire a signature for the given DTO type.
+   *
+   * @param dto The type of DTO to get the expiry for.
+   * @return The configured expiration for the DTO type, or the default expiry if the DTO is not
+   * configured.
+   */
+  public Duration getExpireAfter(SignedDto dto) {
+    return expireAfter.getOrDefault(dto.getClass().getName(), expireAfter.get("default"));
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/config/SignatureConfigurationProperties.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/SignatureConfigurationProperties.java
@@ -58,8 +58,7 @@ public final class SignatureConfigurationProperties {
    * Get the duration after which to expire a signature for the given DTO type.
    *
    * @param dto The type of DTO to get the expiry for.
-   * @return The configured expiration for the DTO type, or the default expiry if the DTO is not
-   * configured.
+   * @return The expiration for the DTO type, or the default expiry if the DTO is not configured.
    */
   public Duration getExpireAfter(SignedDto dto) {
     return expireAfter.getOrDefault(dto.getClass().getName(), expireAfter.get("default"));

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/PlacementDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/PlacementDto.java
@@ -25,12 +25,14 @@ import java.time.LocalDate;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import uk.nhs.hee.trainee.details.dto.enumeration.Status;
+import uk.nhs.hee.trainee.details.dto.signature.Signature;
+import uk.nhs.hee.trainee.details.dto.signature.SignedDto;
 
 /**
  * A DTO for placement information.
  */
 @Data
-public class PlacementDto {
+public class PlacementDto implements SignedDto {
 
   @NotNull
   private String tisId;
@@ -45,4 +47,5 @@ public class PlacementDto {
   private String trainingBody;
   private String wholeTimeEquivalent;
   private Status status;
+  private Signature signature;
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/ProgrammeMembershipDto.java
@@ -26,12 +26,14 @@ import java.util.List;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import uk.nhs.hee.trainee.details.dto.enumeration.Status;
+import uk.nhs.hee.trainee.details.dto.signature.Signature;
+import uk.nhs.hee.trainee.details.dto.signature.SignedDto;
 
 /**
  * A DTO for programme membership information.
  */
 @Data
-public class ProgrammeMembershipDto {
+public class ProgrammeMembershipDto implements SignedDto {
 
   @NotNull
   private String tisId;
@@ -45,4 +47,5 @@ public class ProgrammeMembershipDto {
   private LocalDate programmeCompletionDate;
   private Status status;
   private List<CurriculumDto> curricula;
+  private Signature signature;
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/signature/Signature.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/signature/Signature.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2023 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,21 +19,33 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.mapper;
+package uk.nhs.hee.trainee.details.dto.signature;
 
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import uk.nhs.hee.trainee.details.dto.PlacementDto;
-import uk.nhs.hee.trainee.details.model.Placement;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.time.Instant;
+import java.time.temporal.TemporalAmount;
+import lombok.Data;
 
-@Mapper(componentModel = "spring")
-public interface PlacementMapper {
+/**
+ * A signature object to be included on {@link SignedDto} implementations.
+ */
+@Data
+public class Signature {
 
-  @Mapping(target = "signature", ignore = true)
-  PlacementDto toDto(Placement entity);
+  private final Instant signedAt;
+  private final Instant validUntil;
 
-  Placement toEntity(PlacementDto dto);
+  @JsonInclude(Include.NON_NULL)
+  private String hmac;
 
-  void updatePlacement(@MappingTarget Placement target, Placement source);
+  /**
+   * Create a signature which is valid for a given length of time.
+   *
+   * @param validFor How long the signature is valid for.
+   */
+  public Signature(TemporalAmount validFor) {
+    signedAt = Instant.now();
+    validUntil = signedAt.plus(validFor);
+  }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/signature/SignedDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/signature/SignedDto.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2023 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,21 +19,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.mapper;
+package uk.nhs.hee.trainee.details.dto.signature;
 
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import uk.nhs.hee.trainee.details.dto.PlacementDto;
-import uk.nhs.hee.trainee.details.model.Placement;
+/**
+ * An interface representing a DTO with a verification signature.
+ */
+public interface SignedDto {
 
-@Mapper(componentModel = "spring")
-public interface PlacementMapper {
+  /**
+   * Get the DTOs signature.
+   *
+   * @return The DTOs signature.
+   */
+  Signature getSignature();
 
-  @Mapping(target = "signature", ignore = true)
-  PlacementDto toDto(Placement entity);
-
-  Placement toEntity(PlacementDto dto);
-
-  void updatePlacement(@MappingTarget Placement target, Placement source);
+  /**
+   * Set the DTO signature.
+   *
+   * @param signature The signature to set.
+   */
+  void setSignature(Signature signature);
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/ProgrammeMembershipMapper.java
@@ -27,7 +27,7 @@ import org.mapstruct.MappingTarget;
 import uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = SignatureMapper.class)
 public interface ProgrammeMembershipMapper {
 
   @Mapping(target = "signature", ignore = true)

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/ProgrammeMembershipMapper.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.trainee.details.mapper;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
@@ -29,6 +30,7 @@ import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 @Mapper(componentModel = "spring")
 public interface ProgrammeMembershipMapper {
 
+  @Mapping(target = "signature", ignore = true)
   ProgrammeMembershipDto toDto(ProgrammeMembership entity);
 
   ProgrammeMembership toEntity(ProgrammeMembershipDto dto);

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/SignatureMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/SignatureMapper.java
@@ -52,7 +52,7 @@ public abstract class SignatureMapper {
     } catch (JsonProcessingException e) {
       // Convert to a runtime exception because the mapper can't bubble up checked exceptions.
       log.error("Unable to sign {} dto.", dto.getClass().getSimpleName());
-      throw new RuntimeException(e);
+      throw new IllegalArgumentException(e);
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
@@ -29,7 +29,7 @@ import uk.nhs.hee.trainee.details.dto.TraineeProfileDto;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
-@Mapper(componentModel = "spring")
+@Mapper(componentModel = "spring", uses = {PlacementMapper.class, ProgrammeMembershipMapper.class})
 public interface TraineeProfileMapper {
 
   TraineeProfileDto toDto(TraineeProfile traineeProfile);

--- a/src/main/java/uk/nhs/hee/trainee/details/service/SignatureService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/SignatureService.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
+import org.apache.commons.codec.digest.HmacAlgorithms;
+import org.apache.commons.codec.digest.HmacUtils;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.trainee.details.config.SignatureConfigurationProperties;
+import uk.nhs.hee.trainee.details.dto.signature.Signature;
+import uk.nhs.hee.trainee.details.dto.signature.SignedDto;
+
+/**
+ * A service for handling DTO signature functionality.
+ */
+@Service
+public class SignatureService {
+
+  private final ObjectMapper mapper;
+  private final SignatureConfigurationProperties signatureConfigurationProperties;
+
+  /**
+   * Create an instance of the signature service for handling DTO signature functionality.
+   *
+   * @param mapper                           The object mapper to use for converting the DTO.
+   * @param signatureConfigurationProperties The configuration properties to use when signing.
+   */
+  SignatureService(ObjectMapper mapper,
+      SignatureConfigurationProperties signatureConfigurationProperties) {
+    this.mapper = mapper;
+    this.signatureConfigurationProperties = signatureConfigurationProperties;
+  }
+
+  /**
+   * Signs a {@link SignedDto} by populating its {@link Signature}.
+   *
+   * @param dto The DTO to sign.
+   * @throws JsonProcessingException If the DTO could not be read as JSON.
+   */
+  public void signDto(SignedDto dto) throws JsonProcessingException {
+    Duration expireAfter = signatureConfigurationProperties.getExpireAfter(dto);
+    Signature signature = new Signature(expireAfter);
+    dto.setSignature(signature);
+
+    String secretKey = signatureConfigurationProperties.getSecretKey();
+    byte[] dtoBytes = mapper.writeValueAsBytes(dto);
+    String hmac = new HmacUtils(HmacAlgorithms.HMAC_SHA_256, secretKey).hmacHex(dtoBytes);
+    signature.setHmac(hmac);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,12 @@ application:
   aws:
     sqs:
       event: ${EVENT_QUEUE_URL:}
+  signature:
+    secret-key: ${SIGNATURE_SECRET_KEY}
+    expire-after:  # Minutes
+      default: 1440
+      uk.nhs.hee.trainee.details.dto.PlacementDto: ${ SIGNATURE_PLACEMENT_EXPIRY:1440 }
+      uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto: ${ SIGNATURE_PROGRAMME_MEMBERSHIP_EXPIRY:1440 }
 
 mongock:
   migration-scan-package: uk.nhs.hee.trainee.details.migration

--- a/src/test/java/uk/nhs/hee/trainee/details/api/PlacementResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/PlacementResourceTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -33,12 +34,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -51,11 +52,16 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.nhs.hee.trainee.details.dto.PlacementDto;
 import uk.nhs.hee.trainee.details.dto.enumeration.Status;
+import uk.nhs.hee.trainee.details.dto.signature.Signature;
+import uk.nhs.hee.trainee.details.dto.signature.SignedDto;
 import uk.nhs.hee.trainee.details.mapper.PlacementMapper;
+import uk.nhs.hee.trainee.details.mapper.PlacementMapperImpl;
+import uk.nhs.hee.trainee.details.mapper.SignatureMapperImpl;
 import uk.nhs.hee.trainee.details.model.Placement;
 import uk.nhs.hee.trainee.details.service.PlacementService;
+import uk.nhs.hee.trainee.details.service.SignatureService;
 
-@ContextConfiguration(classes = {PlacementMapper.class})
+@ContextConfiguration(classes = {PlacementMapperImpl.class, SignatureMapperImpl.class})
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(PlacementResource.class)
 class PlacementResourceTest {
@@ -66,15 +72,20 @@ class PlacementResourceTest {
   @Autowired
   private ObjectMapper mapper;
 
+  @Autowired
+  private PlacementMapper placementMapper;
+
   private MockMvc mockMvc;
 
   @MockBean
   private PlacementService service;
 
+  @MockBean
+  private SignatureService signatureService;
+
   @BeforeEach
   void setUp() {
-    PlacementMapper mapper = Mappers.getMapper(PlacementMapper.class);
-    PlacementResource resource = new PlacementResource(service, mapper);
+    PlacementResource resource = new PlacementResource(service, placementMapper);
     mockMvc = MockMvcBuilders.standaloneSetup(resource)
         .setMessageConverters(jacksonMessageConverter)
         .build();
@@ -85,8 +96,8 @@ class PlacementResourceTest {
     when(service.updatePlacementForTrainee("40", new Placement())).thenReturn(Optional.empty());
 
     mockMvc.perform(patch("/api/placement/{traineeTisId}", 40)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(mapper.writeValueAsBytes(new PlacementDto())))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsBytes(new PlacementDto())))
         .andExpect(status().isBadRequest());
   }
 
@@ -98,8 +109,8 @@ class PlacementResourceTest {
     dto.setTisId("tisIdValue");
 
     mockMvc.perform(patch("/api/placement/{traineeTisId}", 40)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(mapper.writeValueAsBytes(dto)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsBytes(dto)))
         .andExpect(status().isNotFound())
         .andExpect(status().reason("Trainee not found."));
   }
@@ -123,12 +134,20 @@ class PlacementResourceTest {
     when(service.updatePlacementForTrainee(eq("40"), any(Placement.class)))
         .thenReturn(Optional.of(placement));
 
+    Signature signature = new Signature(Duration.ofMinutes(60));
+    signature.setHmac("not-really-a-hmac");
+    doAnswer(inv -> {
+      SignedDto dto = inv.getArgument(0);
+      dto.setSignature(signature);
+      return null;
+    }).when(signatureService).signDto(any());
+
     PlacementDto dto = new PlacementDto();
     dto.setTisId("tisIdValue");
 
     mockMvc.perform(patch("/api/placement/{traineeTisId}", 40)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(mapper.writeValueAsBytes(dto)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsBytes(dto)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.tisId").value(is("tisIdValue")))
@@ -139,7 +158,11 @@ class PlacementResourceTest {
         .andExpect(jsonPath("$.grade").value(is("gradeValue")))
         .andExpect(jsonPath("$.specialty").value(is("specialtyValue")))
         .andExpect(jsonPath("$.placementType").value(is("placementTypeValue")))
-        .andExpect(jsonPath("$.status").value(is("CURRENT")));
+        .andExpect(jsonPath("$.status").value(is("CURRENT")))
+        .andExpect(jsonPath("$.signature.hmac").value(signature.getHmac()))
+        .andExpect(jsonPath("$.signature.signedAt").value(signature.getSignedAt().toString()))
+        .andExpect(jsonPath("$.signature.validUntil").value(signature.getValidUntil().toString()));
+    ;
   }
 
   @Test
@@ -149,8 +172,8 @@ class PlacementResourceTest {
         .thenReturn(true);
 
     MvcResult result = mockMvc.perform(
-        delete("/api/placement/{traineeTisId}/{placementTisId}", 40, 1)
-            .contentType(MediaType.APPLICATION_JSON))
+            delete("/api/placement/{traineeTisId}/{placementTisId}", 40, 1)
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andReturn();
 
@@ -165,8 +188,8 @@ class PlacementResourceTest {
         .thenReturn(false);
 
     mockMvc.perform(
-        delete("/api/placement/{traineeTisId}/{placementTisId}", 40, 1)
-            .contentType(MediaType.APPLICATION_JSON))
+            delete("/api/placement/{traineeTisId}/{placementTisId}", 40, 1)
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNotFound());
   }
 
@@ -177,8 +200,8 @@ class PlacementResourceTest {
         .thenThrow(new IllegalArgumentException());
 
     mockMvc.perform(
-        delete("/api/placement/{traineeTisId}/{placementTisId}", "triggersError", "1")
-            .contentType(MediaType.APPLICATION_JSON))
+            delete("/api/placement/{traineeTisId}/{placementTisId}", "triggersError", "1")
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -33,12 +34,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -50,11 +51,16 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto;
+import uk.nhs.hee.trainee.details.dto.signature.Signature;
+import uk.nhs.hee.trainee.details.dto.signature.SignedDto;
 import uk.nhs.hee.trainee.details.mapper.ProgrammeMembershipMapper;
+import uk.nhs.hee.trainee.details.mapper.ProgrammeMembershipMapperImpl;
+import uk.nhs.hee.trainee.details.mapper.SignatureMapperImpl;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 import uk.nhs.hee.trainee.details.service.ProgrammeMembershipService;
+import uk.nhs.hee.trainee.details.service.SignatureService;
 
-@ContextConfiguration(classes = {ProgrammeMembershipMapper.class})
+@ContextConfiguration(classes = {ProgrammeMembershipMapperImpl.class, SignatureMapperImpl.class})
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(ProgrammeMembershipResource.class)
 class ProgrammeMembershipResourceTest {
@@ -65,15 +71,21 @@ class ProgrammeMembershipResourceTest {
   @Autowired
   private ObjectMapper mapper;
 
+  @Autowired
+  private ProgrammeMembershipMapper programmeMembershipMapper;
+
   private MockMvc mockMvc;
 
   @MockBean
   private ProgrammeMembershipService service;
 
+  @MockBean
+  private SignatureService signatureService;
+
   @BeforeEach
   void setUp() {
-    ProgrammeMembershipMapper mapper = Mappers.getMapper(ProgrammeMembershipMapper.class);
-    ProgrammeMembershipResource resource = new ProgrammeMembershipResource(service, mapper);
+    ProgrammeMembershipResource resource = new ProgrammeMembershipResource(service,
+        programmeMembershipMapper);
     mockMvc = MockMvcBuilders.standaloneSetup(resource)
         .setMessageConverters(jacksonMessageConverter)
         .build();
@@ -85,8 +97,8 @@ class ProgrammeMembershipResourceTest {
         .thenReturn(Optional.empty());
 
     mockMvc.perform(patch("/api/programme-membership/{traineeTisId}", 40)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(mapper.writeValueAsBytes(new ProgrammeMembershipDto())))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsBytes(new ProgrammeMembershipDto())))
         .andExpect(status().isBadRequest());
   }
 
@@ -99,8 +111,8 @@ class ProgrammeMembershipResourceTest {
     dto.setTisId("tisIdValue");
 
     mockMvc.perform(patch("/api/programme-membership/{traineeTisId}", 40)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(mapper.writeValueAsBytes(dto)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsBytes(dto)))
         .andExpect(status().isNotFound())
         .andExpect(status().reason("Trainee not found."));
   }
@@ -125,12 +137,20 @@ class ProgrammeMembershipResourceTest {
     when(service.updateProgrammeMembershipForTrainee(eq("40"), any(ProgrammeMembership.class)))
         .thenReturn(Optional.of(programmeMembership));
 
+    Signature signature = new Signature(Duration.ofMinutes(60));
+    signature.setHmac("not-really-a-hmac");
+    doAnswer(inv -> {
+      SignedDto dto = inv.getArgument(0);
+      dto.setSignature(signature);
+      return null;
+    }).when(signatureService).signDto(any());
+
     ProgrammeMembershipDto dto = new ProgrammeMembershipDto();
     dto.setTisId("tisIdValue");
 
     mockMvc.perform(patch("/api/programme-membership/{traineeTisId}", 40)
-        .contentType(MediaType.APPLICATION_JSON)
-        .content(mapper.writeValueAsBytes(dto)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsBytes(dto)))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.tisId").value(is("tisIdValue")))
@@ -141,7 +161,10 @@ class ProgrammeMembershipResourceTest {
         .andExpect(jsonPath("$.programmeMembershipType").value(is("programmeMembershipTypeValue")))
         .andExpect(jsonPath("$.startDate").value(is(start.toString())))
         .andExpect(jsonPath("$.endDate").value(is(end.toString())))
-        .andExpect(jsonPath("$.programmeCompletionDate").value(is(completion.toString())));
+        .andExpect(jsonPath("$.programmeCompletionDate").value(is(completion.toString())))
+        .andExpect(jsonPath("$.signature.hmac").value(signature.getHmac()))
+        .andExpect(jsonPath("$.signature.signedAt").value(signature.getSignedAt().toString()))
+        .andExpect(jsonPath("$.signature.validUntil").value(signature.getValidUntil().toString()));
   }
 
   @Test
@@ -155,8 +178,8 @@ class ProgrammeMembershipResourceTest {
     dto.setTisId("tisIdValue");
 
     MvcResult result = mockMvc.perform(
-        delete("/api/programme-membership/{traineeTisId}", 40)
-            .contentType(MediaType.APPLICATION_JSON))
+            delete("/api/programme-membership/{traineeTisId}", 40)
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andReturn();
 
@@ -174,8 +197,8 @@ class ProgrammeMembershipResourceTest {
     dto.setTisId("tisIdValue");
 
     mockMvc.perform(
-        delete("/api/programme-membership/{traineeTisId}", 40)
-            .contentType(MediaType.APPLICATION_JSON))
+            delete("/api/programme-membership/{traineeTisId}", 40)
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isNotFound());
   }
 
@@ -189,8 +212,8 @@ class ProgrammeMembershipResourceTest {
     dto.setTisId("tisIdValue");
 
     mockMvc.perform(
-        delete("/api/programme-membership/{traineeTisId}", "triggersError")
-            .contentType(MediaType.APPLICATION_JSON))
+            delete("/api/programme-membership/{traineeTisId}", "triggersError")
+                .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -263,8 +263,6 @@ class TraineeProfileResourceTest {
 
   @Test
   void getShouldReturnTraineeProfileWhenTisIdExists() throws Exception {
-    String token = TestJwtUtil.generateTokenForTisId(DEFAULT_TIS_ID_1);
-
     when(service.getTraineeProfileByTraineeTisId(DEFAULT_TIS_ID_1)).thenReturn(traineeProfile);
     when(service.hidePastProgrammes(traineeProfile)).thenReturn(traineeProfile);
     when(service.hidePastPlacements(traineeProfile)).thenReturn(traineeProfile);
@@ -277,6 +275,7 @@ class TraineeProfileResourceTest {
       return null;
     }).when(signatureService).signDto(any());
 
+    String token = TestJwtUtil.generateTokenForTisId(DEFAULT_TIS_ID_1);
     this.mockMvc.perform(get("/api/trainee-profile")
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, token))

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -30,6 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -49,8 +52,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.nhs.hee.trainee.details.TestJwtUtil;
 import uk.nhs.hee.trainee.details.dto.enumeration.Status;
+import uk.nhs.hee.trainee.details.dto.signature.Signature;
+import uk.nhs.hee.trainee.details.dto.signature.SignedDto;
 import uk.nhs.hee.trainee.details.mapper.PlacementMapperImpl;
 import uk.nhs.hee.trainee.details.mapper.ProgrammeMembershipMapperImpl;
+import uk.nhs.hee.trainee.details.mapper.SignatureMapperImpl;
 import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapper;
 import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapperImpl;
 import uk.nhs.hee.trainee.details.model.Curriculum;
@@ -58,10 +64,11 @@ import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.model.Placement;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
+import uk.nhs.hee.trainee.details.service.SignatureService;
 import uk.nhs.hee.trainee.details.service.TraineeProfileService;
 
 @ContextConfiguration(classes = {TraineeProfileMapperImpl.class, PlacementMapperImpl.class,
-    ProgrammeMembershipMapperImpl.class})
+    ProgrammeMembershipMapperImpl.class, SignatureMapperImpl.class})
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = TraineeProfileResource.class)
 class TraineeProfileResourceTest {
@@ -118,6 +125,9 @@ class TraineeProfileResourceTest {
 
   @MockBean
   private TraineeProfileService service;
+
+  @MockBean
+  private SignatureService signatureService;
 
   private TraineeProfile traineeProfile;
   private PersonalDetails personalDetails;
@@ -258,6 +268,15 @@ class TraineeProfileResourceTest {
     when(service.getTraineeProfileByTraineeTisId(DEFAULT_TIS_ID_1)).thenReturn(traineeProfile);
     when(service.hidePastProgrammes(traineeProfile)).thenReturn(traineeProfile);
     when(service.hidePastPlacements(traineeProfile)).thenReturn(traineeProfile);
+
+    Signature signature = new Signature(Duration.ofMinutes(60));
+    signature.setHmac("not-really-a-hmac");
+    doAnswer(inv -> {
+      SignedDto dto = inv.getArgument(0);
+      dto.setSignature(signature);
+      return null;
+    }).when(signatureService).signDto(any());
+
     this.mockMvc.perform(get("/api/trainee-profile")
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, token))
@@ -293,9 +312,19 @@ class TraineeProfileResourceTest {
             .value(CURRICULUM_NAME))
         .andExpect(jsonPath("$.programmeMemberships[*].curricula[*].curriculumSubType")
             .value(CURRICULUM_SUBTYPE))
+        .andExpect(jsonPath("$.programmeMemberships[*].signature.hmac").value(signature.getHmac()))
+        .andExpect(jsonPath("$.programmeMemberships[*].signature.signedAt")
+            .value(signature.getSignedAt().toString()))
+        .andExpect(jsonPath("$.programmeMemberships[*].signature.validUntil")
+            .value(signature.getValidUntil().toString()))
         .andExpect(jsonPath("$.placements[*].tisId").value(PLACEMENT_TISID))
         .andExpect(jsonPath("$.placements[*].site").value(PLACEMENT_SITE))
-        .andExpect(jsonPath("$.placements[*].status").value(PLACEMENT_STATUS.toString()));
+        .andExpect(jsonPath("$.placements[*].status").value(PLACEMENT_STATUS.toString()))
+        .andExpect(jsonPath("$.placements[*].signature.hmac").value(signature.getHmac()))
+        .andExpect(jsonPath("$.placements[*].signature.signedAt")
+            .value(signature.getSignedAt().toString()))
+        .andExpect(jsonPath("$.placements[*].signature.validUntil")
+            .value(signature.getValidUntil().toString()));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mapstruct.factory.Mappers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -50,7 +49,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import uk.nhs.hee.trainee.details.TestJwtUtil;
 import uk.nhs.hee.trainee.details.dto.enumeration.Status;
+import uk.nhs.hee.trainee.details.mapper.PlacementMapperImpl;
+import uk.nhs.hee.trainee.details.mapper.ProgrammeMembershipMapperImpl;
 import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapper;
+import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapperImpl;
 import uk.nhs.hee.trainee.details.model.Curriculum;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.model.Placement;
@@ -58,7 +60,8 @@ import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.service.TraineeProfileService;
 
-@ContextConfiguration(classes = TraineeProfileMapper.class)
+@ContextConfiguration(classes = {TraineeProfileMapperImpl.class, PlacementMapperImpl.class,
+    ProgrammeMembershipMapperImpl.class})
 @ExtendWith(SpringExtension.class)
 @WebMvcTest(controllers = TraineeProfileResource.class)
 class TraineeProfileResourceTest {
@@ -108,6 +111,9 @@ class TraineeProfileResourceTest {
   @Autowired
   private ObjectMapper objectMapper;
 
+  @Autowired
+  private TraineeProfileMapper traineeProfileMapper;
+
   private MockMvc mockMvc;
 
   @MockBean
@@ -124,9 +130,8 @@ class TraineeProfileResourceTest {
    */
   @BeforeEach
   void setup() {
-    TraineeProfileMapper mapper = Mappers.getMapper(TraineeProfileMapper.class);
-    TraineeProfileResource traineeProfileResource = new TraineeProfileResource(service, mapper,
-        objectMapper);
+    TraineeProfileResource traineeProfileResource = new TraineeProfileResource(service,
+        traineeProfileMapper, objectMapper);
     this.mockMvc = MockMvcBuilders.standaloneSetup(traineeProfileResource)
         .setMessageConverters(jacksonMessageConverter)
         .build();

--- a/src/test/java/uk/nhs/hee/trainee/details/config/SignatureConfigurationPropertiesTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/SignatureConfigurationPropertiesTest.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.trainee.details.dto.PlacementDto;
+import uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto;
+import uk.nhs.hee.trainee.details.dto.signature.Signature;
+import uk.nhs.hee.trainee.details.dto.signature.SignedDto;
+
+class SignatureConfigurationPropertiesTest {
+
+  private static final String SECRET_KEY = "not-so-secret-key";
+
+  private SignatureConfigurationProperties configurationProperties;
+
+  @BeforeEach
+  void setUp() {
+    Map<String, Long> expireAfter = Map.of(
+        "default", 10L,
+        PlacementDto.class.getName(), 20L
+    );
+
+    configurationProperties = new SignatureConfigurationProperties(SECRET_KEY, expireAfter);
+  }
+
+  @Test
+  void shouldGetSecretKey() {
+    String secretKey = configurationProperties.getSecretKey();
+    assertThat("Unexpected secret key.", secretKey, is(SECRET_KEY));
+  }
+
+  @Test
+  void shouldGetDefaultExpiryWhenNoConfigFound() {
+    Duration expiry = configurationProperties.getExpireAfter(new ProgrammeMembershipDto());
+    assertThat("Unexpected expiry.", expiry, is(Duration.ofMinutes(10)));
+  }
+
+  @Test
+  void shouldGetClassExpiryWhenConfigFound() {
+    Duration expiry = configurationProperties.getExpireAfter(new PlacementDto());
+    assertThat("Unexpected expiry.", expiry, is(Duration.ofMinutes(20)));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/mapper/SignatureMapperTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/mapper/SignatureMapperTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2023 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,19 +21,34 @@
 
 package uk.nhs.hee.trainee.details.mapper;
 
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.nhs.hee.trainee.details.dto.PlacementDto;
-import uk.nhs.hee.trainee.details.model.Placement;
+import uk.nhs.hee.trainee.details.service.SignatureService;
 
-@Mapper(componentModel = "spring", uses = SignatureMapper.class)
-public interface PlacementMapper {
+@ContextConfiguration(classes = SignatureMapperImpl.class)
+@ExtendWith(SpringExtension.class)
+class SignatureMapperTest {
 
-  @Mapping(target = "signature", ignore = true)
-  PlacementDto toDto(Placement entity);
+  @Autowired
+  private SignatureMapper mapper;
 
-  Placement toEntity(PlacementDto dto);
+  @MockBean
+  private SignatureService service;
 
-  void updatePlacement(@MappingTarget Placement target, Placement source);
+  @Test
+  void shouldThrowRuntimeExceptionWhenServiceFails() throws JsonProcessingException {
+    Mockito.doThrow(JsonProcessingException.class).when(service).signDto(any());
+
+    assertThrows(RuntimeException.class, () -> mapper.signDto(new PlacementDto()));
+  }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/mapper/SignatureMapperTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/mapper/SignatureMapperTest.java
@@ -49,6 +49,7 @@ class SignatureMapperTest {
   void shouldThrowRuntimeExceptionWhenServiceFails() throws JsonProcessingException {
     Mockito.doThrow(JsonProcessingException.class).when(service).signDto(any());
 
-    assertThrows(RuntimeException.class, () -> mapper.signDto(new PlacementDto()));
+    PlacementDto dto = new PlacementDto();
+    assertThrows(RuntimeException.class, () -> mapper.signDto(dto));
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/SignatureServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/SignatureServiceTest.java
@@ -1,0 +1,130 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import org.apache.commons.codec.digest.HmacAlgorithms;
+import org.apache.commons.codec.digest.HmacUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.trainee.details.config.SignatureConfigurationProperties;
+import uk.nhs.hee.trainee.details.dto.PlacementDto;
+import uk.nhs.hee.trainee.details.dto.signature.Signature;
+
+class SignatureServiceTest {
+
+  private static final String SECRET_KEY = "not-so-secret-key";
+
+  private SignatureService service;
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setUp() {
+    objectMapper = spy(new ObjectMapper());
+    objectMapper.registerModule(new JavaTimeModule());
+
+    Map<String, Long> expiresAfter = Map.of(PlacementDto.class.getName(), 1440L);
+    var properties = new SignatureConfigurationProperties(SECRET_KEY, expiresAfter);
+
+    service = new SignatureService(objectMapper, properties);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenDtoCanNotBeRead() throws JsonProcessingException {
+    when(objectMapper.writeValueAsBytes(any())).thenThrow(JsonProcessingException.class);
+
+    assertThrows(JsonProcessingException.class, () -> service.signDto(new PlacementDto()));
+  }
+
+  @Test
+  void shouldSignDto() throws JsonProcessingException, InterruptedException {
+    PlacementDto dto = new PlacementDto();
+
+    Instant start = Instant.now();
+    Thread.sleep(0, 1);
+
+    service.signDto(dto);
+
+    Thread.sleep(0, 1);
+    Instant end = Instant.now();
+
+    Signature signature = dto.getSignature();
+    assertThat("Unexpected signature.", signature, notNullValue());
+
+    Instant signedAt = signature.getSignedAt();
+    assertThat("Signed at timestamp is too early.", signedAt.isAfter(start), is(true));
+    assertThat("Signed at timestamp is too late.", signedAt.isBefore(end), is(true));
+
+    long expiresAfter = signedAt.until(signature.getValidUntil(), ChronoUnit.MINUTES);
+    assertThat("Unexpected valid duration.", expiresAfter, is(1440L));
+
+    String hmac = signature.getHmac();
+    assertThat("Unexpected hmac.", hmac, notNullValue());
+    assertThat("Unexpected hmac length.", hmac.length(), is(64));
+  }
+
+  @Test
+  void shouldNotValidateWhenHmacIncluded() throws JsonProcessingException, InterruptedException {
+    PlacementDto dto = new PlacementDto();
+    dto.setTisId("123");
+
+    service.signDto(dto);
+
+    String serviceHmac = dto.getSignature().getHmac();
+
+    byte[] dtoBytes = objectMapper.writeValueAsBytes(dto);
+    String testHmac = new HmacUtils(HmacAlgorithms.HMAC_SHA_256, SECRET_KEY).hmacHex(dtoBytes);
+
+    assertThat("Unexpected hmac.", serviceHmac, not(is(testHmac)));
+  }
+
+  @Test
+  void shouldValidateWhenHmacExcluded() throws JsonProcessingException, InterruptedException {
+    PlacementDto dto = new PlacementDto();
+    dto.setTisId("123");
+
+    service.signDto(dto);
+
+    Signature signature = dto.getSignature();
+    String serviceHmac = signature.getHmac();
+
+    signature.setHmac(null);
+    byte[] dtoBytes = objectMapper.writeValueAsBytes(dto);
+    String testHmac = new HmacUtils(HmacAlgorithms.HMAC_SHA_256, SECRET_KEY).hmacHex(dtoBytes);
+
+    assertThat("Unexpected hmac.", serviceHmac, is(testHmac));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/service/SignatureServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/SignatureServiceTest.java
@@ -94,7 +94,7 @@ class SignatureServiceTest {
   }
 
   @Test
-  void shouldNotValidateWhenHmacIncluded() throws JsonProcessingException, InterruptedException {
+  void shouldNotValidateWhenHmacIncludedInHmacGeneration() throws JsonProcessingException {
     PlacementDto dto = new PlacementDto();
     dto.setTisId("123");
 
@@ -109,7 +109,7 @@ class SignatureServiceTest {
   }
 
   @Test
-  void shouldValidateWhenHmacExcluded() throws JsonProcessingException, InterruptedException {
+  void shouldValidateWhenHmacExcludedFromHmacGeneration() throws JsonProcessingException {
     PlacementDto dto = new PlacementDto();
     dto.setTisId("123");
 

--- a/src/test/java/uk/nhs/hee/trainee/details/service/SignatureServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/SignatureServiceTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
@@ -73,13 +74,9 @@ class SignatureServiceTest {
   void shouldSignDto() throws JsonProcessingException, InterruptedException {
     PlacementDto dto = new PlacementDto();
 
-    Instant start = Instant.now();
-    Thread.sleep(0, 1);
-
+    final Instant start = Instant.now().minus(Duration.ofNanos(1));
     service.signDto(dto);
-
-    Thread.sleep(0, 1);
-    Instant end = Instant.now();
+    final Instant end = Instant.now().plus(Duration.ofNanos(1));
 
     Signature signature = dto.getSignature();
     assertThat("Unexpected signature.", signature, notNullValue());


### PR DESCRIPTION
Adds a signature to placements and programme memberships with the following structure
```json
{
    "tisId": "315",
    ...
    "status": "CURRENT",
    "signature": {
        "signedAt": "2023-01-11T13:41:39.795528900Z",
        "validUntil": "2023-01-12T13:41:39.795528900Z",
        "hmac": "af03b176aff00fd8bb3bf4723ba6ec895cd2e8c94862f63c0e1c33b576b0e2df"
    }
}
```