### PR TITLE
fix: robustified rabbit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.28.0"
+version = "0.28.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/TisTraineeDetailsApplication.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/TisTraineeDetailsApplication.java
@@ -25,12 +25,10 @@ import io.mongock.runner.springboot.EnableMongock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableMongock
 @SpringBootApplication
 @ConfigurationPropertiesScan
-@EnableScheduling
 public class TisTraineeDetailsApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
@@ -162,7 +162,7 @@ public class ProgrammeMembershipResource {
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
             "Trainee with Programme Membership " + programmeMembershipId + " not found."));
 
-    rabbitPublishService.publishCojSignedEvent(entity);
+    rabbitPublishService.publishCojSignedEvent(entity, 0);
 
     return ResponseEntity.ok(mapper.toDto(entity));
   }

--- a/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
@@ -32,6 +32,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
 @ConditionalOnProperty("spring.rabbitmq.host")
@@ -57,16 +58,14 @@ public class RabbitConfig {
     RetryTemplate retryTemplate = new RetryTemplate();
     ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
     backOffPolicy.setInitialInterval(500);
-    backOffPolicy.setMultiplier(10.0);
-    backOffPolicy.setMaxInterval(10000);
+    backOffPolicy.setMultiplier(3.0);
+    backOffPolicy.setMaxInterval(3000_000);
     retryTemplate.setBackOffPolicy(backOffPolicy);
+    SimpleRetryPolicy simpleRetryPolicy = new SimpleRetryPolicy();
+    simpleRetryPolicy.setMaxAttempts(15);
+
+    retryTemplate.setRetryPolicy(simpleRetryPolicy);
     rabbitTemplate.setRetryTemplate(retryTemplate);
-
-    rabbitTemplate.setReturnsCallback(returned ->
-        log.info("Received Rabbit returned message {}", returned));
-
-    rabbitTemplate.setConfirmCallback((correlationData, ack, cause) ->
-        log.info("Received Rabbit confirmation with result {}", ack));
 
     rabbitTemplate.setMandatory(true);
 

--- a/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/RabbitConfig.java
@@ -55,11 +55,11 @@ public class RabbitConfig {
     rabbitTemplate.setMessageConverter(jsonMessageConverter());
     rabbitTemplate.containerAckMode(AcknowledgeMode.AUTO);
 
-    RetryTemplate retryTemplate = new RetryTemplate();
     ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
     backOffPolicy.setInitialInterval(500);
     backOffPolicy.setMultiplier(3.0);
     backOffPolicy.setMaxInterval(3000_000);
+    RetryTemplate retryTemplate = new RetryTemplate();
     retryTemplate.setBackOffPolicy(backOffPolicy);
     SimpleRetryPolicy simpleRetryPolicy = new SimpleRetryPolicy();
     simpleRetryPolicy.setMaxAttempts(15);

--- a/src/main/java/uk/nhs/hee/trainee/details/config/SchedulePublishRetryConfig.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/SchedulePublishRetryConfig.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.Collection;
+import java.util.Queue;
+import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
+import uk.nhs.hee.trainee.details.model.RetryCorrelationData;
+import uk.nhs.hee.trainee.details.service.RabbitPublishService;
+
+@Slf4j
+@Configuration
+public class SchedulePublishRetryConfig {
+
+  private final RabbitTemplate rabbitTemplate;
+  private final RabbitPublishService rabbitPublishService;
+  private final int maxRetries;
+
+  public SchedulePublishRetryConfig(RabbitTemplate rabbitTemplate,
+                                    RabbitPublishService rabbitPublishService,
+                                    @Value("${spring.rabbitmq.max-retries}") int maxRetries) {
+    this.rabbitTemplate = rabbitTemplate;
+    this.rabbitPublishService = rabbitPublishService;
+    this.maxRetries = maxRetries;
+  }
+
+  @Scheduled(fixedDelay = 10000)
+  public void scheduleNackedRepublishTask() {
+    Queue<RetryCorrelationData> queue = rabbitPublishService.getNegativeAckedMessages();
+
+    // try re-publish with batch size of 100 each time
+    for (int i = 0; i < 100; i++) {
+      if (queue.isEmpty()) {
+        break;
+      }
+      RetryCorrelationData retryCorrelationData = queue.remove();
+
+      log.info("Retry nack-ed Rabbit message : {}", retryCorrelationData.getId());
+      checkRetryCountAndRepublish(retryCorrelationData.getRetryCount(), retryCorrelationData.getId());
+    }
+  }
+
+  @Scheduled(fixedDelay = 5000)
+  public void scheduleUnconfirmedRepublishTask() {
+    Collection<CorrelationData> unconfirmed = rabbitTemplate.getUnconfirmed(10000);
+
+    if (unconfirmed != null) {
+      for (CorrelationData correlationData : unconfirmed) {
+        RetryCorrelationData retryCorrelationData = (RetryCorrelationData) correlationData;
+
+        log.info("Retry unconfirmed Rabbit message id : {}", retryCorrelationData.getId());
+        checkRetryCountAndRepublish(retryCorrelationData.getRetryCount(), correlationData.getId());
+      }
+    }
+  }
+
+  void checkRetryCountAndRepublish(int retryCount, String id) {
+    ProgrammeMembership pm = rabbitPublishService.cleanOutstandingConfirm(id);
+
+    if (pm == null) {
+      log.warn("Failed to retrieve programme membership from outstandingConfirms queue " +
+          "with id : '{}'", id);
+      return;
+    }
+
+    // have limit of retry count of 100, to prevent infinite retry
+    if (retryCount < maxRetries) {
+      rabbitPublishService.publishCojSignedEvent(pm, retryCount + 1);
+    } else {
+      log.warn("Retry limit reached, failed to send message for programme membership id : '{}'",
+          pm.getTisId());
+    }
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/config/SchedulePublishRetryConfig.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/SchedulePublishRetryConfig.java
@@ -26,6 +26,7 @@ import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.Collection;
@@ -36,6 +37,7 @@ import uk.nhs.hee.trainee.details.service.RabbitPublishService;
 
 @Slf4j
 @Configuration
+@EnableScheduling
 public class SchedulePublishRetryConfig {
 
   private final RabbitTemplate rabbitTemplate;

--- a/src/main/java/uk/nhs/hee/trainee/details/model/RetryCorrelationData.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/RetryCorrelationData.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2023 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,21 +19,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details;
+package uk.nhs.hee.trainee.details.model;
 
-import io.mongock.runner.springboot.EnableMongock;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
 
-@EnableMongock
-@SpringBootApplication
-@ConfigurationPropertiesScan
-@EnableScheduling
-public class TisTraineeDetailsApplication {
+/**
+ * Extends the CorrelationData class with a retry count to allow a sensible number of retries for
+ * nack'd messages.
+ */
+public class RetryCorrelationData extends CorrelationData {
 
-  public static void main(String[] args) {
-    SpringApplication.run(TisTraineeDetailsApplication.class);
+  private final int retryCount;
+
+  public RetryCorrelationData(String id, int retryCount) {
+    super(id);
+    this.retryCount = retryCount;
+  }
+
+  public int getRetryCount() {
+    return retryCount;
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/RabbitPublishService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/RabbitPublishService.java
@@ -71,6 +71,13 @@ public class RabbitPublishService {
     });
   }
 
+  /**
+   * Manage the collections of nacked and unconfirmed messages based on Rabbit message
+   * acknowledgements.
+   *
+   * @param isAck                was the message acknowledged (success) or not (failure).
+   * @param retryCorrelationData message correlation details to match to cached entries.
+   */
   void handleRabbitAcknowledgement(boolean isAck, RetryCorrelationData retryCorrelationData) {
     final String id = retryCorrelationData.getId();
     if (!isAck) {
@@ -112,12 +119,23 @@ public class RabbitPublishService {
     rabbitTemplate.convertAndSend(rabbitExchange, routingKey, event, correlationData);
   }
 
+  /**
+   * Remove a cached outstanding confirm message (if it has been successfully processed).
+   *
+   * @param id the message id.
+   * @return the queued programme membership.
+   */
   public ProgrammeMembership cleanOutstandingConfirm(String id) {
     // remove the data from outstandingConfirms
     // created as public method for usage in other retry schedulers as well.
     return outstandingConfirms.remove(id);
   }
 
+  /**
+   * Get the queue of nacked messages.
+   *
+   * @return the queue of nacked messages.
+   */
   public Queue<RetryCorrelationData> getNegativeAckedMessages() {
     return negativeAckedMessages;
   }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/RabbitPublishService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/RabbitPublishService.java
@@ -22,8 +22,8 @@
 package uk.nhs.hee.trainee.details.service;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
-import java.util.UUID;
 import java.util.Queue;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import javax.annotation.PostConstruct;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,8 @@ spring:
     username: ${TRAINEE_DETAILS_RABBITMQ_USERNAME}
     password: ${TRAINEE_DETAILS_RABBITMQ_PASSWORD}
     ssl.enabled: ${TRAINEE_DETAILS_RABBITMQ_USE_SSL}
+    publisher-confirm-type: correlated
+    max-retries: 50
 
 logging:
   level:

--- a/src/test/java/uk/nhs/hee/trainee/details/config/SchedulePublishRetryConfigTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/SchedulePublishRetryConfigTest.java
@@ -42,7 +42,7 @@ import uk.nhs.hee.trainee.details.model.RetryCorrelationData;
 import uk.nhs.hee.trainee.details.service.RabbitPublishService;
 
 class SchedulePublishRetryConfigTest {
-  private final int MAX_RETRIES = 3;
+  private static final int MAX_RETRIES = 3;
 
   @Mock
   RabbitPublishService rabbitPublishServiceMock;

--- a/src/test/java/uk/nhs/hee/trainee/details/config/SchedulePublishRetryConfigTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/SchedulePublishRetryConfigTest.java
@@ -1,0 +1,142 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.amqp.rabbit.connection.CorrelationData;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
+import uk.nhs.hee.trainee.details.model.RetryCorrelationData;
+import uk.nhs.hee.trainee.details.service.RabbitPublishService;
+
+class SchedulePublishRetryConfigTest {
+  private final int MAX_RETRIES = 3;
+
+  @Mock
+  RabbitPublishService rabbitPublishServiceMock;
+  @Mock
+  RabbitTemplate rabbitTemplateMock;
+
+  private SchedulePublishRetryConfig schedulePublishRetryConfig;
+
+  @BeforeEach
+  void setUp() {
+    rabbitTemplateMock = Mockito.mock(RabbitTemplate.class);
+    rabbitPublishServiceMock = Mockito.mock(RabbitPublishService.class);
+    schedulePublishRetryConfig = new SchedulePublishRetryConfig(rabbitTemplateMock,
+        rabbitPublishServiceMock, MAX_RETRIES);
+  }
+
+  @Test
+  void shouldRepublishNackedMessage() {
+    int retryCount = 1;
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId("123");
+
+    ConcurrentLinkedQueue<RetryCorrelationData> negativeAckedMessages
+        = new ConcurrentLinkedQueue<>();
+    RetryCorrelationData retryCorrelationData
+        = new RetryCorrelationData(programmeMembership.getTisId(), retryCount);
+    negativeAckedMessages.add(retryCorrelationData);
+    when(rabbitPublishServiceMock.getNegativeAckedMessages())
+        .thenReturn(negativeAckedMessages);
+    when(rabbitPublishServiceMock.cleanOutstandingConfirm("123"))
+        .thenReturn(programmeMembership);
+
+    schedulePublishRetryConfig.scheduleNackedRepublishTask();
+
+    verify(rabbitPublishServiceMock)
+        .publishCojSignedEvent(programmeMembership, retryCount + 1);
+  }
+
+  @Test
+  void shouldNotRepublishMessageWithTooManyRetries() {
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId("123");
+
+    ConcurrentLinkedQueue<RetryCorrelationData> negativeAckedMessages
+        = new ConcurrentLinkedQueue<>();
+    RetryCorrelationData retryCorrelationData
+        = new RetryCorrelationData(programmeMembership.getTisId(), MAX_RETRIES);
+    negativeAckedMessages.add(retryCorrelationData);
+    when(rabbitPublishServiceMock.getNegativeAckedMessages())
+        .thenReturn(negativeAckedMessages);
+    when(rabbitPublishServiceMock.cleanOutstandingConfirm("123"))
+        .thenReturn(programmeMembership);
+
+    schedulePublishRetryConfig.scheduleNackedRepublishTask();
+
+    verify(rabbitPublishServiceMock, never()).publishCojSignedEvent(any(), anyInt());
+  }
+
+  @Test
+  void shouldNotRepublishNackedMessageIfNotInQueue() {
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId("123");
+
+    ConcurrentLinkedQueue<RetryCorrelationData> negativeAckedMessages
+        = new ConcurrentLinkedQueue<>();
+    RetryCorrelationData retryCorrelationData
+        = new RetryCorrelationData(programmeMembership.getTisId(), MAX_RETRIES);
+    negativeAckedMessages.add(retryCorrelationData);
+    when(rabbitPublishServiceMock.getNegativeAckedMessages())
+        .thenReturn(negativeAckedMessages);
+    when(rabbitPublishServiceMock.cleanOutstandingConfirm("123"))
+        .thenReturn(null);
+
+    schedulePublishRetryConfig.scheduleNackedRepublishTask();
+
+    verify(rabbitPublishServiceMock, never()).publishCojSignedEvent(any(), anyInt());
+  }
+
+  @Test
+  void shouldRepublishUnconfirmedMessage() {
+    int retryCount = 1;
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId("123");
+    RetryCorrelationData unconfirmedCorrelationData
+        = new RetryCorrelationData(programmeMembership.getTisId(), retryCount);
+    Collection<CorrelationData> unconfirmed = Collections.singletonList(unconfirmedCorrelationData);
+
+    when(rabbitTemplateMock.getUnconfirmed(anyLong())).thenReturn(unconfirmed);
+    when(rabbitPublishServiceMock.cleanOutstandingConfirm("123"))
+        .thenReturn(programmeMembership);
+
+    schedulePublishRetryConfig.scheduleUnconfirmedRepublishTask();
+
+    verify(rabbitPublishServiceMock)
+        .publishCojSignedEvent(programmeMembership, retryCount + 1);
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/service/RabbitPublishServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/RabbitPublishServiceTest.java
@@ -36,7 +36,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import uk.nhs.hee.trainee.details.dto.enumeration.GoldGuideVersion;
 import uk.nhs.hee.trainee.details.event.CojSignedEvent;
@@ -167,7 +166,8 @@ class RabbitPublishServiceTest {
 
     rabbitPublishService.handleRabbitAcknowledgement(true, retryCorrelationData);
 
-    assertThat("Unexpected outstanding confirms", rabbitPublishService.outstandingConfirms.size(), is(0));
+    assertThat("Unexpected outstanding confirms",
+        rabbitPublishService.outstandingConfirms.size(), is(0));
   }
 
   @Test
@@ -181,7 +181,8 @@ class RabbitPublishServiceTest {
 
     rabbitPublishService.handleRabbitAcknowledgement(false, retryCorrelationData);
 
-    assertThat("Unexpected outstanding confirms", rabbitPublishService.outstandingConfirms.size(), is(1));
+    assertThat("Unexpected outstanding confirms",
+        rabbitPublishService.outstandingConfirms.size(), is(1));
   }
 
   @Test
@@ -196,7 +197,8 @@ class RabbitPublishServiceTest {
     assertThat("Unexpected nacked queue",
         rabbitPublishService.negativeAckedMessages.size(), is(1));
 
-    Queue<RetryCorrelationData> retryCorrelationDataQueue = rabbitPublishService.getNegativeAckedMessages();
+    Queue<RetryCorrelationData> retryCorrelationDataQueue
+        = rabbitPublishService.getNegativeAckedMessages();
     assertThat("Unexpected nacked queue element retry count",
         retryCorrelationDataQueue.remove().getRetryCount(), is(1));
   }


### PR DESCRIPTION
WIP. This might be considered overkill (we could simply log failed CoJ messages to handle manually I guess). Largely based on https://developers.ascendcorp.com/reliable-publishing-to-rabbitmq-with-spring-amqp-d2f3e81275e7 


Output if exchange is deleted from rabbit:

```
2023-08-08 14:20:59.069  INFO 33168 --- [   scheduling-1] u.n.h.t.d.service.RabbitPublishService   : Sending CoJ signed event for programme membership id 'eb6fec7f-d83d-11ec-9eb2-0638a616fc76' [retry 0]
2023-08-08 14:20:59.080 ERROR 33168 --- [168.178.55:5672] o.s.a.r.c.CachingConnectionFactory       : Shutdown Signal: channel error; protocol method: #method<channel.close>(reply-code=404, reply-text=NOT_FOUND - no exchange 'trainee.exchange.coj.signed' in vhost '/', class-id=60, method-id=40)
2023-08-08 14:20:59.080  INFO 33168 --- [nectionFactory2] u.n.h.t.d.service.RabbitPublishService   : Rabbit message for programme membership id 'eb6fec7f-d83d-11ec-9eb2-0638a616fc76' got nack-ed, saving to nack-ed message queue for retry
```
...
```
2023-08-08 14:21:09.086  INFO 33168 --- [   scheduling-1] u.n.h.t.d.c.SchedulePublishRetryConfig   : Retry nack-ed Rabbit message : eb6fec7f-d83d-11ec-9eb2-0638a616fc76
2023-08-08 14:21:09.086  WARN 33168 --- [   scheduling-1] u.n.h.t.d.c.SchedulePublishRetryConfig   : Retry counter limit reached, failed to send message for programme membership : eb6fec7f-d83d-11ec-9eb2-0638a616fc76
```

TIS21-4925
TIS21-4911