### PR TITLE
fix: incorrect DSP property mappings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.14.0"
+version = "0.14.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/JwtService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/JwtService.java
@@ -34,8 +34,8 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import uk.nhs.hee.trainee.details.config.DspConfigurationProperties;
 import uk.nhs.hee.trainee.details.model.Placement;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 
@@ -48,12 +48,10 @@ public class JwtService {
   private final String tokenAudience;
   private final String tokenSigningKey;
 
-  JwtService(@Value("${dsp.token.issuer}") String tokenIssuer,
-             @Value("${dsp.token.audience}") String tokenAudience,
-             @Value("${dsp.token.signing-key}") String tokenSigningKey) {
-    this.tokenIssuer = tokenIssuer;
-    this.tokenAudience = tokenAudience;
-    this.tokenSigningKey = tokenSigningKey;
+  JwtService(DspConfigurationProperties dspConfigurationProperties) {
+    this.tokenIssuer = dspConfigurationProperties.getTokenIssuer();
+    this.tokenAudience = dspConfigurationProperties.getTokenAudience();
+    this.tokenSigningKey = dspConfigurationProperties.getTokenSigningKey();
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/trainee/details/service/JwtServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/JwtServiceTest.java
@@ -32,9 +32,11 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.nhs.hee.trainee.details.config.DspConfigurationProperties;
 import uk.nhs.hee.trainee.details.model.Placement;
 
 class JwtServiceTest {
+
   private static final String TOKEN_ISSUER = "issuer";
   private static final String TOKEN_AUDIENCE = "audience";
   private static final String TOKEN_SIGNING_KEY = "signing key";
@@ -47,7 +49,12 @@ class JwtServiceTest {
 
   @BeforeEach
   void setup() {
-    service = new JwtService(TOKEN_ISSUER, TOKEN_AUDIENCE, TOKEN_SIGNING_KEY);
+    DspConfigurationProperties properties = new DspConfigurationProperties();
+    properties.setTokenAudience(TOKEN_AUDIENCE);
+    properties.setTokenIssuer(TOKEN_ISSUER);
+    properties.setTokenSigningKey(TOKEN_SIGNING_KEY);
+
+    service = new JwtService(properties);
     placement = new Placement();
     placement.setTisId("test");
     token = service.generatePlacementToken(placement);


### PR DESCRIPTION
The application property names are in the format `dsp.slash-separated` but the JwtService expects a `dsp.dot.separated` format. This is working in some environments as Spring maps env vars directly, but we should be using the application properties value instead of direct env mapping.

TIS21-SHED