### PR TITLE
build: prepare for kotlin DSL migration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
   id "java"
-  id "org.springframework.boot" version "2.7.5"
-  id "io.spring.dependency-management" version "1.1.3"
+  id("org.springframework.boot") version "2.7.5"
+  id("io.spring.dependency-management") version "1.1.3"
 
   // Code Quality
   id "checkstyle"
   id "jacoco"
-  id "org.sonarqube" version "4.4.0.3356"
+  id("org.sonarqube") version "4.4.0.3356"
 }
 
 group = "uk.nhs.hee.trainee.details"
@@ -14,7 +14,7 @@ version = "0.33.1"
 
 configurations {
   compileOnly {
-    extendsFrom annotationProcessor
+    extendsFrom(annotationProcessor)
   }
 }
 
@@ -24,79 +24,79 @@ repositories {
 
 dependencyManagement {
   imports {
-    mavenBom "org.springframework.cloud:spring-cloud-dependencies:2021.0.7"
-    mavenBom "io.awspring.cloud:spring-cloud-aws-dependencies:2.4.4"
+    mavenBom("org.springframework.cloud:spring-cloud-dependencies:2021.0.7")
+    mavenBom("io.awspring.cloud:spring-cloud-aws-dependencies:2.4.4")
   }
 }
 
 dependencies {
   // Spring Boot
-  implementation "org.springframework.boot:spring-boot-starter-data-redis"
-  implementation "org.springframework.boot:spring-boot-starter-data-mongodb"
-  implementation "org.springframework.boot:spring-boot-starter-web"
-  implementation "org.springframework.boot:spring-boot-starter-actuator"
-  implementation "org.springframework.boot:spring-boot-starter-validation"
+  implementation("org.springframework.boot:spring-boot-starter-data-redis")
+  implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
+  implementation("org.springframework.boot:spring-boot-starter-web")
+  implementation("org.springframework.boot:spring-boot-starter-actuator")
+  implementation("org.springframework.boot:spring-boot-starter-validation")
 
-  testImplementation "org.springframework.boot:spring-boot-starter-test"
-  testImplementation "org.springframework.cloud:spring-cloud-starter-bootstrap"
-  testImplementation "com.playtika.testcontainers:embedded-redis:3.0.6"
-  testImplementation "org.testcontainers:junit-jupiter:1.19.3"
+  testImplementation("org.springframework.boot:spring-boot-starter-test")
+  testImplementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
+  testImplementation("com.playtika.testcontainers:embedded-redis:3.0.6")
+  testImplementation("org.testcontainers:junit-jupiter:1.19.3")
 
   // Lombok
-  compileOnly "org.projectlombok:lombok"
-  annotationProcessor "org.projectlombok:lombok"
+  compileOnly("org.projectlombok:lombok")
+  annotationProcessor("org.projectlombok:lombok")
 
   // Mapstruct
   ext.mapstructVersion = "1.5.5.Final"
-  implementation "org.mapstruct:mapstruct:${mapstructVersion}"
-  annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+  implementation("org.mapstruct:mapstruct:${mapstructVersion}")
+  annotationProcessor("org.mapstruct:mapstruct-processor:${mapstructVersion}")
 
   ext.mongockVersion = "5.3.4"
-  implementation "io.mongock:mongock-springboot:${mongockVersion}"
-  implementation "io.mongock:mongodb-springdata-v3-driver:${mongockVersion}"
+  implementation("io.mongock:mongock-springboot:${mongockVersion}")
+  implementation("io.mongock:mongodb-springdata-v3-driver:${mongockVersion}")
 
   // Sentry reporting
-  implementation "io.sentry:sentry-spring-boot-starter:6.32.0"
+  implementation("io.sentry:sentry-spring-boot-starter:6.32.0")
 
   // Amazon AWS
-  implementation "io.awspring.cloud:spring-cloud-starter-aws-messaging"
-  implementation "com.amazonaws:aws-xray-recorder-sdk-spring:2.14.0"
+  implementation("io.awspring.cloud:spring-cloud-starter-aws-messaging")
+  implementation("com.amazonaws:aws-xray-recorder-sdk-spring:2.14.0")
 
   // Rabbit MQ
-  implementation "org.springframework.boot:spring-boot-starter-amqp"
+  implementation("org.springframework.boot:spring-boot-starter-amqp")
 }
 
 checkstyle {
   config = resources.text.fromArchiveEntry(configurations.checkstyle[0], "google_checks.xml")
 }
 
-jacocoTestReport {
+tasks.jacocoTestReport {
   reports {
-    html.required = true
-    xml.required = true
+    html.required.set(true)
+    xml.required.set(true)
   }
 }
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
-    vendor = JvmVendorSpec.ADOPTIUM
+    languageVersion.set(JavaLanguageVersion.of(17))
+    vendor.set(JvmVendorSpec.ADOPTIUM)
   }
 }
 
 sonarqube {
   properties {
-    property "sonar.host.url", "https://sonarcloud.io"
-    property "sonar.login", System.getenv("SONAR_TOKEN")
-    property "sonar.organization", "health-education-england"
-    property "sonar.projectKey", "Health-Education-England_TIS-TRAINEE-DETAILS"
+    property("sonar.host.url", "https://sonarcloud.io")
+    property("sonar.login", System.getenv("SONAR_TOKEN"))
+    property("sonar.organization", "health-education-england")
+    property("sonar.projectKey", "Health-Education-England_TIS-TRAINEE-DETAILS")
 
-    property "sonar.java.checkstyle.reportPaths",
-      "build/reports/checkstyle/main.xml,build/reports/checkstyle/test.xml"
+    property("sonar.java.checkstyle.reportPaths",
+      "build/reports/checkstyle/main.xml,build/reports/checkstyle/test.xml")
   }
 }
 
-test {
-  finalizedBy jacocoTestReport
+tasks.test {
+  finalizedBy(tasks.jacocoTestReport)
   useJUnitPlatform()
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'trainee-details'
+rootProject.name = "trainee-details"


### PR DESCRIPTION
Most of the changes required to migrate the build scripts to Kotlin DSL can be implemented up front and as supported in the Groovy DSL. Update the Gradle build script and settings to
 - Use `"` instead of `'`
 - Use parentheses for function calls
 - Exclude parentheses for core plugins, as these will be treated differently
 - Use `task` prefix to differentiate task config vs plugin config
 - Use `.set()` for some config known to use Kotlin `val`

TIS21-SHED