### PR TITLE
feat: add Other Sites to placement records

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.28.1"
+version = "0.29.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/SiteDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/SiteDto.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2023 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,34 +21,21 @@
 
 package uk.nhs.hee.trainee.details.dto;
 
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import java.time.LocalDate;
-import java.util.Set;
-import javax.validation.constraints.NotNull;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
-import uk.nhs.hee.trainee.details.dto.enumeration.Status;
-import uk.nhs.hee.trainee.details.dto.signature.Signature;
-import uk.nhs.hee.trainee.details.dto.signature.SignedDto;
 
 /**
- * A DTO for placement information.
+ * A DTO representing TIS site data.
  */
 @Data
-public class PlacementDto implements SignedDto {
+public class SiteDto {
 
-  @NotNull
-  private String tisId;
-  private LocalDate startDate;
-  private LocalDate endDate;
-  @JsonUnwrapped
-  private SiteDto site;
-  private Set<SiteDto> otherSites;
-  private String grade;
-  private String specialty;
-  private String placementType;
-  private String employingBody;
-  private String trainingBody;
-  private String wholeTimeEquivalent;
-  private Status status;
-  private Signature signature;
+  @JsonProperty("site")
+  private String name;
+
+  @JsonProperty("siteKnownAs")
+  private String knownAs;
+
+  @JsonProperty("siteLocation")
+  private String location;
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/model/Placement.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/Placement.java
@@ -22,7 +22,10 @@
 package uk.nhs.hee.trainee.details.model;
 
 import java.time.LocalDate;
+import java.util.Set;
 import lombok.Data;
+import org.springframework.data.mongodb.core.mapping.Unwrapped;
+import org.springframework.data.mongodb.core.mapping.Unwrapped.OnEmpty;
 import uk.nhs.hee.trainee.details.dto.enumeration.Status;
 
 @Data
@@ -31,9 +34,9 @@ public class Placement {
   private String tisId;
   private LocalDate startDate;
   private LocalDate endDate;
-  private String site;
-  private String siteLocation;
-  private String siteKnownAs;
+  @Unwrapped(onEmpty = OnEmpty.USE_NULL)
+  private Site site;
+  private Set<Site> otherSites;
   private String grade;
   private String specialty;
   private String placementType;

--- a/src/main/java/uk/nhs/hee/trainee/details/model/Site.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/Site.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2023 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,36 +19,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.dto;
+package uk.nhs.hee.trainee.details.model;
 
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import java.time.LocalDate;
-import java.util.Set;
-import javax.validation.constraints.NotNull;
 import lombok.Data;
-import uk.nhs.hee.trainee.details.dto.enumeration.Status;
-import uk.nhs.hee.trainee.details.dto.signature.Signature;
-import uk.nhs.hee.trainee.details.dto.signature.SignedDto;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 /**
- * A DTO for placement information.
+ * An entity representing site data.
  */
 @Data
-public class PlacementDto implements SignedDto {
+public class Site {
 
-  @NotNull
-  private String tisId;
-  private LocalDate startDate;
-  private LocalDate endDate;
-  @JsonUnwrapped
-  private SiteDto site;
-  private Set<SiteDto> otherSites;
-  private String grade;
-  private String specialty;
-  private String placementType;
-  private String employingBody;
-  private String trainingBody;
-  private String wholeTimeEquivalent;
-  private Status status;
-  private Signature signature;
+  @Field("site")
+  private String name;
+
+  @Field("siteKnownAs")
+  private String knownAs;
+
+  @Field("siteLocation")
+  private String location;
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/api/PlacementResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/PlacementResourceTest.java
@@ -58,6 +58,7 @@ import uk.nhs.hee.trainee.details.mapper.PlacementMapper;
 import uk.nhs.hee.trainee.details.mapper.PlacementMapperImpl;
 import uk.nhs.hee.trainee.details.mapper.SignatureMapperImpl;
 import uk.nhs.hee.trainee.details.model.Placement;
+import uk.nhs.hee.trainee.details.model.Site;
 import uk.nhs.hee.trainee.details.service.PlacementService;
 import uk.nhs.hee.trainee.details.service.SignatureService;
 
@@ -124,13 +125,16 @@ class PlacementResourceTest {
     placement.setTisId("tisIdValue");
     placement.setStartDate(start);
     placement.setEndDate(end);
-    placement.setSite("siteValue");
-    placement.setSiteLocation("siteLocationValue");
-    placement.setSiteKnownAs("siteKnownAsValue");
     placement.setGrade("gradeValue");
     placement.setSpecialty("specialtyValue");
     placement.setPlacementType("placementTypeValue");
     placement.setStatus(Status.CURRENT);
+
+    Site site = new Site();
+    site.setName("siteValue");
+    site.setKnownAs("siteKnownAsValue");
+    site.setLocation("siteLocationValue");
+    placement.setSite(site);
 
     when(service.updatePlacementForTrainee(eq("40"), any(Placement.class)))
         .thenReturn(Optional.of(placement));

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -66,6 +66,7 @@ import uk.nhs.hee.trainee.details.model.Curriculum;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.model.Placement;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
+import uk.nhs.hee.trainee.details.model.Site;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.service.SignatureService;
 import uk.nhs.hee.trainee.details.service.TraineeProfileService;
@@ -222,8 +223,11 @@ class TraineeProfileResourceTest {
   void setupPlacementData() {
     placement = new Placement();
     placement.setTisId(PLACEMENT_TISID);
-    placement.setSite(PLACEMENT_SITE);
     placement.setStatus(PLACEMENT_STATUS);
+
+    Site site = new Site();
+    site.setName(PLACEMENT_SITE);
+    placement.setSite(site);
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PlacementServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PlacementServiceTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,6 +36,7 @@ import org.mapstruct.factory.Mappers;
 import uk.nhs.hee.trainee.details.dto.enumeration.Status;
 import uk.nhs.hee.trainee.details.mapper.PlacementMapper;
 import uk.nhs.hee.trainee.details.model.Placement;
+import uk.nhs.hee.trainee.details.model.Site;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 
@@ -93,13 +93,16 @@ class PlacementServiceTest {
     expectedPlacement.setTisId(NEW_PLACEMENT_ID);
     expectedPlacement.setStartDate(START_DATE.plusDays(100));
     expectedPlacement.setEndDate(END_DATE.plusDays(100));
-    expectedPlacement.setSite(SITE + MODIFIED_SUFFIX);
-    expectedPlacement.setSiteLocation(SITE_LOCATION + MODIFIED_SUFFIX);
-    expectedPlacement.setSiteKnownAs(SITE_KNOWN_AS + MODIFIED_SUFFIX);
     expectedPlacement.setGrade(GRADE);
     expectedPlacement.setSpecialty(SPECIALTY);
     expectedPlacement.setPlacementType(PLACEMENT_TYPE);
     expectedPlacement.setStatus(Status.CURRENT);
+
+    Site site = new Site();
+    site.setName(SITE + MODIFIED_SUFFIX);
+    site.setKnownAs(SITE_KNOWN_AS + MODIFIED_SUFFIX);
+    site.setLocation(SITE_LOCATION + MODIFIED_SUFFIX);
+    expectedPlacement.setSite(site);
 
     assertThat("Unexpected placement.", placement.get(), is(expectedPlacement));
   }
@@ -122,13 +125,16 @@ class PlacementServiceTest {
     expectedPlacement.setTisId(NEW_PLACEMENT_ID);
     expectedPlacement.setStartDate(START_DATE.plusDays(100));
     expectedPlacement.setEndDate(END_DATE.plusDays(100));
-    expectedPlacement.setSite(SITE + MODIFIED_SUFFIX);
-    expectedPlacement.setSiteLocation(SITE_LOCATION + MODIFIED_SUFFIX);
-    expectedPlacement.setSiteKnownAs(SITE_KNOWN_AS + MODIFIED_SUFFIX);
     expectedPlacement.setGrade(GRADE);
     expectedPlacement.setSpecialty(SPECIALTY);
     expectedPlacement.setPlacementType(PLACEMENT_TYPE);
     expectedPlacement.setStatus(Status.CURRENT);
+
+    Site site = new Site();
+    site.setName(SITE + MODIFIED_SUFFIX);
+    site.setKnownAs(SITE_KNOWN_AS + MODIFIED_SUFFIX);
+    site.setLocation(SITE_LOCATION + MODIFIED_SUFFIX);
+    expectedPlacement.setSite(site);
 
     assertThat("Unexpected placement.", placement.get(), is(expectedPlacement));
   }
@@ -152,13 +158,16 @@ class PlacementServiceTest {
     expectedPlacement.setTisId(EXISTING_PLACEMENT_ID);
     expectedPlacement.setStartDate(START_DATE.plusDays(100));
     expectedPlacement.setEndDate(END_DATE.plusDays(100));
-    expectedPlacement.setSite(SITE + MODIFIED_SUFFIX);
-    expectedPlacement.setSiteLocation(SITE_LOCATION + MODIFIED_SUFFIX);
-    expectedPlacement.setSiteKnownAs(SITE_KNOWN_AS + MODIFIED_SUFFIX);
     expectedPlacement.setGrade(GRADE);
     expectedPlacement.setSpecialty(SPECIALTY);
     expectedPlacement.setPlacementType(PLACEMENT_TYPE);
     expectedPlacement.setStatus(Status.CURRENT);
+
+    Site site = new Site();
+    site.setName(SITE + MODIFIED_SUFFIX);
+    site.setKnownAs(SITE_KNOWN_AS + MODIFIED_SUFFIX);
+    site.setLocation(SITE_LOCATION + MODIFIED_SUFFIX);
+    expectedPlacement.setSite(site);
 
     assertThat("Unexpected placement.", placement.get(), is(expectedPlacement));
   }
@@ -216,13 +225,16 @@ class PlacementServiceTest {
     placement.setTisId(tisId);
     placement.setStartDate(START_DATE.plusDays(dateAdjustmentDays));
     placement.setEndDate(END_DATE.plusDays(dateAdjustmentDays));
-    placement.setSite(SITE + stringSuffix);
-    placement.setSiteLocation(SITE_LOCATION + stringSuffix);
-    placement.setSiteKnownAs(SITE_KNOWN_AS + stringSuffix);
     placement.setGrade(GRADE);
     placement.setSpecialty(SPECIALTY);
     placement.setPlacementType(PLACEMENT_TYPE);
     placement.setStatus(Status.CURRENT);
+
+    Site site = new Site();
+    site.setName(SITE + stringSuffix);
+    site.setKnownAs(SITE_KNOWN_AS + stringSuffix);
+    site.setLocation(SITE_LOCATION + stringSuffix);
+    placement.setSite(site);
 
     return placement;
   }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -56,6 +56,7 @@ import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.model.Placement;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 import uk.nhs.hee.trainee.details.model.Qualification;
+import uk.nhs.hee.trainee.details.model.Site;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 
@@ -201,13 +202,19 @@ class TraineeProfileServiceTest {
   void setupPlacementData() {
     placement1 = new Placement();
     placement1.setTisId(PLACEMENT_TISID1);
-    placement1.setSite(PLACEMENT_SITE1);
     placement1.setStatus(PLACEMENT_STATUS1);
+
+    Site site1 = new Site();
+    site1.setName(PLACEMENT_SITE1);
+    placement1.setSite(site1);
 
     placement2 = new Placement();
     placement2.setTisId(PLACEMENT_TISID2);
-    placement2.setSite(PLACEMENT_SITE2);
     placement2.setStatus(PLACEMENT_STATUS2);
+
+    Site site2 = new Site();
+    site2.setName(PLACEMENT_SITE2);
+    placement2.setSite(site2);
   }
 
   @Test


### PR DESCRIPTION
Create a Site entity and SiteDto to standardize the fields used to represent sites.
Update the existing Placement entity and PlacementDto to include a collectioin of Other Sites as well as use the Site entity/dto for the existing site fields. Those existing fields will be unwrapped automatically so that the existing DTO/DB structures are unchanged.

TIS21-4970
TIS21-4396