### PR TITLE
fix: hide UUID programme memberships

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.24.1"
+version = "0.24.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
@@ -83,6 +83,7 @@ public class TraineeProfileResource {
 
     traineeProfile = service.hidePastProgrammes(traineeProfile);
     traineeProfile = service.hidePastPlacements(traineeProfile);
+    traineeProfile = service.hideUuidProgrammes(traineeProfile); //remove once migrated
     return ResponseEntity.ok(mapper.toDto(traineeProfile));
   }
 

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -125,6 +125,17 @@ public class TraineeProfileService {
   }
 
   /**
+   * Remove uuid programmes from the trainee profile.
+   *
+   * @param traineeProfile The trainee profile to modify.
+   * @return The modified trainee profile.
+   */
+  public TraineeProfile hideUuidProgrammes(TraineeProfile traineeProfile) {
+    traineeProfile.getProgrammeMemberships().removeIf(c -> !c.getTisId().matches("[0-9,]+"));
+    return traineeProfile;
+  }
+
+  /**
    * Remove past placements from the trainee profile.
    *
    * @param traineeProfile The trainee profile to modify.

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -267,6 +267,7 @@ class TraineeProfileResourceTest {
   void getShouldReturnTraineeProfileWhenTisIdExists() throws Exception {
     when(service.getTraineeProfileByTraineeTisId(DEFAULT_TIS_ID_1)).thenReturn(traineeProfile);
     when(service.hidePastProgrammes(traineeProfile)).thenReturn(traineeProfile);
+    when(service.hideUuidProgrammes(traineeProfile)).thenReturn(traineeProfile);
     when(service.hidePastPlacements(traineeProfile)).thenReturn(traineeProfile);
 
     Signature signature = new Signature(Duration.ofMinutes(60));

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -90,6 +91,7 @@ class TraineeProfileServiceTest {
   private static final String PERSON_POSTCODE = "SW1A1AA";
   private static final String PERSON_GMC = "1111111";
 
+  private static final String PROGRAMME_MEMBERSHIP_TISID = "123";
   private static final String PROGRAMME_TISID = "1";
   private static final String PROGRAMME_NAME = "General Practice";
   private static final String PROGRAMME_NUMBER = "EOE8950";
@@ -176,6 +178,7 @@ class TraineeProfileServiceTest {
    */
   void setupProgrammeMembershipsData() {
     programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId(PROGRAMME_MEMBERSHIP_TISID);
     programmeMembership.setProgrammeTisId(PROGRAMME_TISID);
     programmeMembership.setProgrammeName(PROGRAMME_NAME);
     programmeMembership.setProgrammeNumber(PROGRAMME_NUMBER);
@@ -235,6 +238,23 @@ class TraineeProfileServiceTest {
     TraineeProfile returnedTraineeProfile = service.hidePastProgrammes(traineeProfile);
     assertThat(returnedTraineeProfile.getProgrammeMemberships().size(), is(1));
     assertThat(returnedTraineeProfile.getProgrammeMemberships(), hasItem(programmeMembership));
+  }
+
+  @Test
+  void hideUuidProgrammesShouldHideUuidProgrammes() {
+    var programmeMembership2 = new ProgrammeMembership();
+    programmeMembership2.setTisId("456,7,8934");
+    var programmeMembership3 = new ProgrammeMembership();
+    programmeMembership3.setTisId(UUID.randomUUID().toString());
+
+    List<ProgrammeMembership> programmeMemberships = traineeProfile.getProgrammeMemberships();
+    programmeMemberships.add(programmeMembership2);
+    programmeMemberships.add(programmeMembership3);
+
+    TraineeProfile returnedTraineeProfile = service.hideUuidProgrammes(traineeProfile);
+    assertThat(returnedTraineeProfile.getProgrammeMemberships().size(), is(2));
+    assertThat(returnedTraineeProfile.getProgrammeMemberships(), hasItem(programmeMembership));
+    assertThat(returnedTraineeProfile.getProgrammeMemberships(), hasItem(programmeMembership2));
   }
 
   @Test


### PR DESCRIPTION
Until migration to UUID style is complete.

TIS21-4699