### PR TITLE
Feat: pm id or UUID CoJ handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.23.0"
+version = "0.24.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CurriculumDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CurriculumDto.java
@@ -30,6 +30,7 @@ import lombok.Data;
 @Data
 public class CurriculumDto {
 
+  private String tisId;
   private String curriculumTisId;
   private String curriculumName;
   private String curriculumSubType;

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CurriculumDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CurriculumDto.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 import lombok.Data;
 
@@ -30,6 +31,7 @@ import lombok.Data;
 @Data
 public class CurriculumDto {
 
+  @JsonProperty(value = "curriculumMembershipId")
   private String tisId;
   private String curriculumTisId;
   private String curriculumName;

--- a/src/main/java/uk/nhs/hee/trainee/details/model/Curriculum.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/Curriculum.java
@@ -27,6 +27,7 @@ import lombok.Data;
 @Data
 public class Curriculum {
 
+  private String tisId;
   private String curriculumTisId;
   private String curriculumName;
   private String curriculumSubType;

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -78,7 +78,7 @@ public class ProgrammeMembershipService {
           //2. new uuid PM, with CoJ cached against old delimited cm ids *THE PRESENT*
           for (Curriculum curriculum : programmeMembership.getCurricula()) {
             Optional<ConditionsOfJoining> conditionsOfJoiningId
-                = cachingDelegate.getConditionsOfJoining(curriculum.getCurriculumTisId());
+                = cachingDelegate.getConditionsOfJoining(curriculum.getTisId());
             conditionsOfJoiningId.ifPresent(programmeMembership::setConditionsOfJoining);
             // All results should be the same, but iterating through all IDs ensures a clean cache.
           }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -45,7 +45,7 @@ public class ProgrammeMembershipService {
   private final CachingDelegate cachingDelegate;
 
   ProgrammeMembershipService(TraineeProfileRepository repository,
-      ProgrammeMembershipMapper mapper, CachingDelegate cachingDelegate) {
+                             ProgrammeMembershipMapper mapper, CachingDelegate cachingDelegate) {
     this.repository = repository;
     this.mapper = mapper;
     this.cachingDelegate = cachingDelegate;
@@ -59,7 +59,7 @@ public class ProgrammeMembershipService {
    * @return The updated programme membership or empty if a trainee with the ID was not found.
    */
   public Optional<ProgrammeMembership> updateProgrammeMembershipForTrainee(String traineeTisId,
-      ProgrammeMembership programmeMembership) {
+                                                                           ProgrammeMembership programmeMembership) {
     if (programmeMembership.getConditionsOfJoining() == null
         || programmeMembership.getConditionsOfJoining().signedAt() == null) {
 
@@ -144,16 +144,16 @@ public class ProgrammeMembershipService {
             })
         )
         .forEach(pm -> {
-              try {
-                //preferentially cache against new uuid
-                UUID uuid = UUID.fromString(pm.getTisId());
-                cachingDelegate.cacheConditionsOfJoining(uuid.toString(),
-                    pm.getConditionsOfJoining());
-              } catch (IllegalArgumentException e) {
-                //fallback: cache against delimited ids
-                cachingDelegate.cacheConditionsOfJoining(pm.getTisId(),
-                    pm.getConditionsOfJoining());
-              }
+          try {
+            //preferentially cache against new uuid
+            UUID uuid = UUID.fromString(pm.getTisId());
+            cachingDelegate.cacheConditionsOfJoining(uuid.toString(),
+                pm.getConditionsOfJoining());
+          } catch (IllegalArgumentException e) {
+            //fallback: cache against delimited ids
+            cachingDelegate.cacheConditionsOfJoining(pm.getTisId(),
+                pm.getConditionsOfJoining());
+          }
         });
 
     existingProgrammeMemberships.clear();
@@ -170,7 +170,7 @@ public class ProgrammeMembershipService {
    * @return True, or False if a trainee with the ID was not found.
    */
   public boolean deleteProgrammeMembershipForTrainee(String traineeTisId,
-      String programmeMembershipId) {
+                                                     String programmeMembershipId) {
     TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
 
     if (traineeProfile == null) {
@@ -195,7 +195,7 @@ public class ProgrammeMembershipService {
    *
    * @param programmeMembershipId The ID of the programme membership for signing COJ.
    * @return The updated programme membership or empty if the programme membership with the ID was
-   *     not found.
+   * not found.
    */
   public Optional<ProgrammeMembership> signProgrammeMembershipCoj(
       String traineeTisId, String programmeMembershipId) {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -45,7 +45,7 @@ public class ProgrammeMembershipService {
   private final CachingDelegate cachingDelegate;
 
   ProgrammeMembershipService(TraineeProfileRepository repository,
-                             ProgrammeMembershipMapper mapper, CachingDelegate cachingDelegate) {
+      ProgrammeMembershipMapper mapper, CachingDelegate cachingDelegate) {
     this.repository = repository;
     this.mapper = mapper;
     this.cachingDelegate = cachingDelegate;
@@ -59,7 +59,7 @@ public class ProgrammeMembershipService {
    * @return The updated programme membership or empty if a trainee with the ID was not found.
    */
   public Optional<ProgrammeMembership> updateProgrammeMembershipForTrainee(String traineeTisId,
-                                                                           ProgrammeMembership programmeMembership) {
+      ProgrammeMembership programmeMembership) {
     if (programmeMembership.getConditionsOfJoining() == null
         || programmeMembership.getConditionsOfJoining().signedAt() == null) {
 
@@ -170,7 +170,7 @@ public class ProgrammeMembershipService {
    * @return True, or False if a trainee with the ID was not found.
    */
   public boolean deleteProgrammeMembershipForTrainee(String traineeTisId,
-                                                     String programmeMembershipId) {
+      String programmeMembershipId) {
     TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
 
     if (traineeProfile == null) {
@@ -195,7 +195,7 @@ public class ProgrammeMembershipService {
    *
    * @param programmeMembershipId The ID of the programme membership for signing COJ.
    * @return The updated programme membership or empty if the programme membership with the ID was
-   * not found.
+   *     not found.
    */
   public Optional<ProgrammeMembership> signProgrammeMembershipCoj(
       String traineeTisId, String programmeMembershipId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,11 +14,11 @@ spring:
     user: ${REDIS_USER:default}
     password: ${REDIS_PASSWORD:password}
   rabbitmq:
-    host: ${TRAINEE_DETAILS_RABBITMQ_HOST}
-    port: ${TRAINEE_DETAILS_RABBITMQ_PORT}
+    host: ${TRAINEE_DETAILS_RABBITMQ_HOST:host.docker.internal}
+    port: ${TRAINEE_DETAILS_RABBITMQ_PORT:5672}
     username: ${TRAINEE_DETAILS_RABBITMQ_USERNAME}
     password: ${TRAINEE_DETAILS_RABBITMQ_PASSWORD}
-    ssl.enabled: ${TRAINEE_DETAILS_RABBITMQ_USE_SSL}
+    ssl.enabled: ${TRAINEE_DETAILS_RABBITMQ_USE_SSL:false}
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,11 +14,11 @@ spring:
     user: ${REDIS_USER:default}
     password: ${REDIS_PASSWORD:password}
   rabbitmq:
-    host: ${TRAINEE_DETAILS_RABBITMQ_HOST:host.docker.internal}
-    port: ${TRAINEE_DETAILS_RABBITMQ_PORT:5672}
+    host: ${TRAINEE_DETAILS_RABBITMQ_HOST}
+    port: ${TRAINEE_DETAILS_RABBITMQ_PORT}
     username: ${TRAINEE_DETAILS_RABBITMQ_USERNAME}
     password: ${TRAINEE_DETAILS_RABBITMQ_PASSWORD}
-    ssl.enabled: ${TRAINEE_DETAILS_RABBITMQ_USE_SSL:false}
+    ssl.enabled: ${TRAINEE_DETAILS_RABBITMQ_USE_SSL}
 
 logging:
   level:

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -473,6 +473,20 @@ class ProgrammeMembershipServiceTest {
   }
 
   @Test
+  void shouldCacheCojFromDeleteProgrammeMembershipsWhenCojSignedUsingUuid() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.getProgrammeMemberships()
+        .add(createProgrammeMembership(PROGRAMME_MEMBERSHIP_UUID.toString(), ORIGINAL_SUFFIX, 0));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    service.deleteProgrammeMembershipsForTrainee(TRAINEE_TIS_ID);
+
+    verify(cachingDelegate, times(1))
+        .cacheConditionsOfJoining(eq(PROGRAMME_MEMBERSHIP_UUID.toString()), any());
+  }
+
+  @Test
   void shouldNotCacheCojFromDeleteProgrammeMembershipsWhenCojNotSigned() {
     ProgrammeMembership programmeMembership = createProgrammeMembership(
         EXISTING_PROGRAMME_MEMBERSHIP_ID, ORIGINAL_SUFFIX, 0);

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -633,7 +633,7 @@ class ProgrammeMembershipServiceTest {
    * @return The dummy entity.
    */
   private ProgrammeMembership createProgrammeMembership(String tisId, String stringSuffix,
-                                                        int dateAdjustmentDays) {
+      int dateAdjustmentDays) {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setTisId(tisId);
     programmeMembership.setProgrammeTisId(PROGRAMME_TIS_ID + stringSuffix);

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -633,7 +633,7 @@ class ProgrammeMembershipServiceTest {
    * @return The dummy entity.
    */
   private ProgrammeMembership createProgrammeMembership(String tisId, String stringSuffix,
-      int dateAdjustmentDays) {
+                                                        int dateAdjustmentDays) {
     ProgrammeMembership programmeMembership = new ProgrammeMembership();
     programmeMembership.setTisId(tisId);
     programmeMembership.setProgrammeTisId(PROGRAMME_TIS_ID + stringSuffix);

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -350,8 +350,7 @@ class ProgrammeMembershipServiceTest {
     assertThat("Unexpected signed version.", conditionsOfJoining.version(),
         is(GoldGuideVersion.GG9));
 
-    verify(cachingDelegate, times(1))
-        .getConditionsOfJoining(PROGRAMME_MEMBERSHIP_UUID.toString());
+    verify(cachingDelegate).getConditionsOfJoining(PROGRAMME_MEMBERSHIP_UUID.toString());
   }
 
   @Test
@@ -386,10 +385,8 @@ class ProgrammeMembershipServiceTest {
     assertThat("Unexpected signed version.", conditionsOfJoining.version(),
         is(GoldGuideVersion.GG9));
 
-    verify(cachingDelegate, times(1))
-        .getConditionsOfJoining(PROGRAMME_MEMBERSHIP_UUID.toString());
-    verify(cachingDelegate, times(1))
-        .getConditionsOfJoining("123");
+    verify(cachingDelegate).getConditionsOfJoining(PROGRAMME_MEMBERSHIP_UUID.toString());
+    verify(cachingDelegate).getConditionsOfJoining("123");
   }
 
   @Test
@@ -482,8 +479,7 @@ class ProgrammeMembershipServiceTest {
 
     service.deleteProgrammeMembershipsForTrainee(TRAINEE_TIS_ID);
 
-    verify(cachingDelegate, times(1))
-        .cacheConditionsOfJoining(eq(PROGRAMME_MEMBERSHIP_UUID.toString()), any());
+    verify(cachingDelegate).cacheConditionsOfJoining(eq(PROGRAMME_MEMBERSHIP_UUID.toString()), any());
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -37,14 +37,18 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.nhs.hee.trainee.details.dto.enumeration.GoldGuideVersion;
 import uk.nhs.hee.trainee.details.mapper.ProgrammeMembershipMapperImpl;
 import uk.nhs.hee.trainee.details.model.ConditionsOfJoining;
+import uk.nhs.hee.trainee.details.model.Curriculum;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
@@ -65,6 +69,7 @@ class ProgrammeMembershipServiceTest {
   private static final String NEW_PROGRAMME_MEMBERSHIP_ID = "1";
   private static final String EXISTING_PROGRAMME_MEMBERSHIP_ID = "2";
   private static final String MULTIPLE_PROGRAMME_MEMBERSHIP_ID = "123,456,789";
+  private static final UUID PROGRAMME_MEMBERSHIP_UUID = UUID.randomUUID();
   private static final Instant COJ_SIGNED_AT = Instant.now();
   private static final GoldGuideVersion GOLD_GUIDE_VERSION = GoldGuideVersion.GG9;
 
@@ -316,6 +321,75 @@ class ProgrammeMembershipServiceTest {
     verify(cachingDelegate, times(1)).getConditionsOfJoining("123");
     verify(cachingDelegate, times(1)).getConditionsOfJoining("456");
     verify(cachingDelegate, times(1)).getConditionsOfJoining("789");
+  }
+
+  @Test
+  void shouldUpdateProgrammeMembershipCojWhenPmHasUuidAndCachedCojHasUuid() {
+    ProgrammeMembership programmeMembership = createProgrammeMembership(
+        PROGRAMME_MEMBERSHIP_UUID.toString(), ORIGINAL_SUFFIX, 0);
+    programmeMembership.setConditionsOfJoining(null);
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.getProgrammeMemberships().add(programmeMembership);
+
+    when(cachingDelegate.getConditionsOfJoining(PROGRAMME_MEMBERSHIP_UUID.toString())).thenReturn(
+        Optional.of(new ConditionsOfJoining(COJ_SIGNED_AT, GoldGuideVersion.GG9)));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    Optional<ProgrammeMembership> optionalProgrammeMembership = service
+        .updateProgrammeMembershipForTrainee(TRAINEE_TIS_ID, programmeMembership);
+
+    assertThat("Unexpected optional isEmpty flag.", optionalProgrammeMembership.isEmpty(),
+        is(false));
+    ProgrammeMembership updatedProgrammeMembership = optionalProgrammeMembership.get();
+    assertThat("Unexpected conditions of joining.",
+        updatedProgrammeMembership.getConditionsOfJoining(), notNullValue());
+
+    ConditionsOfJoining conditionsOfJoining = updatedProgrammeMembership.getConditionsOfJoining();
+    assertThat("Unexpected signed at.", conditionsOfJoining.signedAt(), is(COJ_SIGNED_AT));
+    assertThat("Unexpected signed version.", conditionsOfJoining.version(),
+        is(GoldGuideVersion.GG9));
+
+    verify(cachingDelegate, times(1))
+        .getConditionsOfJoining(PROGRAMME_MEMBERSHIP_UUID.toString());
+  }
+
+  @Test
+  void shouldUpdateProgrammeMembershipCojWhenPmHasUuidAndCachedCojHasIds() {
+    Curriculum curriculum = new Curriculum();
+    curriculum.setTisId("123");
+    ProgrammeMembership programmeMembership = createProgrammeMembership(
+        PROGRAMME_MEMBERSHIP_UUID.toString(), ORIGINAL_SUFFIX, 0);
+    programmeMembership.setConditionsOfJoining(null);
+    programmeMembership.setCurricula(new ArrayList<>(Arrays.asList(curriculum)));
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.getProgrammeMemberships().add(programmeMembership);
+
+    when(cachingDelegate.getConditionsOfJoining(PROGRAMME_MEMBERSHIP_UUID.toString())).thenReturn(
+        Optional.empty());
+    when(cachingDelegate.getConditionsOfJoining("123")).thenReturn(
+        Optional.of(new ConditionsOfJoining(COJ_SIGNED_AT, GoldGuideVersion.GG9)));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    Optional<ProgrammeMembership> optionalProgrammeMembership = service
+        .updateProgrammeMembershipForTrainee(TRAINEE_TIS_ID, programmeMembership);
+
+    assertThat("Unexpected optional isEmpty flag.", optionalProgrammeMembership.isEmpty(),
+        is(false));
+    ProgrammeMembership updatedProgrammeMembership = optionalProgrammeMembership.get();
+    assertThat("Unexpected conditions of joining.",
+        updatedProgrammeMembership.getConditionsOfJoining(), notNullValue());
+
+    ConditionsOfJoining conditionsOfJoining = updatedProgrammeMembership.getConditionsOfJoining();
+    assertThat("Unexpected signed at.", conditionsOfJoining.signedAt(), is(COJ_SIGNED_AT));
+    assertThat("Unexpected signed version.", conditionsOfJoining.version(),
+        is(GoldGuideVersion.GG9));
+
+    verify(cachingDelegate, times(1))
+        .getConditionsOfJoining(PROGRAMME_MEMBERSHIP_UUID.toString());
+    verify(cachingDelegate, times(1))
+        .getConditionsOfJoining("123");
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/trainee/details/service/RabbitPublishServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/RabbitPublishServiceTest.java
@@ -27,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
 import java.time.Instant;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -103,5 +104,27 @@ class RabbitPublishServiceTest {
     CojSignedEvent event = eventCaptor.getValue();
     assertThat("Unexpected programme membership ID.",
         event.getProgrammeMembershipTisId(), is("123"));
+  }
+
+  @Test
+  void shouldPublishCojSignedEventWithUuid() {
+    UUID uuid = UUID.randomUUID();
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId(uuid.toString());
+    Instant signedAt = Instant.now();
+    ConditionsOfJoining conditionsOfJoining
+        = new ConditionsOfJoining(signedAt, GoldGuideVersion.GG9);
+    programmeMembership.setConditionsOfJoining(conditionsOfJoining);
+
+    rabbitPublishService.publishCojSignedEvent(programmeMembership);
+
+    ArgumentCaptor<CojSignedEvent> eventCaptor = ArgumentCaptor.forClass(
+        CojSignedEvent.class);
+
+    verify(rabbitTemplate).convertAndSend(any(), any(), eventCaptor.capture());
+
+    CojSignedEvent event = eventCaptor.getValue();
+    assertThat("Unexpected programme membership ID.",
+        event.getProgrammeMembershipTisId(), is(uuid.toString()));
   }
 }


### PR DESCRIPTION
Initial speculative branch to validate approach. 

Requires programme membership curricula to have tisId populated to work - a change that needs to be made in tis-trainee-sync.

TIS21-4659