### PR TITLE
feat: migrator delete old programme memberships

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "0.31.0"
+version = "0.32.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/migration/DeleteDuplicateTraineeProfileProgrammeMemberships.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/migration/DeleteDuplicateTraineeProfileProgrammeMemberships.java
@@ -57,7 +57,8 @@ public class DeleteDuplicateTraineeProfileProgrammeMemberships {
       UpdateResult result = mongoTemplate.updateMulti(new Query(), update, PROFILE_COLLECTION);
       log.info("Duplicate programme memberships deleted on {} trainees", result.getModifiedCount());
     } catch (MongoException me) {
-      log.error("Unable to delete duplicate programme memberships due to an error: {} ", me.toString());
+      log.error("Unable to delete duplicate programme memberships due to an error: {} ",
+          me.toString());
     }
   }
 
@@ -67,6 +68,6 @@ public class DeleteDuplicateTraineeProfileProgrammeMemberships {
   @RollbackExecution
   public void rollback() {
     log.warn("Rollback requested but not available "
-        + "for 'deleteDuplicateTraineeProfilePlacements' migration.");
+        + "for 'deleteDuplicateTraineeProfileProgrammeMemberships' migration.");
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/migration/DeleteDuplicateTraineeProfileProgrammeMemberships.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/migration/DeleteDuplicateTraineeProfileProgrammeMemberships.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.migration;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.MongoException;
+import com.mongodb.client.result.UpdateResult;
+import io.mongock.api.annotations.ChangeUnit;
+import io.mongock.api.annotations.Execution;
+import io.mongock.api.annotations.RollbackExecution;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+/**
+ * Delete duplicated trainee profile programme memberships caused by non-UUID keys.
+ */
+@Slf4j
+@ChangeUnit(id = "deleteDuplicateTraineeProfileProgrammeMemberships", order = "3")
+public class DeleteDuplicateTraineeProfileProgrammeMemberships {
+  private static final String PROFILE_COLLECTION = "TraineeProfile";
+  private final MongoTemplate mongoTemplate;
+
+  public DeleteDuplicateTraineeProfileProgrammeMemberships(MongoTemplate mongoTemplate) {
+    this.mongoTemplate = mongoTemplate;
+  }
+
+  /**
+   * Remove Trainee Profile Programme Memberships with a generated ID.
+   */
+  @Execution
+  public void migrate() {
+    Update update =
+        new Update().pull("programmeMemberships",
+            new BasicDBObject("tisId", new BasicDBObject("$regex", "^[\\d,]*$")));
+    try {
+      UpdateResult result = mongoTemplate.updateMulti(new Query(), update, PROFILE_COLLECTION);
+      log.info("Duplicate programme memberships deleted on {} trainees", result.getModifiedCount());
+    } catch (MongoException me) {
+      log.error("Unable to delete duplicate programme memberships due to an error: {} ", me.toString());
+    }
+  }
+
+  /**
+   * Do not attempt rollback, the collection should be left as-is.
+   */
+  @RollbackExecution
+  public void rollback() {
+    log.warn("Rollback requested but not available "
+        + "for 'deleteDuplicateTraineeProfilePlacements' migration.");
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/migration/DeleteDuplicateTraineeProfileProgrammeMembershipsTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/migration/DeleteDuplicateTraineeProfileProgrammeMembershipsTest.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2023 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.migration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.mongodb.BasicDBObject;
+import com.mongodb.MongoException;
+import com.mongodb.client.result.UpdateResult;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+
+class DeleteDuplicateTraineeProfileProgrammeMembershipsTest {
+  private static final String PROFILE_COLLECTION = "TraineeProfile";
+  private DeleteDuplicateTraineeProfileProgrammeMemberships migration;
+  private MongoTemplate template;
+
+  @BeforeEach
+  void setUp() {
+    template = mock(MongoTemplate.class);
+    migration = new DeleteDuplicateTraineeProfileProgrammeMemberships(template);
+  }
+
+  @Test
+  void shouldDeleteDuplicateTraineeProfileProgrammeMemberships() {
+    final Update update =
+        new Update().pull("programmeMemberships",
+            new BasicDBObject("tisId", new BasicDBObject("$regex", "^[\\d,]*$")));
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
+    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+    UpdateResult result = mock(UpdateResult.class);
+
+    when(template.updateMulti(
+        queryCaptor.capture(),
+        updateCaptor.capture(),
+        eq(PROFILE_COLLECTION)))
+        .thenReturn(result);
+    when(result.getModifiedCount()).thenReturn(1L);
+
+    migration.migrate();
+
+    Query queryUsed = queryCaptor.getValue();
+    assertThat("Unexpected query.", queryUsed, is(new Query()));
+    Update updateUsed = updateCaptor.getValue();
+    assertThat("Unexpected programme membership deletion", updateUsed, is(update));
+  }
+
+  @Test
+  void shouldCatchMongoExceptionNotThrowIt() {
+    when(template.updateMulti(any(), any(), (String) any()))
+        .thenThrow(new MongoException("exception"));
+    Assertions.assertDoesNotThrow(() -> migration.migrate());
+  }
+
+  @Test
+  void shouldNotAttemptRollback() {
+    migration.rollback();
+    verifyNoInteractions(template);
+  }
+}


### PR DESCRIPTION
Dependent on
https://github.com/Health-Education-England/tis-trainee-details/pull/380 merged, TIS CoJ DMS redrive and checks on all UUID-style PMs CoJs having receivedFromTis set.

TIS21-4715