### PR TITLE
feat: create endpoint for delete of single PM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.22.0"
+version = "0.23.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
@@ -110,8 +110,34 @@ public class ProgrammeMembershipResource {
   }
 
   /**
-   * Sign Condition of Joining with the given programme membership,
-   * setting version to the latest Gold Guide version, and signedAt to current time.
+   * Delete a programme membership of the trainee.
+   *
+   * @param traineeTisId          The ID of the trainee to update.
+   * @param programmeMembershipId The ID of the programme membership to delete.
+   * @return True if the programme membership was deleted.
+   */
+  @DeleteMapping("/{traineeTisId}/{programmeMembershipId}")
+  public ResponseEntity<Boolean> deleteProgrammeMembership(
+      @PathVariable(name = "traineeTisId") String traineeTisId,
+      @PathVariable(name = "programmeMembershipId") String programmeMembershipId) {
+    log.info("Delete programme membership {} of trainee with TIS ID {}", programmeMembershipId,
+        traineeTisId);
+    try {
+      boolean found = service.deleteProgrammeMembershipForTrainee(traineeTisId,
+          programmeMembershipId);
+      if (!found) {
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "ProgrammeMembership not found.");
+      }
+    } catch (IllegalArgumentException | InvalidDataAccessApiUsageException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getLocalizedMessage());
+      // other exceptions are possible, e.g. DataAccessException if MongoDB is down
+    }
+    return ResponseEntity.ok(true);
+  }
+
+  /**
+   * Sign Condition of Joining with the given programme membership, setting version to the latest
+   * Gold Guide version, and signedAt to current time.
    *
    * @param programmeMembershipId The ID of the programme membership for signing COJ.
    * @return The updated Programme Membership.

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -130,6 +130,34 @@ public class ProgrammeMembershipService {
   }
 
   /**
+   * Delete the matching programme membership for the trainee with the given TIS ID.
+   *
+   * @param traineeTisId          The TIS id of the trainee.
+   * @param programmeMembershipId The ID of the programme membership to delete.
+   * @return True, or False if a trainee with the ID was not found.
+   */
+  public boolean deleteProgrammeMembershipForTrainee(String traineeTisId,
+      String programmeMembershipId) {
+    TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
+
+    if (traineeProfile == null) {
+      return false;
+    }
+
+    for (var iter = traineeProfile.getProgrammeMemberships().iterator(); iter.hasNext(); ) {
+      ProgrammeMembership programmeMembership = iter.next();
+
+      if (programmeMembership.getTisId().equals(programmeMembershipId)) {
+        iter.remove();
+        repository.save(traineeProfile);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
    * Sign Condition of Joining with the given programme membership ID.
    *
    * @param programmeMembershipId The ID of the programme membership for signing COJ.

--- a/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
@@ -181,13 +181,50 @@ class ProgrammeMembershipResourceTest {
 
   @Test
   void shouldDeleteProgrammeMembershipWhenTraineeFound() throws Exception {
+    when(service
+        .deleteProgrammeMembershipForTrainee("40", "140"))
+        .thenReturn(true);
 
+    MvcResult result = mockMvc.perform(
+            delete("/api/programme-membership/{traineeTisId}/{programmeMembershipId}", 40, 140)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    Boolean resultBoolean = Boolean.parseBoolean(result.getResponse().getContentAsString());
+    assertThat("Unexpected result.", resultBoolean, is(true));
+  }
+
+  @Test
+  void shouldNotDeleteProgrammeMembershipWhenTraineeNotFound() throws Exception {
+    when(service
+        .deleteProgrammeMembershipForTrainee("40", "140"))
+        .thenReturn(false);
+
+    mockMvc.perform(
+            delete("/api/programme-membership/{traineeTisId}/{programmeMembershipId}", 40, 140)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void shouldThrowBadRequestWhenDeleteProgrammeMembershipException() throws Exception {
+    when(service
+        .deleteProgrammeMembershipForTrainee("triggersError", "triggersError"))
+        .thenThrow(new IllegalArgumentException());
+
+    mockMvc.perform(
+            delete("/api/programme-membership/{traineeTisId}/{programmeMembershipId}",
+                "triggersError", "triggersError")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void shouldDeleteProgrammeMembershipsWhenTraineeFound() throws Exception {
     when(service
         .deleteProgrammeMembershipsForTrainee("40"))
         .thenReturn(true);
-
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto();
-    dto.setTisId("tisIdValue");
 
     MvcResult result = mockMvc.perform(
             delete("/api/programme-membership/{traineeTisId}", 40)
@@ -200,13 +237,10 @@ class ProgrammeMembershipResourceTest {
   }
 
   @Test
-  void shouldNotDeleteProgrammeMembershipWhenTraineeNotFound() throws Exception {
+  void shouldNotDeleteProgrammeMembershipsWhenTraineeNotFound() throws Exception {
     when(service
         .deleteProgrammeMembershipsForTrainee("40"))
         .thenReturn(false);
-
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto();
-    dto.setTisId("tisIdValue");
 
     mockMvc.perform(
             delete("/api/programme-membership/{traineeTisId}", 40)
@@ -215,13 +249,10 @@ class ProgrammeMembershipResourceTest {
   }
 
   @Test
-  void shouldThrowBadRequestWhenDeleteProgrammeMembershipException() throws Exception {
+  void shouldThrowBadRequestWhenDeleteProgrammeMembershipsException() throws Exception {
     when(service
         .deleteProgrammeMembershipsForTrainee("triggersError"))
         .thenThrow(new IllegalArgumentException());
-
-    ProgrammeMembershipDto dto = new ProgrammeMembershipDto();
-    dto.setTisId("tisIdValue");
 
     mockMvc.perform(
             delete("/api/programme-membership/{traineeTisId}", "triggersError")


### PR DESCRIPTION
The synchronization of ProgrammeMemberships has been refactored and no longer requires all PMs to be deleted from the TraineeProfile. Create a new API endpoint to allow the deletion of a single PM given the trainee and PM IDs.

TIS21-4172
TIS21-2399