### PR TITLE
fix: skip processing after finding 1st legacy COJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.24.4"
+version = "0.24.5"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -94,12 +94,13 @@ public class ProgrammeMembershipService {
                     .anyMatch(id -> id.equals(curriculum.getTisId())))
                 .findAny()
                 .orElse(null);
-            if (oldProgrammeMembership != null) {
+            if (oldProgrammeMembership != null
+                && oldProgrammeMembership.getConditionsOfJoining() != null) {
               ConditionsOfJoining savedCoj = oldProgrammeMembership.getConditionsOfJoining();
               programmeMembership.setConditionsOfJoining(savedCoj);
+              break;
             }
           }
-
         }
       } catch (IllegalArgumentException e) {
         //3. old cm-ids PM, with CoJ cached against old delimited cm ids *THE PAST*
@@ -205,7 +206,7 @@ public class ProgrammeMembershipService {
    *
    * @param programmeMembershipId The ID of the programme membership for signing COJ.
    * @return The updated programme membership or empty if the programme membership with the ID was
-   *     not found.
+   * not found.
    */
   public Optional<ProgrammeMembership> signProgrammeMembershipCoj(
       String traineeTisId, String programmeMembershipId) {

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -430,6 +430,78 @@ class ProgrammeMembershipServiceTest {
   }
 
   @Test
+  void shouldUpdateProgrammeMembershipCojWhenPmHasUuidAndFirstSavedPmHasCoj() {
+    Curriculum curriculum123 = new Curriculum();
+    curriculum123.setTisId("123");
+    ProgrammeMembership oldPm123 = createProgrammeMembership("123", ORIGINAL_SUFFIX, 0);
+    oldPm123.setConditionsOfJoining(new ConditionsOfJoining(COJ_SIGNED_AT, GoldGuideVersion.GG9));
+
+    Curriculum curriculum456 = new Curriculum();
+    curriculum456.setTisId("456");
+    ProgrammeMembership oldPm456 = createProgrammeMembership("456", ORIGINAL_SUFFIX, 0);
+    oldPm456.setConditionsOfJoining(null);
+
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.getProgrammeMemberships().addAll(List.of(oldPm123, oldPm456));
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    ProgrammeMembership programmeMembership = createProgrammeMembership(
+        PROGRAMME_MEMBERSHIP_UUID.toString(), ORIGINAL_SUFFIX, 0);
+    programmeMembership.setConditionsOfJoining(null);
+    programmeMembership.setCurricula(List.of(curriculum123, curriculum456));
+
+    Optional<ProgrammeMembership> optionalProgrammeMembership =
+        service.updateProgrammeMembershipForTrainee(TRAINEE_TIS_ID, programmeMembership);
+
+    assertThat("Unexpected optional isEmpty flag.", optionalProgrammeMembership.isEmpty(),
+        is(false));
+    ProgrammeMembership updatedProgrammeMembership = optionalProgrammeMembership.get();
+    assertThat("Unexpected conditions of joining.",
+        updatedProgrammeMembership.getConditionsOfJoining(), notNullValue());
+
+    ConditionsOfJoining conditionsOfJoining = updatedProgrammeMembership.getConditionsOfJoining();
+    assertThat("Unexpected signed at.", conditionsOfJoining.signedAt(), is(COJ_SIGNED_AT));
+    assertThat("Unexpected signed version.", conditionsOfJoining.version(),
+        is(GoldGuideVersion.GG9));
+  }
+
+  @Test
+  void shouldUpdateProgrammeMembershipCojWhenPmHasUuidAndSecondSavedPmHasCoj() {
+    Curriculum curriculum123 = new Curriculum();
+    curriculum123.setTisId("123");
+    ProgrammeMembership oldPm123 = createProgrammeMembership("123", ORIGINAL_SUFFIX, 0);
+    oldPm123.setConditionsOfJoining(null);
+
+    Curriculum curriculum456 = new Curriculum();
+    curriculum456.setTisId("456");
+    ProgrammeMembership oldPm456 = createProgrammeMembership("456", ORIGINAL_SUFFIX, 0);
+    oldPm456.setConditionsOfJoining(new ConditionsOfJoining(COJ_SIGNED_AT, GoldGuideVersion.GG9));
+
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.getProgrammeMemberships().addAll(List.of(oldPm123, oldPm456));
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    ProgrammeMembership programmeMembership = createProgrammeMembership(
+        PROGRAMME_MEMBERSHIP_UUID.toString(), ORIGINAL_SUFFIX, 0);
+    programmeMembership.setConditionsOfJoining(null);
+    programmeMembership.setCurricula(List.of(curriculum123, curriculum456));
+
+    Optional<ProgrammeMembership> optionalProgrammeMembership =
+        service.updateProgrammeMembershipForTrainee(TRAINEE_TIS_ID, programmeMembership);
+
+    assertThat("Unexpected optional isEmpty flag.", optionalProgrammeMembership.isEmpty(),
+        is(false));
+    ProgrammeMembership updatedProgrammeMembership = optionalProgrammeMembership.get();
+    assertThat("Unexpected conditions of joining.",
+        updatedProgrammeMembership.getConditionsOfJoining(), notNullValue());
+
+    ConditionsOfJoining conditionsOfJoining = updatedProgrammeMembership.getConditionsOfJoining();
+    assertThat("Unexpected signed at.", conditionsOfJoining.signedAt(), is(COJ_SIGNED_AT));
+    assertThat("Unexpected signed version.", conditionsOfJoining.version(),
+        is(GoldGuideVersion.GG9));
+  }
+
+  @Test
   void shouldNotUpdateProgrammeMembershipCojWhenPmHasUuidAndSavedPmNotFound() {
     Curriculum curriculum = new Curriculum();
     curriculum.setTisId("123");
@@ -547,7 +619,8 @@ class ProgrammeMembershipServiceTest {
 
     service.deleteProgrammeMembershipsForTrainee(TRAINEE_TIS_ID);
 
-    verify(cachingDelegate).cacheConditionsOfJoining(eq(PROGRAMME_MEMBERSHIP_UUID.toString()), any());
+    verify(cachingDelegate).cacheConditionsOfJoining(eq(PROGRAMME_MEMBERSHIP_UUID.toString()),
+        any());
   }
 
   @Test


### PR DESCRIPTION
If the legacy Programme Membership data is structured incorrectly, i.e. as two PMs instead of one with multiple curricula, it is possible for a valid COJ to not be copied over to the new UUID PM. This occurs when the first returned PM has a COJ but subsequent matching PMs do not, the later `null` values overwrite the originally assigned COJ.

Add a null check and a break to ensure that we only set COJ values that are non-null and exit the loop early if we've found a COJ already.

TIS21-2399