### PR TITLE
feat: retain COJ status when patching PMs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.19.0"
+version = "0.20.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/ProgrammeMembershipMapper.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.trainee.details.mapper;
 
+import static org.mapstruct.NullValuePropertyMappingStrategy.IGNORE;
+
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
@@ -35,6 +37,7 @@ public interface ProgrammeMembershipMapper {
 
   ProgrammeMembership toEntity(ProgrammeMembershipDto dto);
 
+  @Mapping(target = "conditionsOfJoining", nullValuePropertyMappingStrategy = IGNORE)
   void updateProgrammeMembership(@MappingTarget ProgrammeMembership target,
       ProgrammeMembership source);
 }


### PR DESCRIPTION
When patching a ProgrammeMembership the Conditions of Joining should not be overwritten unless the new value is not null. This avoids any "unsigning" of the CoJ when syncing data changes from TIS. This fix is required until CoJ data is available in TIS and synced via `tis-trainee-sync`.

TIS21-4460
TIS21-4375