### PR TITLE
refactor: the personal details update event

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.26.0"
+version = "0.27.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/config/AmazonSqsConfig.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/AmazonSqsConfig.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.messaging.core.QueueMessagingTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.MessageConverter;
+
+/**
+ * Configuration for SQS functionality.
+ */
+@Configuration
+public class AmazonSqsConfig {
+
+  /**
+   * Create a default {@link AmazonSQSAsync} bean.
+   *
+   * @return The created bean.
+   */
+  @Bean
+  @Primary
+  public AmazonSQSAsync amazonSqsAsync() {
+    return AmazonSQSAsyncClientBuilder.defaultClient();
+  }
+
+  /**
+   * Create a default {@link QueueMessagingTemplate} bean.
+   *
+   * @return The created bean.
+   */
+  @Bean
+  public QueueMessagingTemplate queueMessagingTemplate() {
+    return new QueueMessagingTemplate(amazonSqsAsync());
+  }
+
+  /**
+   * Create a message converter bean with an object mapper.
+   *
+   * @param objectMapper The object mapper to set.
+   * @return The created message converter.
+   */
+  @Bean
+  public MessageConverter messageConverter(ObjectMapper objectMapper) {
+    var converter = new MappingJackson2MessageConverter();
+    converter.setObjectMapper(objectMapper);
+    return converter;
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsDto.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.time.LocalDate;
 import lombok.Data;
@@ -39,6 +40,7 @@ public class PersonalDetailsDto implements SignedDto {
   private String knownAs;
   private String maidenName;
   private String title;
+  @JsonAlias("owner")
   private String personOwner;
   private LocalDate dateOfBirth;
   private String gender;

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsUpdateEvent.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsUpdateEvent.java
@@ -21,9 +21,33 @@
 
 package uk.nhs.hee.trainee.details.dto;
 
-public record PersonalDetailsEvent(PersonalDetailsDto data, PersonalDetailsMetadata metadata) {
+import com.fasterxml.jackson.annotation.JsonProperty;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
-  public record PersonalDetailsMetadata(String tisId) {
+/**
+ * A representation of a PersonalDetails update event.
+ *
+ * @param tisId  The TIS ID of the record being updated.
+ * @param update A wrapper around the update data.
+ */
+public record PersonalDetailsUpdateEvent(
+    @NotEmpty String tisId,
+
+    @NotNull
+    @JsonProperty("record")
+    Update update) {
+
+  /**
+   * A wrapper around the update data, used so the record structure matches the incoming message.
+   *
+   * @param personalDetails The updated personal details.
+   */
+  public record Update(
+      @NotNull
+      @JsonProperty("data")
+      PersonalDetailsDto personalDetails) {
 
   }
+
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/event/BasicDetailsListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/BasicDetailsListener.java
@@ -27,11 +27,14 @@ import io.awspring.cloud.messaging.listener.annotation.SqsListener;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
+/**
+ * A listener for Basic Details events.
+ */
 @Slf4j
 @Component
 public class BasicDetailsListener {
@@ -50,12 +53,12 @@ public class BasicDetailsListener {
    *
    * @param event The sync event containing the basic details.
    */
-  @SqsListener(value = "${application.aws.sqs.basic-details-update", deletionPolicy = ON_SUCCESS)
-  void updateBasicDetails(PersonalDetailsEvent event) {
-    String tisId = event.metadata().tisId();
+  @SqsListener(value = "${application.aws.sqs.basic-details-update}", deletionPolicy = ON_SUCCESS)
+  void updateBasicDetails(PersonalDetailsUpdateEvent event) {
+    String tisId = event.tisId();
     log.info("Update basic details of trainee with TIS ID {}", tisId);
 
-    PersonalDetailsDto dto = event.data();
+    PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
     service.createProfileOrUpdateBasicDetailsByTisId(tisId, entity);
   }

--- a/src/main/java/uk/nhs/hee/trainee/details/event/ContactDetailsListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/ContactDetailsListener.java
@@ -28,11 +28,14 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
+/**
+ * A listener for Contact Details events.
+ */
 @Slf4j
 @Component
 public class ContactDetailsListener {
@@ -50,12 +53,12 @@ public class ContactDetailsListener {
    *
    * @param event The sync event containing the contact details.
    */
-  @SqsListener(value = "${application.aws.sqs.contact-details-update", deletionPolicy = ON_SUCCESS)
-  void updateContactDetails(PersonalDetailsEvent event) {
-    String tisId = event.metadata().tisId();
+  @SqsListener(value = "${application.aws.sqs.contact-details-update}", deletionPolicy = ON_SUCCESS)
+  void updateContactDetails(PersonalDetailsUpdateEvent event) {
+    String tisId = event.tisId();
     log.info("Update contact details of trainee with TIS ID {}", tisId);
 
-    PersonalDetailsDto dto = event.data();
+    PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
     Optional<PersonalDetails> optionalEntity = service.updateContactDetailsByTisId(tisId, entity);
 

--- a/src/main/java/uk/nhs/hee/trainee/details/event/GdcDetailsListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/GdcDetailsListener.java
@@ -28,11 +28,14 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
+/**
+ * A listener for GDC Details events.
+ */
 @Slf4j
 @Component
 public class GdcDetailsListener {
@@ -50,12 +53,12 @@ public class GdcDetailsListener {
    *
    * @param event The sync event containing the GDC details.
    */
-  @SqsListener(value = "${application.aws.sqs.gdc-details-update", deletionPolicy = ON_SUCCESS)
-  void updateGdcDetails(PersonalDetailsEvent event) {
-    String tisId = event.metadata().tisId();
+  @SqsListener(value = "${application.aws.sqs.gdc-details-update}", deletionPolicy = ON_SUCCESS)
+  void updateGdcDetails(PersonalDetailsUpdateEvent event) {
+    String tisId = event.tisId();
     log.info("Update GDC details of trainee with TIS ID {}", tisId);
 
-    PersonalDetailsDto dto = event.data();
+    PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
     Optional<PersonalDetails> optionalEntity = service.updateGdcDetailsByTisId(tisId, entity);
 

--- a/src/main/java/uk/nhs/hee/trainee/details/event/GmcDetailsListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/GmcDetailsListener.java
@@ -28,11 +28,14 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
+/**
+ * A listener for GMC Details events.
+ */
 @Slf4j
 @Component
 public class GmcDetailsListener {
@@ -50,12 +53,12 @@ public class GmcDetailsListener {
    *
    * @param event The sync event containing the GMC details.
    */
-  @SqsListener(value = "${application.aws.sqs.gmc-details-update", deletionPolicy = ON_SUCCESS)
-  void updateGmcDetails(PersonalDetailsEvent event) {
-    String tisId = event.metadata().tisId();
+  @SqsListener(value = "${application.aws.sqs.gmc-details-update}", deletionPolicy = ON_SUCCESS)
+  void updateGmcDetails(PersonalDetailsUpdateEvent event) {
+    String tisId = event.tisId();
     log.info("Update GMC details of trainee with TIS ID {}", tisId);
 
-    PersonalDetailsDto dto = event.data();
+    PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
     Optional<PersonalDetails> optionalEntity = service.updateGmcDetailsByTisId(tisId, entity);
 

--- a/src/main/java/uk/nhs/hee/trainee/details/event/PersonOwnerListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/PersonOwnerListener.java
@@ -28,11 +28,14 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
+/**
+ * A listener for Person Owner events.
+ */
 @Slf4j
 @Component
 public class PersonOwnerListener {
@@ -50,12 +53,12 @@ public class PersonOwnerListener {
    *
    * @param event The sync event containing the person owner data.
    */
-  @SqsListener(value = "${application.aws.sqs.person-owner-update", deletionPolicy = ON_SUCCESS)
-  void updatePersonOwner(PersonalDetailsEvent event) {
-    String tisId = event.metadata().tisId();
+  @SqsListener(value = "${application.aws.sqs.person-owner-update}", deletionPolicy = ON_SUCCESS)
+  void updatePersonOwner(PersonalDetailsUpdateEvent event) {
+    String tisId = event.tisId();
     log.info("Update person owner of trainee with TIS ID {}", tisId);
 
-    PersonalDetailsDto dto = event.data();
+    PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
     Optional<PersonalDetails> optionalEntity = service.updatePersonOwnerByTisId(tisId, entity);
 

--- a/src/main/java/uk/nhs/hee/trainee/details/event/PersonalInfoListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/PersonalInfoListener.java
@@ -27,11 +27,14 @@ import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
+/**
+ * A listener for Personal Info events.
+ */
 @Slf4j
 @Component
 public class PersonalInfoListener {
@@ -49,13 +52,13 @@ public class PersonalInfoListener {
    *
    * @param event The sync event containing the personal information.
    */
-  @SqsListener(value = "${application.aws.sqs.personal-info-update",
+  @SqsListener(value = "${application.aws.sqs.personal-info-update}",
       deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
-  void updatePersonalInfo(PersonalDetailsEvent event) {
-    String tisId = event.metadata().tisId();
+  void updatePersonalInfo(PersonalDetailsUpdateEvent event) {
+    String tisId = event.tisId();
     log.info("Update personal info of trainee with TIS ID {}", tisId);
 
-    PersonalDetailsDto dto = event.data();
+    PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
     Optional<PersonalDetails> optionalEntity = service.updatePersonalInfoByTisId(tisId, entity);
 

--- a/src/test/java/uk/nhs/hee/trainee/details/config/AmazonSqsConfigTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/AmazonSqsConfigTest.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.MessageConverter;
+
+class AmazonSqsConfigTest {
+
+  private AmazonSqsConfig config;
+
+  @BeforeEach
+  void setUp() {
+    config = new AmazonSqsConfig();
+  }
+
+  @Test
+  void shouldIncludeExistingObjectMapperInMessageConverter() {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    MessageConverter messageConverter = config.messageConverter(objectMapper);
+
+    assertThat("Unexpected message converter.", messageConverter,
+        instanceOf(MappingJackson2MessageConverter.class));
+    assertThat("Unexpected object mapper.",
+        ((MappingJackson2MessageConverter) messageConverter).getObjectMapper(),
+        sameInstance(objectMapper));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/event/BasicDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/BasicDetailsListenerTest.java
@@ -31,8 +31,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent.PersonalDetailsMetadata;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent.Update;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
@@ -57,8 +57,8 @@ class BasicDetailsListenerTest {
     PersonalDetailsDto dto = new PersonalDetailsDto();
     dto.setPublicHealthNumber(PUBLIC_HEALTH_NUMBER);
 
-    PersonalDetailsMetadata metadata = new PersonalDetailsMetadata(TIS_ID);
-    PersonalDetailsEvent event = new PersonalDetailsEvent(dto, metadata);
+    Update update = new Update(dto);
+    PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     listener.updateBasicDetails(event);
 

--- a/src/test/java/uk/nhs/hee/trainee/details/event/ContactDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/ContactDetailsListenerTest.java
@@ -34,8 +34,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent.PersonalDetailsMetadata;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent.Update;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
@@ -60,8 +60,8 @@ class ContactDetailsListenerTest {
   @Test
   void shouldThrowExceptionWhenTraineeNotFound() {
     PersonalDetailsDto dto = new PersonalDetailsDto();
-    PersonalDetailsMetadata metadata = new PersonalDetailsMetadata(TIS_ID);
-    PersonalDetailsEvent event = new PersonalDetailsEvent(dto, metadata);
+    Update update = new Update(dto);
+    PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     when(service.updateContactDetailsByTisId(eq(TIS_ID), any())).thenReturn(Optional.empty());
 
@@ -75,8 +75,8 @@ class ContactDetailsListenerTest {
     dto.setSurname(SURNAME);
     dto.setEmail(EMAIL);
 
-    PersonalDetailsMetadata metadata = new PersonalDetailsMetadata(TIS_ID);
-    PersonalDetailsEvent event = new PersonalDetailsEvent(dto, metadata);
+    Update update = new Update(dto);
+    PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
     when(service.updateContactDetailsByTisId(eq(TIS_ID), entityCaptor.capture())).then(

--- a/src/test/java/uk/nhs/hee/trainee/details/event/GdcDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/GdcDetailsListenerTest.java
@@ -34,8 +34,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent.PersonalDetailsMetadata;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent.Update;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
@@ -59,8 +59,8 @@ class GdcDetailsListenerTest {
   @Test
   void shouldThrowExceptionWhenTraineeNotFound() {
     PersonalDetailsDto dto = new PersonalDetailsDto();
-    PersonalDetailsMetadata metadata = new PersonalDetailsMetadata(TIS_ID);
-    PersonalDetailsEvent event = new PersonalDetailsEvent(dto, metadata);
+    Update update = new Update(dto);
+    PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     when(service.updateGdcDetailsByTisId(eq(TIS_ID), any())).thenReturn(Optional.empty());
 
@@ -73,8 +73,8 @@ class GdcDetailsListenerTest {
     dto.setGdcNumber(GDC_NUMBER);
     dto.setGdcStatus(GDC_STATUS);
 
-    PersonalDetailsMetadata metadata = new PersonalDetailsMetadata(TIS_ID);
-    PersonalDetailsEvent event = new PersonalDetailsEvent(dto, metadata);
+    Update update = new Update(dto);
+    PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
     when(service.updateGdcDetailsByTisId(eq(TIS_ID), entityCaptor.capture())).then(

--- a/src/test/java/uk/nhs/hee/trainee/details/event/GmcDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/GmcDetailsListenerTest.java
@@ -34,8 +34,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent.PersonalDetailsMetadata;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent.Update;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
@@ -59,8 +59,8 @@ class GmcDetailsListenerTest {
   @Test
   void shouldThrowExceptionWhenTraineeNotFound() {
     PersonalDetailsDto dto = new PersonalDetailsDto();
-    PersonalDetailsMetadata metadata = new PersonalDetailsMetadata(TIS_ID);
-    PersonalDetailsEvent event = new PersonalDetailsEvent(dto, metadata);
+    Update update = new Update(dto);
+    PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     when(service.updateGmcDetailsByTisId(eq(TIS_ID), any())).thenReturn(Optional.empty());
 
@@ -73,8 +73,8 @@ class GmcDetailsListenerTest {
     dto.setGmcNumber(GMC_NUMBER);
     dto.setGmcStatus(GMC_STATUS);
 
-    PersonalDetailsMetadata metadata = new PersonalDetailsMetadata(TIS_ID);
-    PersonalDetailsEvent event = new PersonalDetailsEvent(dto, metadata);
+    Update update = new Update(dto);
+    PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
     when(service.updateGmcDetailsByTisId(eq(TIS_ID), entityCaptor.capture())).then(

--- a/src/test/java/uk/nhs/hee/trainee/details/event/PersonOwnerListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/PersonOwnerListenerTest.java
@@ -34,8 +34,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent.PersonalDetailsMetadata;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent.Update;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
@@ -58,8 +58,8 @@ class PersonOwnerListenerTest {
   @Test
   void shouldThrowExceptionWhenTraineeNotFound() {
     PersonalDetailsDto dto = new PersonalDetailsDto();
-    PersonalDetailsMetadata metadata = new PersonalDetailsMetadata(TIS_ID);
-    PersonalDetailsEvent event = new PersonalDetailsEvent(dto, metadata);
+    Update update = new Update(dto);
+    PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     when(service.updatePersonOwnerByTisId(eq(TIS_ID), any())).thenReturn(Optional.empty());
 
@@ -71,8 +71,8 @@ class PersonOwnerListenerTest {
     PersonalDetailsDto dto = new PersonalDetailsDto();
     dto.setPersonOwner(PERSON_OWNER);
 
-    PersonalDetailsMetadata metadata = new PersonalDetailsMetadata(TIS_ID);
-    PersonalDetailsEvent event = new PersonalDetailsEvent(dto, metadata);
+    Update update = new Update(dto);
+    PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
     when(service.updatePersonOwnerByTisId(eq(TIS_ID), entityCaptor.capture())).then(

--- a/src/test/java/uk/nhs/hee/trainee/details/event/PersonalInfoListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/PersonalInfoListenerTest.java
@@ -35,8 +35,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent;
-import uk.nhs.hee.trainee.details.dto.PersonalDetailsEvent.PersonalDetailsMetadata;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
+import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent.Update;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
@@ -60,8 +60,8 @@ class PersonalInfoListenerTest {
   @Test
   void shouldThrowExceptionWhenTraineeNotFound() {
     PersonalDetailsDto dto = new PersonalDetailsDto();
-    PersonalDetailsMetadata metadata = new PersonalDetailsMetadata(TIS_ID);
-    PersonalDetailsEvent event = new PersonalDetailsEvent(dto, metadata);
+    Update update = new Update(dto);
+    PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     when(service.updatePersonalInfoByTisId(eq(TIS_ID), any())).thenReturn(Optional.empty());
 
@@ -74,8 +74,8 @@ class PersonalInfoListenerTest {
     dto.setDateOfBirth(DOB);
     dto.setGender(GENDER);
 
-    PersonalDetailsMetadata metadata = new PersonalDetailsMetadata(TIS_ID);
-    PersonalDetailsEvent event = new PersonalDetailsEvent(dto, metadata);
+    Update update = new Update(dto);
+    PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
     when(service.updatePersonalInfoByTisId(eq(TIS_ID), entityCaptor.capture())).then(


### PR DESCRIPTION
The data structure for the PersonalDetailsEvent does not currently match the data that is sent from tis-trainee-sync.

Update the event DTO to more closely reflect the structure of the incoming message data.
Add SQS config to ensure that messages are read correctly.

Add an alias to the PersonalDetailsDto to ensure that `owner` can be correctly mapped to `personOwner`.

TIS21-4086
TIS21-4076