### PR TITLE
feat: add tracing to API and Service classes

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -92,7 +92,7 @@
           "value": "eu-west-2"
         },
         {
-          "name": "SENTRY_ENVIRONMENT",
+          "name": "ENVIRONMENT",
           "value": "${environment}"
         }
       ]

--- a/README.md
+++ b/README.md
@@ -27,16 +27,17 @@ gradlew bootRun
 
 #### Environmental Variables
 
-| Name               | Description                                   | Default   |
-|--------------------|-----------------------------------------------|-----------|
-| DB_HOST            | The MongoDB host to connect to.               | localhost |
-| DB_PORT            | The port to connect to MongoDB on.            | 27017     |
-| DB_NAME            | The name of the MongoDB database.             | trainee   |
-| DB_USER            | The username to access the MongoDB instance.  | admin     |
-| DB_PASSWORD        | The password to access the MongoDB instance.  | pwd       |
-| SENTRY_DSN         | A Sentry error monitoring Data Source Name.   |           |
-| SENTRY_ENVIRONMENT | The environment to log Sentry events against. | local     |
-| EVENT_QUEUE_URL    | The URL of the SQS event queue.               |           |
+| Name                    | Description                                  | Default   |
+|-------------------------|----------------------------------------------|-----------|
+| AWS_XRAY_DAEMON_ADDRESS | The AWS XRay daemon host.                    |           |
+| DB_HOST                 | The MongoDB host to connect to.              | localhost |
+| DB_PORT                 | The port to connect to MongoDB on.           | 27017     |
+| DB_NAME                 | The name of the MongoDB database.            | trainee   |
+| DB_USER                 | The username to access the MongoDB instance. | admin     |
+| DB_PASSWORD             | The password to access the MongoDB instance. | pwd       |
+| ENVIRONMENT             | The environment to log events against.       | local     |
+| EVENT_QUEUE_URL         | The URL of the SQS event queue.              |           |
+| SENTRY_DSN              | A Sentry error monitoring Data Source Name.  |           |
 
 #### Usage Examples
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.15.0"
+version = "0.16.0"
 
 configurations {
   compileOnly {
@@ -53,8 +53,9 @@ dependencies {
   // Sentry reporting
   implementation "io.sentry:sentry-spring-boot-starter:6.16.0"
 
-  // Amazon SQS
+  // Amazon AWS
   implementation "io.awspring.cloud:spring-cloud-starter-aws-messaging"
+  implementation "com.amazonaws:aws-xray-recorder-sdk-spring:2.13.0"
 
   // JWT
   implementation "io.jsonwebtoken:jjwt:0.9.1"

--- a/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -36,6 +37,7 @@ import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 @Slf4j
 @RestController
 @RequestMapping("/api/basic-details")
+@XRayEnabled
 public class BasicDetailsResource {
 
   private final PersonalDetailsService service;

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ContactDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ContactDetailsResource.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -39,6 +40,7 @@ import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 @Slf4j
 @RestController
 @RequestMapping("/api/contact-details")
+@XRayEnabled
 public class ContactDetailsResource {
 
   private final PersonalDetailsService service;

--- a/src/main/java/uk/nhs/hee/trainee/details/api/GdcDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/GdcDetailsResource.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -39,6 +40,7 @@ import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 @Slf4j
 @RestController
 @RequestMapping("/api/gdc-details")
+@XRayEnabled
 public class GdcDetailsResource {
 
   private final PersonalDetailsService service;

--- a/src/main/java/uk/nhs/hee/trainee/details/api/GmcDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/GmcDetailsResource.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -39,6 +40,7 @@ import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 @Slf4j
 @RestController
 @RequestMapping("/api/gmc-details")
+@XRayEnabled
 public class GmcDetailsResource {
 
   private final PersonalDetailsService service;

--- a/src/main/java/uk/nhs/hee/trainee/details/api/PersonOwnerResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/PersonOwnerResource.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -39,6 +40,7 @@ import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 @Slf4j
 @RestController
 @RequestMapping("/api/person-owner")
+@XRayEnabled
 public class PersonOwnerResource {
 
   private final PersonalDetailsService service;

--- a/src/main/java/uk/nhs/hee/trainee/details/api/PersonalInfoResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/PersonalInfoResource.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -39,6 +40,7 @@ import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 @Slf4j
 @RestController
 @RequestMapping("/api/personal-info")
+@XRayEnabled
 public class PersonalInfoResource {
 
   private final PersonalDetailsService service;

--- a/src/main/java/uk/nhs/hee/trainee/details/api/PlacementResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/PlacementResource.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -42,6 +43,7 @@ import uk.nhs.hee.trainee.details.service.PlacementService;
 @Slf4j
 @RestController
 @RequestMapping("/api/placement")
+@XRayEnabled
 public class PlacementResource {
 
   private final PlacementService service;

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -42,6 +43,7 @@ import uk.nhs.hee.trainee.details.service.ProgrammeMembershipService;
 @Slf4j
 @RestController
 @RequestMapping("/api/programme-membership")
+@XRayEnabled
 public class ProgrammeMembershipResource {
 
   private final ProgrammeMembershipService service;

--- a/src/main/java/uk/nhs/hee/trainee/details/api/QualificationResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/QualificationResource.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -41,6 +42,7 @@ import uk.nhs.hee.trainee.details.service.QualificationService;
 @Slf4j
 @RestController
 @RequestMapping("/api/qualification")
+@XRayEnabled
 public class QualificationResource {
 
   private final QualificationService service;

--- a/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -46,6 +47,7 @@ import uk.nhs.hee.trainee.details.service.TraineeProfileService;
 @Slf4j
 @RestController
 @RequestMapping("/api/trainee-profile")
+@XRayEnabled
 public class TraineeProfileResource {
 
   private static final String TIS_ID_ATTRIBUTE = "custom:tisId";

--- a/src/main/java/uk/nhs/hee/trainee/details/config/AwsXrayConfiguration.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/AwsXrayConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import com.amazonaws.xray.javax.servlet.AWSXRayServletFilter;
+import javax.servlet.Filter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnExpression("!T(org.springframework.util.StringUtils)"
+    + ".isEmpty('${com.amazonaws.xray.emitters.daemon-address}')")
+public class AwsXrayConfiguration {
+
+  @Bean
+  public Filter tracingFilter(@Value("${application.environment}") String environment) {
+    return new AWSXRayServletFilter("tis-trainee-details-" + environment);
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/config/AwsXrayInterceptor.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/AwsXrayInterceptor.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import com.amazonaws.xray.spring.aop.AbstractXRayInterceptor;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@ConditionalOnExpression("!T(org.springframework.util.StringUtils)"
+    + ".isEmpty('${com.amazonaws.xray.emitters.daemon-address}')")
+public class AwsXrayInterceptor extends AbstractXRayInterceptor {
+
+  @Override
+  @Pointcut(
+      "@within(com.amazonaws.xray.spring.aop.XRayEnabled) && (bean(*Resource) || bean(*Service))")
+  public void xrayEnabledClasses() {
+
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/service/EventPublishService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/EventPublishService.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.service;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -33,6 +34,7 @@ import uk.nhs.hee.trainee.details.model.TraineeProfile;
  */
 @Slf4j
 @Service
+@XRayEnabled
 public class EventPublishService {
 
   private final QueueMessagingTemplate messagingTemplate;

--- a/src/main/java/uk/nhs/hee/trainee/details/service/JwtService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/JwtService.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.trainee.details.service;
 
 import static io.jsonwebtoken.SignatureAlgorithm.HS256;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.SignatureException;
@@ -41,6 +42,7 @@ import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 
 @Slf4j
 @Service
+@XRayEnabled
 public class JwtService {
 
   private static final Long JWT_EXPIRATION_MS = 31556926000L; //1 year in milliseconds

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.service;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import lombok.extern.slf4j.Slf4j;
@@ -32,6 +33,7 @@ import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 
 @Slf4j
 @Service
+@XRayEnabled
 public class PersonalDetailsService {
 
   private final TraineeProfileRepository repository;

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PlacementService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PlacementService.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.service;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,6 +32,7 @@ import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 
 @Service
+@XRayEnabled
 public class PlacementService {
 
   private final TraineeProfileRepository repository;

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.service;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,6 +32,7 @@ import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 
 @Service
+@XRayEnabled
 public class ProgrammeMembershipService {
 
   private final TraineeProfileRepository repository;

--- a/src/main/java/uk/nhs/hee/trainee/details/service/QualificationService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/QualificationService.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.service;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
@@ -30,6 +31,7 @@ import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 
 @Service
+@XRayEnabled
 public class QualificationService {
 
   private final TraineeProfileRepository repository;

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.service;
 
+import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,6 +33,7 @@ import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 
 @Service
+@XRayEnabled
 public class TraineeProfileService {
 
   private final TraineeProfileRepository repository;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,18 +14,25 @@ logging:
 
 sentry:
   dsn: ${SENTRY_DSN:}
-  environment: ${SENTRY_ENVIRONMENT:local}
+  environment: ${application.environment}
 
 application:
   aws:
     sqs:
       event: ${EVENT_QUEUE_URL:}
+  environment: ${ENVIRONMENT:local}
   signature:
     secret-key: ${SIGNATURE_SECRET_KEY}
     expire-after:  # Minutes
       default: 1440
       uk.nhs.hee.trainee.details.dto.PlacementDto: ${ SIGNATURE_PLACEMENT_EXPIRY:1440 }
       uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto: ${ SIGNATURE_PROGRAMME_MEMBERSHIP_EXPIRY:1440 }
+
+com:
+  amazonaws:
+    xray:
+      emitters:
+        daemon-address: ${AWS_XRAY_DAEMON_ADDRESS:}
 
 mongock:
   migration-scan-package: uk.nhs.hee.trainee.details.migration

--- a/src/test/java/uk/nhs/hee/trainee/details/config/AwsXrayConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/AwsXrayConfigurationTest.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.amazonaws.xray.javax.servlet.AWSXRayServletFilter;
+import javax.servlet.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AwsXrayConfigurationTest {
+
+  private AwsXrayConfiguration configuration;
+
+  @BeforeEach
+  void setUp() {
+    configuration = new AwsXrayConfiguration();
+  }
+
+  @Test
+  void shouldCreateInstanceOfAwsXrayServletFilter() {
+    Filter filter = configuration.tracingFilter("testEnvironment");
+
+    assertThat("Unexpected filter type.", filter, instanceOf(AWSXRayServletFilter.class));
+  }
+}


### PR DESCRIPTION
Configure the app to enable AWS XRay tracing for the rest controller and service beans.
The filter name includes the environment (preprod/prod) to allow differentiation in the traces.

TIS21-4224
TIS21-4227