### PR TITLE
fix: use Rabbit for CoJ signing event queue

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -33,12 +33,40 @@
           "valueFrom": "/tis/trainee/${environment}/queue-url/profile-created"
         },
         {
-          "name": "COJ_SIGNED_QUEUE_URL",
+          "name": "COJ_SIGNED_RABBIT_QUEUE_URL",
           "valueFrom": "/tis/trainee/${environment}/queue-url/coj-signed"
+        },
+        {
+          "name": "COJ_SIGNED_RABBIT_EXCHANGE",
+          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/exchange"
+        },
+        {
+          "name": "COJ_SIGNED_RABBIT_ROUTING_KEY",
+          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/routing-key"
         },
         {
           "name": "SIGNATURE_SECRET_KEY",
           "valueFrom": "/tis/trainee/${environment}/signature/secret-key"
+        },
+        {
+          "name": "TRAINEE_DETAILS_RABBITMQ_HOST",
+          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/host"
+        },
+        {
+          "name": "TRAINEE_DETAILS_RABBITMQ_PORT",
+          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/port"
+        },
+        {
+          "name": "TRAINEE_DETAILS_RABBITMQ_USERNAME",
+          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/user"
+        },
+        {
+          "name": "TRAINEE_DETAILS_RABBITMQ_PASSWORD",
+          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/password"
+        },
+        {
+          "name": "TRAINEE_DETAILS_RABBITMQ_USE_SSL",
+          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/use-ssl"
         }
       ],
       "logConfiguration": {

--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -33,10 +33,6 @@
           "valueFrom": "/tis/trainee/${environment}/queue-url/profile-created"
         },
         {
-          "name": "COJ_SIGNED_RABBIT_QUEUE_URL",
-          "valueFrom": "/tis/trainee/${environment}/queue-url/coj-signed"
-        },
-        {
           "name": "COJ_SIGNED_RABBIT_EXCHANGE",
           "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/exchange"
         },

