### PR TITLE
build: migrate Gradle to Kotlin DSL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
-  id "java"
+  java
   id("org.springframework.boot") version "2.7.5"
   id("io.spring.dependency-management") version "1.1.4"
 
   // Code Quality
-  id "checkstyle"
-  id "jacoco"
+  checkstyle
+  jacoco
   id("org.sonarqube") version "4.4.0.3356"
 }
 
@@ -14,7 +14,7 @@ version = "0.33.1"
 
 configurations {
   compileOnly {
-    extendsFrom(annotationProcessor)
+    extendsFrom(configurations.annotationProcessor.get())
   }
 }
 
@@ -47,11 +47,11 @@ dependencies {
   annotationProcessor("org.projectlombok:lombok")
 
   // Mapstruct
-  ext.mapstructVersion = "1.5.5.Final"
+  val mapstructVersion = "1.5.5.Final"
   implementation("org.mapstruct:mapstruct:${mapstructVersion}")
   annotationProcessor("org.mapstruct:mapstruct-processor:${mapstructVersion}")
 
-  ext.mongockVersion = "5.3.6"
+  val mongockVersion = "5.3.6"
   implementation("io.mongock:mongock-springboot:${mongockVersion}")
   implementation("io.mongock:mongodb-springdata-v3-driver:${mongockVersion}")
 
@@ -67,14 +67,7 @@ dependencies {
 }
 
 checkstyle {
-  config = resources.text.fromArchiveEntry(configurations.checkstyle[0], "google_checks.xml")
-}
-
-tasks.jacocoTestReport {
-  reports {
-    html.required.set(true)
-    xml.required.set(true)
-  }
+  config = resources.text.fromArchiveEntry(configurations.checkstyle.get().first(), "google_checks.xml")
 }
 
 java {
@@ -93,6 +86,13 @@ sonarqube {
 
     property("sonar.java.checkstyle.reportPaths",
       "build/reports/checkstyle/main.xml,build/reports/checkstyle/test.xml")
+  }
+}
+
+tasks.jacocoTestReport {
+  reports {
+    html.required.set(true)
+    xml.required.set(true)
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = "trainee-details"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "tis-trainee-details"


### PR DESCRIPTION
Kotlin DSL is now the default for Gradle, migrate the Groovy based build script to Kotlin.

TIS21-5521
TIS21-5523