### PR TITLE
fix: only send the first PM ID for a CoJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.21.1"
+version = "0.21.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/RabbitPublishService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/RabbitPublishService.java
@@ -61,7 +61,11 @@ public class RabbitPublishService {
 
     ConditionsOfJoining conditionsOfJoining = programmeMembership.getConditionsOfJoining();
 
-    CojSignedEvent event = new CojSignedEvent(programmeMembership.getTisId(), conditionsOfJoining);
+    // FIXME: simplify multiple curriculum membership IDs - they should all resolve to the same
+    // parent programme membership ID in TIS.
+    String firstPmId = programmeMembership.getTisId().split(",")[0];
+
+    CojSignedEvent event = new CojSignedEvent(firstPmId, conditionsOfJoining);
     rabbitTemplate.convertAndSend(rabbitExchange, routingKey, event);
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/RabbitPublishServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/RabbitPublishServiceTest.java
@@ -83,4 +83,25 @@ class RabbitPublishServiceTest {
     assertThat("Unexpected CoJ Version",
         conditionsOfJoiningSent.version(), is(GoldGuideVersion.GG9));
   }
+
+  @Test
+  void shouldPublishCojSignedEventWithSimplifiedId() {
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId("123,456,7890");
+    Instant signedAt = Instant.now();
+    ConditionsOfJoining conditionsOfJoining
+        = new ConditionsOfJoining(signedAt, GoldGuideVersion.GG9);
+    programmeMembership.setConditionsOfJoining(conditionsOfJoining);
+
+    rabbitPublishService.publishCojSignedEvent(programmeMembership);
+
+    ArgumentCaptor<CojSignedEvent> eventCaptor = ArgumentCaptor.forClass(
+        CojSignedEvent.class);
+
+    verify(rabbitTemplate).convertAndSend(any(), any(), eventCaptor.capture());
+
+    CojSignedEvent event = eventCaptor.getValue();
+    assertThat("Unexpected programme membership ID.",
+        event.getProgrammeMembershipTisId(), is("123"));
+  }
 }


### PR DESCRIPTION
Where the PM has multiple curricula. They will all resolve to the same PM within TIS-TCS

NO-TICKET