--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -34,7 +34,7 @@
         },
         {
           "name": "COJ_SIGNED_RABBIT_EXCHANGE",
-          "valueFrom": "/tis/trainee/coj/${environment}/rabbit/exchange"
+          "valueFrom": "/tis/trainee/${environment}/rabbit/exchange"
         },
         {
           "name": "COJ_SIGNED_RABBIT_ROUTING_KEY",

--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -62,7 +62,7 @@
         },
         {
           "name": "TRAINEE_DETAILS_RABBITMQ_USE_SSL",
-          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/use-ssl"
+          "valueFrom": "/tis/trainee/${environment}/rabbit/use-ssl"
         }
       ],
       "logConfiguration": {

--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -34,11 +34,11 @@
         },
         {
           "name": "COJ_SIGNED_RABBIT_EXCHANGE",
-          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/exchange"
+          "valueFrom": "/tis/trainee/coj/${environment}/rabbit/exchange"
         },
         {
           "name": "COJ_SIGNED_RABBIT_ROUTING_KEY",
-          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/routing-key"
+          "valueFrom": "/tis/trainee/coj/${environment}/rabbit/routing-key"
         },
         {
           "name": "SIGNATURE_SECRET_KEY",
@@ -46,19 +46,19 @@
         },
         {
           "name": "TRAINEE_DETAILS_RABBITMQ_HOST",
-          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/host"
+          "valueFrom": "/tis/rabbitmq/${environment}/host"
         },
         {
           "name": "TRAINEE_DETAILS_RABBITMQ_PORT",
-          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/port"
+          "valueFrom": "/tis/rabbitmq/${environment}/port"
         },
         {
           "name": "TRAINEE_DETAILS_RABBITMQ_USERNAME",
-          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/user"
+          "valueFrom": "/tis/trainee/${environment}/rabbit/user"
         },
         {
           "name": "TRAINEE_DETAILS_RABBITMQ_PASSWORD",
-          "valueFrom": "/tis/trainee/${environment}/rabbitmq/rabbit/password"
+          "valueFrom": "/tis/trainee/${environment}/rabbit/password"
         },
         {
           "name": "TRAINEE_DETAILS_RABBITMQ_USE_SSL",

--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,7 @@ dependencies {
   implementation "com.amazonaws:aws-xray-recorder-sdk-spring:2.13.0"
 
   // Rabbit MQ
-  implementation "org.springframework.integration:spring-integration-amqp:6.0.5"
-
+  implementation "org.springframework.boot:spring-boot-starter-amqp"
 }
 
 checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.19.0"
+version = "0.20.0"
 
 configurations {
   compileOnly {
@@ -56,6 +56,9 @@ dependencies {
   // Amazon AWS
   implementation "io.awspring.cloud:spring-cloud-starter-aws-messaging"
   implementation "com.amazonaws:aws-xray-recorder-sdk-spring:2.13.0"
+
+  // Rabbit MQ
+  implementation "org.springframework.integration:spring-integration-amqp:6.0.5"
 
 }
 

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
@@ -43,8 +43,8 @@ import uk.nhs.hee.trainee.details.api.util.AuthTokenUtil;
 import uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto;
 import uk.nhs.hee.trainee.details.mapper.ProgrammeMembershipMapper;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
-import uk.nhs.hee.trainee.details.service.EventPublishService;
 import uk.nhs.hee.trainee.details.service.ProgrammeMembershipService;
+import uk.nhs.hee.trainee.details.service.RabbitPublishService;
 
 @Slf4j
 @RestController
@@ -54,16 +54,16 @@ public class ProgrammeMembershipResource {
 
   private final ProgrammeMembershipService service;
   private final ProgrammeMembershipMapper mapper;
-  private final EventPublishService eventPublishService;
+  private final RabbitPublishService rabbitPublishService;
 
   /**
    * ProgrammeMembershipResource class constructor.
    */
   public ProgrammeMembershipResource(ProgrammeMembershipService service,
-      ProgrammeMembershipMapper mapper, EventPublishService eventPublishService) {
+      ProgrammeMembershipMapper mapper, RabbitPublishService rabbitPublishService) {
     this.service = service;
     this.mapper = mapper;
-    this.eventPublishService = eventPublishService;
+    this.rabbitPublishService = rabbitPublishService;
   }
 
   /**
@@ -136,7 +136,7 @@ public class ProgrammeMembershipResource {
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
             "Trainee with Programme Membership " + programmeMembershipId + " not found."));
 
-    eventPublishService.publishCojSignedEvent(entity);
+    rabbitPublishService.publishCojSignedEvent(entity);
 
     return ResponseEntity.ok(mapper.toDto(entity));
   }

--- a/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
@@ -44,9 +44,9 @@ public class RabbitConfig {
   private final String cojExchange;
   private final String cojRoutingKey;
 
-  RabbitConfig(@Value("${application.rabbit.coj-signed}") String cojQueueName,
-               @Value("${application.rabbit.coj-signed-exchange}") String cojExchange,
-               @Value("${application.rabbit.coj-signed-routing-key}") String cojRoutingKey) {
+  RabbitConfig(@Value("${application.rabbit.coj-signed.queue}") String cojQueueName,
+               @Value("${application.rabbit.coj-signed.exchange}") String cojExchange,
+               @Value("${application.rabbit.coj-signed.routing-key}") String cojRoutingKey) {
     this.cojQueueName = cojQueueName;
     this.cojExchange = cojExchange;
     this.cojRoutingKey = cojRoutingKey;
@@ -54,7 +54,7 @@ public class RabbitConfig {
 
   @Bean
   public Queue cojSignedQueue() {
-    return new Queue(cojQueueName, false);
+    return new Queue(cojQueueName, true);
   }
 
   @Bean

--- a/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
@@ -23,15 +23,10 @@ package uk.nhs.hee.trainee.details.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.amqp.core.AcknowledgeMode;
-import org.springframework.amqp.core.Binding;
-import org.springframework.amqp.core.BindingBuilder;
-import org.springframework.amqp.core.DirectExchange;
-import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.amqp.support.converter.MessageConverter;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -39,33 +34,6 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty("spring.rabbitmq.host")
 @Configuration
 public class RabbitConfig {
-
-  private final String cojQueueName;
-  private final String cojExchange;
-  private final String cojRoutingKey;
-
-  RabbitConfig(@Value("${application.rabbit.coj-signed.queue}") String cojQueueName,
-               @Value("${application.rabbit.coj-signed.exchange}") String cojExchange,
-               @Value("${application.rabbit.coj-signed.routing-key}") String cojRoutingKey) {
-    this.cojQueueName = cojQueueName;
-    this.cojExchange = cojExchange;
-    this.cojRoutingKey = cojRoutingKey;
-  }
-
-  @Bean
-  public Queue cojSignedQueue() {
-    return new Queue(cojQueueName, true);
-  }
-
-  @Bean
-  public DirectExchange exchange() {
-    return new DirectExchange(cojExchange);
-  }
-
-  @Bean
-  public Binding cojBinding(final Queue cojSignedQueue, final DirectExchange exchange) {
-    return BindingBuilder.bind(cojSignedQueue).to(exchange).with(cojRoutingKey);
-  }
 
   @Bean
   public MessageConverter jsonMessageConverter() {

--- a/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
@@ -40,14 +40,17 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class RabbitConfig {
 
-  @Value("${application.rabbit.coj-signed}")
-  private String cojQueueName;
+  private final String cojQueueName;
+  private final String cojExchange;
+  private final String cojRoutingKey;
 
-  @Value("${application.rabbit.coj-signed-exchange}")
-  private String cojExchange;
-
-  @Value("${application.rabbit.coj-signed-routing-key}")
-  private String cojRoutingKey;
+  RabbitConfig(@Value("${application.rabbit.coj-signed}") String cojQueueName,
+               @Value("${application.rabbit.coj-signed-exchange}") String cojExchange,
+               @Value("${application.rabbit.coj-signed-routing-key}") String cojRoutingKey) {
+    this.cojQueueName = cojQueueName;
+    this.cojExchange = cojExchange;
+    this.cojRoutingKey = cojRoutingKey;
+  }
 
   @Bean
   public Queue cojSignedQueue() {

--- a/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.amqp.core.AcknowledgeMode;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@ConditionalOnProperty("spring.rabbitmq.host")
+@Configuration
+public class RabbitConfig {
+
+  @Value("${application.rabbit.coj-signed}")
+  private String cojQueueName;
+
+  @Value("${application.rabbit.coj-signed-exchange}")
+  private String cojExchange;
+
+  @Value("${application.rabbit.coj-signed-routing-key}")
+  private String cojRoutingKey;
+
+  @Bean
+  public Queue cojSignedQueue() {
+    return new Queue(cojQueueName, false);
+  }
+
+  @Bean
+  public DirectExchange exchange() {
+    return new DirectExchange(cojExchange);
+  }
+
+  @Bean
+  public Binding cojBinding(final Queue cojSignedQueue, final DirectExchange exchange) {
+    return BindingBuilder.bind(cojSignedQueue).to(exchange).with(cojRoutingKey);
+  }
+
+  @Bean
+  public MessageConverter jsonMessageConverter() {
+    final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+    return new Jackson2JsonMessageConverter(mapper);
+  }
+
+  /**
+   * Rabbit template for sending message to RabbitMQ.
+   */
+  @Bean
+  public RabbitTemplate rabbitTemplate(final ConnectionFactory connectionFactory) {
+    final RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+    rabbitTemplate.setMessageConverter(jsonMessageConverter());
+    rabbitTemplate.containerAckMode(AcknowledgeMode.AUTO);
+    return rabbitTemplate;
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/service/RabbitPublishService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/RabbitPublishService.java
@@ -22,19 +22,13 @@
 package uk.nhs.hee.trainee.details.service;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
-import com.rabbitmq.client.AMQP;
-import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.amqp.core.Exchange;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.trainee.details.event.CojSignedEvent;
-import uk.nhs.hee.trainee.details.event.ProfileCreateEvent;
 import uk.nhs.hee.trainee.details.model.ConditionsOfJoining;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
-import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
 /**
  * A service to publish events to Rabbit MQ.
@@ -48,8 +42,8 @@ public class RabbitPublishService {
   private final String routingKey;
   private final RabbitTemplate rabbitTemplate;
 
-  RabbitPublishService(@Value("${application.rabbit.coj-signed-exchange}") String rabbitExchange,
-                       @Value("${application.rabbit.coj-signed-routing-key}") String routingKey,
+  RabbitPublishService(@Value("${application.rabbit.coj-signed.exchange}") String rabbitExchange,
+                       @Value("${application.rabbit.coj-signed.routing-key}") String routingKey,
                        RabbitTemplate rabbitTemplate) {
     this.rabbitExchange = rabbitExchange;
     this.routingKey = routingKey;

--- a/src/main/java/uk/nhs/hee/trainee/details/service/RabbitPublishService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/RabbitPublishService.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2022 Crown Copyright (Health Education England)
+ * Copyright 2023 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -22,39 +22,52 @@
 package uk.nhs.hee.trainee.details.service;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
+import com.rabbitmq.client.AMQP;
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.Exchange;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import uk.nhs.hee.trainee.details.event.CojSignedEvent;
 import uk.nhs.hee.trainee.details.event.ProfileCreateEvent;
+import uk.nhs.hee.trainee.details.model.ConditionsOfJoining;
+import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
 /**
- * A service to publish events to SQS.
+ * A service to publish events to Rabbit MQ.
  */
 @Slf4j
 @Service
 @XRayEnabled
-public class EventPublishService {
+public class RabbitPublishService {
 
-  private final QueueMessagingTemplate messagingTemplate;
-  private final String eventQueueUrl;
+  private final String rabbitExchange;
+  private final String routingKey;
+  private final RabbitTemplate rabbitTemplate;
 
-  EventPublishService(QueueMessagingTemplate messagingTemplate,
-      @Value("${application.aws.sqs.event}") String eventQueueUrl) {
-    this.messagingTemplate = messagingTemplate;
-    this.eventQueueUrl = eventQueueUrl;
+  RabbitPublishService(@Value("${application.rabbit.coj-signed-exchange}") String rabbitExchange,
+                       @Value("${application.rabbit.coj-signed-routing-key}") String routingKey,
+                       RabbitTemplate rabbitTemplate) {
+    this.rabbitExchange = rabbitExchange;
+    this.routingKey = routingKey;
+    this.rabbitTemplate = rabbitTemplate;
   }
 
   /**
-   * Publish a Profile Create event.
+   * Publish a CoJ signed event.
    *
-   * @param profile The created {@link TraineeProfile}.
+   * @param programmeMembership The signed {@link ProgrammeMembership}.
    */
-  public void publishProfileCreateEvent(TraineeProfile profile) {
-    log.info("Sending profile creation event for trainee id '{}'", profile.getTraineeTisId());
+  public void publishCojSignedEvent(ProgrammeMembership programmeMembership) {
+    log.info("Sending CoJ signed event for programme membership id '{}'",
+        programmeMembership.getTisId());
 
-    ProfileCreateEvent event = new ProfileCreateEvent(profile.getTraineeTisId());
-    messagingTemplate.convertAndSend(eventQueueUrl, event);
+    ConditionsOfJoining conditionsOfJoining = programmeMembership.getConditionsOfJoining();
+
+    CojSignedEvent event = new CojSignedEvent(programmeMembership.getTisId(), conditionsOfJoining);
+    rabbitTemplate.convertAndSend(rabbitExchange, routingKey, event);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,6 @@ application:
   environment: ${ENVIRONMENT:local}
   rabbit:
     coj-signed:
-      queue: ${COJ_SIGNED_RABBIT_QUEUE_URL:}
       exchange: ${COJ_SIGNED_RABBIT_EXCHANGE:}
       routing-key: ${COJ_SIGNED_RABBIT_ROUTING_KEY:}
   signature:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,12 @@ spring:
   data:
     mongodb:
       uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:trainee}?authSource=admin
+  rabbitmq:
+    host: ${TRAINEE_DETAILS_RABBITMQ_HOST}
+    port: ${TRAINEE_DETAILS_RABBITMQ_PORT}
+    username: ${TRAINEE_DETAILS_RABBITMQ_USERNAME}
+    password: ${TRAINEE_DETAILS_RABBITMQ_PASSWORD}
+    ssl.enabled: ${TRAINEE_DETAILS_RABBITMQ_USE_SSL}
 
 logging:
   level:
@@ -20,8 +26,11 @@ application:
   aws:
     sqs:
       event: ${EVENT_QUEUE_URL:}
-      coj-signed: ${COJ_SIGNED_QUEUE_URL:}
   environment: ${ENVIRONMENT:local}
+  rabbit:
+    coj-signed-queue: ${COJ_SIGNED_RABBIT_QUEUE_URL:}
+    coj-signed-exchange: ${COJ_SIGNED_RABBIT_EXCHANGE:}
+    coj-signed-routing-key: ${COJ_SIGNED_RABBIT_ROUTING_KEY:}
   signature:
     secret-key: ${SIGNATURE_SECRET_KEY}
     expire-after:  # Minutes

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,9 +28,10 @@ application:
       event: ${EVENT_QUEUE_URL:}
   environment: ${ENVIRONMENT:local}
   rabbit:
-    coj-signed-queue: ${COJ_SIGNED_RABBIT_QUEUE_URL:}
-    coj-signed-exchange: ${COJ_SIGNED_RABBIT_EXCHANGE:}
-    coj-signed-routing-key: ${COJ_SIGNED_RABBIT_ROUTING_KEY:}
+    coj-signed:
+      queue: ${COJ_SIGNED_RABBIT_QUEUE_URL:}
+      exchange: ${COJ_SIGNED_RABBIT_EXCHANGE:}
+      routing-key: ${COJ_SIGNED_RABBIT_ROUTING_KEY:}
   signature:
     secret-key: ${SIGNATURE_SECRET_KEY}
     expire-after:  # Minutes

--- a/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
@@ -63,8 +63,8 @@ import uk.nhs.hee.trainee.details.mapper.ProgrammeMembershipMapperImpl;
 import uk.nhs.hee.trainee.details.mapper.SignatureMapperImpl;
 import uk.nhs.hee.trainee.details.model.ConditionsOfJoining;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
-import uk.nhs.hee.trainee.details.service.EventPublishService;
 import uk.nhs.hee.trainee.details.service.ProgrammeMembershipService;
+import uk.nhs.hee.trainee.details.service.RabbitPublishService;
 import uk.nhs.hee.trainee.details.service.SignatureService;
 
 @ContextConfiguration(classes = {ProgrammeMembershipMapperImpl.class, SignatureMapperImpl.class})
@@ -89,7 +89,7 @@ class ProgrammeMembershipResourceTest {
   private ProgrammeMembershipService service;
 
   @MockBean
-  private EventPublishService eventPublishService;
+  private RabbitPublishService rabbitPublishService;
 
   @MockBean
   private SignatureService signatureService;
@@ -97,7 +97,7 @@ class ProgrammeMembershipResourceTest {
   @BeforeEach
   void setUp() {
     ProgrammeMembershipResource resource = new ProgrammeMembershipResource(service,
-        programmeMembershipMapper, eventPublishService);
+        programmeMembershipMapper, rabbitPublishService);
     mockMvc = MockMvcBuilders.standaloneSetup(resource)
         .setMessageConverters(jacksonMessageConverter)
         .build();

--- a/src/test/java/uk/nhs/hee/trainee/details/config/RabbitConfigTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/RabbitConfigTest.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Test class for the Rabbit configuration.
+ * TODO: check that these are actually meaningful tests
+ */
+class RabbitConfigTest {
+
+  private static final String RABBIT_QUEUE_NAME = "coj.queue";
+  private static final String RABBIT_EXCHANGE = "exchange";
+  private static final String RABBIT_ROUTING_KEY = "routing.key";
+
+  @Autowired
+  private ConnectionFactory connectionFactory;
+
+  private RabbitConfig rabbitConfig;
+
+  @BeforeEach
+  void setUp() {
+    rabbitConfig = new RabbitConfig(RABBIT_QUEUE_NAME, RABBIT_EXCHANGE, RABBIT_ROUTING_KEY);
+  }
+
+  @Test
+  void shouldBuildQueue() {
+    Queue cojQueue = rabbitConfig.cojSignedQueue();
+    assertThat("Unexpected CoJ queue name", cojQueue.getName(), is(RABBIT_QUEUE_NAME));
+    assertThat("Unexpected CoJ queue durability", cojQueue.isDurable(), is(false));
+  }
+
+  @Test
+  void shouldBuildExchange() {
+    DirectExchange exchange = rabbitConfig.exchange();
+    assertThat("Unexpected exchange name", exchange.getName(), is(RABBIT_EXCHANGE));
+  }
+
+  @Test
+  void shouldBuildBinding() {
+    Binding binding
+        = rabbitConfig.cojBinding(rabbitConfig.cojSignedQueue(), rabbitConfig.exchange());
+    assertThat("Unexpected binding exchange",
+        binding.getExchange(), is(RABBIT_EXCHANGE));
+    assertThat("Unexpected binding destination",
+        binding.getDestination(), is(RABBIT_QUEUE_NAME));
+    assertThat("Unexpected binding routing key",
+        binding.getRoutingKey(), is(RABBIT_ROUTING_KEY));
+  }
+
+  @Test
+  void shouldBuildMessageConverter() {
+    MessageConverter messageConverter = rabbitConfig.jsonMessageConverter();
+    String converterName = messageConverter.getClass().getName();
+    assertThat("Unexpected message converter type", converterName,
+        is(Jackson2JsonMessageConverter.class.getName()));
+  }
+
+  @Test
+  void shouldBuildRabbitTemplate() {
+    RabbitTemplate rabbitTemplate = rabbitConfig.rabbitTemplate(connectionFactory);
+    String converterName = rabbitTemplate.getMessageConverter().getClass().getName();
+    assertThat("Unexpected rabbit template converter", converterName,
+        is(Jackson2JsonMessageConverter.class.getName()));
+    assertThat("Unexpected rabbit template channel transaction mode",
+        rabbitTemplate.isChannelTransacted(), is(false));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/config/RabbitConfigTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/RabbitConfigTest.java
@@ -26,9 +26,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.amqp.core.Binding;
-import org.springframework.amqp.core.DirectExchange;
-import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
@@ -37,13 +34,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 /**
  * Test class for the Rabbit configuration.
- * TODO: check that these are actually meaningful tests
  */
 class RabbitConfigTest {
-
-  private static final String RABBIT_QUEUE_NAME = "coj.queue";
-  private static final String RABBIT_EXCHANGE = "exchange";
-  private static final String RABBIT_ROUTING_KEY = "routing.key";
 
   @Autowired
   private ConnectionFactory connectionFactory;
@@ -52,32 +44,7 @@ class RabbitConfigTest {
 
   @BeforeEach
   void setUp() {
-    rabbitConfig = new RabbitConfig(RABBIT_QUEUE_NAME, RABBIT_EXCHANGE, RABBIT_ROUTING_KEY);
-  }
-
-  @Test
-  void shouldBuildQueue() {
-    Queue cojQueue = rabbitConfig.cojSignedQueue();
-    assertThat("Unexpected CoJ queue name", cojQueue.getName(), is(RABBIT_QUEUE_NAME));
-    assertThat("Unexpected CoJ queue durability", cojQueue.isDurable(), is(true));
-  }
-
-  @Test
-  void shouldBuildExchange() {
-    DirectExchange exchange = rabbitConfig.exchange();
-    assertThat("Unexpected exchange name", exchange.getName(), is(RABBIT_EXCHANGE));
-  }
-
-  @Test
-  void shouldBuildBinding() {
-    Binding binding
-        = rabbitConfig.cojBinding(rabbitConfig.cojSignedQueue(), rabbitConfig.exchange());
-    assertThat("Unexpected binding exchange",
-        binding.getExchange(), is(RABBIT_EXCHANGE));
-    assertThat("Unexpected binding destination",
-        binding.getDestination(), is(RABBIT_QUEUE_NAME));
-    assertThat("Unexpected binding routing key",
-        binding.getRoutingKey(), is(RABBIT_ROUTING_KEY));
+    rabbitConfig = new RabbitConfig();
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/trainee/details/config/RabbitConfigTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/RabbitConfigTest.java
@@ -59,7 +59,7 @@ class RabbitConfigTest {
   void shouldBuildQueue() {
     Queue cojQueue = rabbitConfig.cojSignedQueue();
     assertThat("Unexpected CoJ queue name", cojQueue.getName(), is(RABBIT_QUEUE_NAME));
-    assertThat("Unexpected CoJ queue durability", cojQueue.isDurable(), is(false));
+    assertThat("Unexpected CoJ queue durability", cojQueue.isDurable(), is(true));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/trainee/details/service/EventPublishServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/EventPublishServiceTest.java
@@ -28,15 +28,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
-import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import uk.nhs.hee.trainee.details.dto.enumeration.GoldGuideVersion;
-import uk.nhs.hee.trainee.details.event.CojSignedEvent;
 import uk.nhs.hee.trainee.details.event.ProfileCreateEvent;
-import uk.nhs.hee.trainee.details.model.ConditionsOfJoining;
-import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
 class EventPublishServiceTest {

--- a/src/test/java/uk/nhs/hee/trainee/details/service/EventPublishServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/EventPublishServiceTest.java
@@ -42,14 +42,13 @@ import uk.nhs.hee.trainee.details.model.TraineeProfile;
 class EventPublishServiceTest {
 
   private static final String QUEUE_URL = "queue.url";
-  private static final String COJ_QUEUE_URL = "coj.queue.url";
   private EventPublishService eventPublishService;
   private QueueMessagingTemplate messagingTemplate;
 
   @BeforeEach
   void setUp() {
     messagingTemplate = mock(QueueMessagingTemplate.class);
-    eventPublishService = new EventPublishService(messagingTemplate, QUEUE_URL, COJ_QUEUE_URL);
+    eventPublishService = new EventPublishService(messagingTemplate, QUEUE_URL);
   }
 
   @Test
@@ -65,30 +64,5 @@ class EventPublishServiceTest {
 
     ProfileCreateEvent event = eventCaptor.getValue();
     assertThat("Unexpected trainee ID.", event.getTraineeTisId(), is("10"));
-  }
-
-  @Test
-  void shouldPublishCojSignedEvent() {
-    ProgrammeMembership programmeMembership = new ProgrammeMembership();
-    programmeMembership.setTisId("123");
-    Instant signedAt = Instant.now();
-    ConditionsOfJoining conditionsOfJoining
-        = new ConditionsOfJoining(signedAt, GoldGuideVersion.GG9);
-    programmeMembership.setConditionsOfJoining(conditionsOfJoining);
-
-    eventPublishService.publishCojSignedEvent(programmeMembership);
-
-    ArgumentCaptor<CojSignedEvent> eventCaptor = ArgumentCaptor.forClass(
-        CojSignedEvent.class);
-    verify(messagingTemplate).convertAndSend(eq(COJ_QUEUE_URL), eventCaptor.capture());
-
-    CojSignedEvent event = eventCaptor.getValue();
-    assertThat("Unexpected programme membership ID.",
-        event.getProgrammeMembershipTisId(), is("123"));
-    ConditionsOfJoining conditionsOfJoiningSent = event.getConditionsOfJoining();
-    assertThat("Unexpected CoJ Signed At",
-        conditionsOfJoiningSent.signedAt(), is(signedAt));
-    assertThat("Unexpected CoJ Version",
-        conditionsOfJoiningSent.version(), is(GoldGuideVersion.GG9));
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/RabbitPublishServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/RabbitPublishServiceTest.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import uk.nhs.hee.trainee.details.dto.enumeration.GoldGuideVersion;
+import uk.nhs.hee.trainee.details.event.CojSignedEvent;
+import uk.nhs.hee.trainee.details.model.ConditionsOfJoining;
+import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
+
+@ExtendWith(MockitoExtension.class)
+class RabbitPublishServiceTest {
+
+  private static final String RABBIT_EXCHANGE = "rabbit.exchange";
+  private static final String RABBIT_ROUTING_KEY = "routing.key";
+
+  @InjectMocks
+  RabbitPublishService rabbitPublishService;
+
+  @Mock
+  RabbitTemplate rabbitTemplate;
+
+  @BeforeEach
+  void setUp() {
+    rabbitPublishService = new RabbitPublishService(RABBIT_EXCHANGE, RABBIT_ROUTING_KEY, rabbitTemplate);
+  }
+
+  @Test
+  void shouldPublishCojSignedEvent() {
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId("123");
+    Instant signedAt = Instant.now();
+    ConditionsOfJoining conditionsOfJoining
+        = new ConditionsOfJoining(signedAt, GoldGuideVersion.GG9);
+    programmeMembership.setConditionsOfJoining(conditionsOfJoining);
+
+    rabbitPublishService.publishCojSignedEvent(programmeMembership);
+
+    ArgumentCaptor<CojSignedEvent> eventCaptor = ArgumentCaptor.forClass(
+        CojSignedEvent.class);
+
+    verify(rabbitTemplate).convertAndSend(any(), any(), eventCaptor.capture());
+
+    CojSignedEvent event = eventCaptor.getValue();
+    assertThat("Unexpected programme membership ID.",
+        event.getProgrammeMembershipTisId(), is("123"));
+    ConditionsOfJoining conditionsOfJoiningSent = event.getConditionsOfJoining();
+    assertThat("Unexpected CoJ Signed At",
+        conditionsOfJoiningSent.signedAt(), is(signedAt));
+    assertThat("Unexpected CoJ Version",
+        conditionsOfJoiningSent.version(), is(GoldGuideVersion.GG9));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/service/RabbitPublishServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/RabbitPublishServiceTest.java
@@ -54,7 +54,8 @@ class RabbitPublishServiceTest {
 
   @BeforeEach
   void setUp() {
-    rabbitPublishService = new RabbitPublishService(RABBIT_EXCHANGE, RABBIT_ROUTING_KEY, rabbitTemplate);
+    rabbitPublishService
+        = new RabbitPublishService(RABBIT_EXCHANGE, RABBIT_ROUTING_KEY, rabbitTemplate);
   }
 
   @Test


### PR DESCRIPTION
Note: this has been put together without a lot of RabbitMQ experience. The tests may be inadequate, and the implementation in general may offer scope for improvements.

Don't merge until TIS21-4456 done.

TIS21-4455: Event handler to push CoJ data to Rabbit exchange/queue