### PR TITLE
fix: handle coj cache for multi-curriculum PMs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.21.2"
+version = "0.21.3"
 
 configurations {
   compileOnly {


### PR DESCRIPTION
When a PM has multiple curriculums the PM ID comes through as a concatenated list of CurriculumMembership IDs.
When deleting a PM and restoring the existing COJ from cache the concatenated IDs should be properly handled.

TIS21-4460
TIS21-4375