### PR TITLE
feat: new starter API endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.0.1"
+version = "1.1.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
@@ -61,7 +61,7 @@ public class ProgrammeMembershipResource {
    * ProgrammeMembershipResource class constructor.
    */
   public ProgrammeMembershipResource(ProgrammeMembershipService service,
-         ProgrammeMembershipMapper mapper, RabbitPublishService rabbitPublishService) {
+       ProgrammeMembershipMapper mapper, RabbitPublishService rabbitPublishService) {
     this.service = service;
     this.mapper = mapper;
     this.rabbitPublishService = rabbitPublishService;

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
@@ -31,6 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -165,5 +166,20 @@ public class ProgrammeMembershipResource {
     rabbitPublishService.publishCojSignedEvent(entity);
 
     return ResponseEntity.ok(mapper.toDto(entity));
+  }
+
+  @GetMapping("/isnewstarter/{traineeTisId}/{programmeMembershipId}")
+  public ResponseEntity<Boolean> isNewStarter(
+      @PathVariable(name = "traineeTisId") String traineeTisId,
+      @PathVariable(name = "programmeMembershipId") String programmeMembershipId) {
+    log.info("Assess new starter status: programme membership {} of trainee with TIS ID {}",
+        programmeMembershipId, traineeTisId);
+    try {
+      boolean isNewStarter = service.isNewStarter(traineeTisId, programmeMembershipId);
+      return ResponseEntity.ok(isNewStarter);
+    } catch (IllegalArgumentException | InvalidDataAccessApiUsageException e) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getLocalizedMessage());
+      // other exceptions are possible, e.g. DataAccessException if MongoDB is down
+    }
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
@@ -61,7 +61,7 @@ public class ProgrammeMembershipResource {
    * ProgrammeMembershipResource class constructor.
    */
   public ProgrammeMembershipResource(ProgrammeMembershipService service,
-                                     ProgrammeMembershipMapper mapper, RabbitPublishService rabbitPublishService) {
+         ProgrammeMembershipMapper mapper, RabbitPublishService rabbitPublishService) {
     this.service = service;
     this.mapper = mapper;
     this.rabbitPublishService = rabbitPublishService;

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
@@ -61,7 +61,7 @@ public class ProgrammeMembershipResource {
    * ProgrammeMembershipResource class constructor.
    */
   public ProgrammeMembershipResource(ProgrammeMembershipService service,
-      ProgrammeMembershipMapper mapper, RabbitPublishService rabbitPublishService) {
+                                     ProgrammeMembershipMapper mapper, RabbitPublishService rabbitPublishService) {
     this.service = service;
     this.mapper = mapper;
     this.rabbitPublishService = rabbitPublishService;
@@ -168,6 +168,13 @@ public class ProgrammeMembershipResource {
     return ResponseEntity.ok(mapper.toDto(entity));
   }
 
+  /**
+   * Determine whether the given programme membership represents a 'new starter' event or not.
+   *
+   * @param traineeTisId          The ID of the trainee.
+   * @param programmeMembershipId The ID of the programme membership to assess.
+   * @return True if the programme membership is a new starter, otherwise false.
+   */
   @GetMapping("/isnewstarter/{traineeTisId}/{programmeMembershipId}")
   public ResponseEntity<Boolean> isNewStarter(
       @PathVariable(name = "traineeTisId") String traineeTisId,

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -25,7 +25,6 @@ import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -68,7 +67,7 @@ public class ProgrammeMembershipService {
    * @return The updated programme membership or empty if a trainee with the ID was not found.
    */
   public Optional<ProgrammeMembership> updateProgrammeMembershipForTrainee(String traineeTisId,
-                                                                           ProgrammeMembership programmeMembership) {
+         ProgrammeMembership programmeMembership) {
     TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
 
     if (traineeProfile == null) {
@@ -314,7 +313,7 @@ public class ProgrammeMembershipService {
             })
             .filter(pm ->
                 pm.getStartDate().isBefore(anchorPm.getStartDate())
-                //dates cannot be null because any offenders are removed in getRecentPrecedingPms()
+            //dates cannot be null because any offenders are removed in getRecentPrecedingPms()
             ).toList();
 
     List<String> anchorPmCurriculumSpecialties = anchorPm.getCurricula().stream()
@@ -355,7 +354,8 @@ public class ProgrammeMembershipService {
               if (pm.getEndDate() == null) {
                 return false;
               } else {
-                return pm.getEndDate().isAfter(anchorPm.getStartDate().minusDays(PROGRAMME_BREAK_DAYS));
+                return pm.getEndDate()
+                    .isAfter(anchorPm.getStartDate().minusDays(PROGRAMME_BREAK_DAYS));
               }
             }).toList();
   }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -256,15 +256,15 @@ public class ProgrammeMembershipService {
     //if there are no preceding PMs, it is a new starter
     List<ProgrammeMembership> precedingPms = getRecentPrecedingPms(programmeMembership, otherPms);
     if (precedingPms.isEmpty()) {
-      log.info("New starter: [true] there are no preceding programme memberships " +
-          "that ended within {} days", PROGRAMME_BREAK_DAYS);
+      log.info("New starter: [true] there are no preceding programme memberships "
+          + "that ended within {} days", PROGRAMME_BREAK_DAYS);
       return true;
     }
 
     //if none of the preceding PMs are intra-deanery transfer or rota PMs, it is a new starter
     List<ProgrammeMembership> intraOrRotaPms = getIntraOrRotaPms(programmeMembership, precedingPms);
     log.info("New starter: [{}] there are {} preceding intra-deanery / rota programme memberships ",
-        intraOrRotaPms.isEmpty()? "true" : "false", intraOrRotaPms.size());
+        intraOrRotaPms.isEmpty() ? "true" : "false", intraOrRotaPms.size());
     return intraOrRotaPms.isEmpty();
     //otherwise it is not a new starter
   }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -245,15 +245,16 @@ public class ProgrammeMembershipService {
         = pmsToConsider.stream()
         .filter(pm -> !pm.getTisId().equals(programmeMembershipId)).toList();
 
-    List<ProgrammeMembership> intraOrRotaPms = getIntraOrRotaPms(programmeMembership, otherPms);
+    //if there are no preceding PMs, it is a new starter
     List<ProgrammeMembership> precedingPms = getRecentPrecedingPms(programmeMembership, otherPms);
-
-    //if there are no intra-deanery transfer or rota PMs, or no preceding PM, it is a new starter
-    if (intraOrRotaPms.isEmpty() || precedingPms.isEmpty()) {
+    if (precedingPms.isEmpty()) {
       return true;
     }
-    //if the preceding PM is one of the intra-deanery or rota PMs, it is not a new starter
-    return !intraOrRotaPms.contains(precedingPms.get(0));
+
+    //if none of the preceding PMs are intra-deanery transfer or rota PMs, it is a new starter
+    List<ProgrammeMembership> intraOrRotaPms = getIntraOrRotaPms(programmeMembership, precedingPms);
+    return intraOrRotaPms.isEmpty();
+    //otherwise it is not a new starter
   }
 
   /**
@@ -342,7 +343,7 @@ public class ProgrammeMembershipService {
    * @param candidatePms The possible programme memberships.
    * @return The filtered list.
    */
-  List<ProgrammeMembership> getRecentPrecedingPms(ProgrammeMembership anchorPm,
+  private List<ProgrammeMembership> getRecentPrecedingPms(ProgrammeMembership anchorPm,
                                                   List<ProgrammeMembership> candidatePms) {
     List<ProgrammeMembership> precedingPms
         = new ArrayList<>(candidatePms.stream()

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -68,7 +68,7 @@ public class ProgrammeMembershipService {
    * @return The updated programme membership or empty if a trainee with the ID was not found.
    */
   public Optional<ProgrammeMembership> updateProgrammeMembershipForTrainee(String traineeTisId,
-                                                                           ProgrammeMembership programmeMembership) {
+         ProgrammeMembership programmeMembership) {
     TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
 
     if (traineeProfile == null) {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -68,7 +68,7 @@ public class ProgrammeMembershipService {
    * @return The updated programme membership or empty if a trainee with the ID was not found.
    */
   public Optional<ProgrammeMembership> updateProgrammeMembershipForTrainee(String traineeTisId,
-         ProgrammeMembership programmeMembership) {
+                                                                           ProgrammeMembership programmeMembership) {
     TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
 
     if (traineeProfile == null) {
@@ -312,13 +312,10 @@ public class ProgrammeMembershipService {
                 return pm.getManagingDeanery().equalsIgnoreCase(anchorPm.getManagingDeanery());
               }
             })
-            .filter(pm -> {
-              if (pm.getStartDate() == null || anchorPm.getStartDate() == null) {
-                return false;
-              } else {
-                return pm.getStartDate().isBefore(anchorPm.getStartDate());
-              }
-            }).toList();
+            .filter(pm ->
+                pm.getStartDate().isBefore(anchorPm.getStartDate())
+                //dates cannot be null because any offenders are removed in getRecentPrecedingPms()
+            ).toList();
 
     List<String> anchorPmCurriculumSpecialties = anchorPm.getCurricula().stream()
         .map(Curriculum::getCurriculumSpecialtyCode)
@@ -344,24 +341,22 @@ public class ProgrammeMembershipService {
    * @return The filtered list.
    */
   private List<ProgrammeMembership> getRecentPrecedingPms(ProgrammeMembership anchorPm,
-                                                  List<ProgrammeMembership> candidatePms) {
-    List<ProgrammeMembership> precedingPms
-        = new ArrayList<>(candidatePms.stream()
-        .filter(pm -> {
-          if (pm.getStartDate() == null || anchorPm.getStartDate() == null) {
-            return false;
-          } else {
-            return pm.getStartDate().isBefore(anchorPm.getStartDate());
-          }
-        })
-        .filter(pm -> {
-          if (pm.getEndDate() == null) {
-            return false;
-          } else {
-            return pm.getEndDate().isAfter(anchorPm.getStartDate().minusDays(PROGRAMME_BREAK_DAYS));
-          }
-        }).toList());
-    precedingPms.sort(Comparator.comparing(ProgrammeMembership::getStartDate).reversed());
-    return precedingPms;
+                                                          List<ProgrammeMembership> candidatePms) {
+    return
+        candidatePms.stream()
+            .filter(pm -> {
+              if (pm.getStartDate() == null || anchorPm.getStartDate() == null) {
+                return false;
+              } else {
+                return pm.getStartDate().isBefore(anchorPm.getStartDate());
+              }
+            })
+            .filter(pm -> {
+              if (pm.getEndDate() == null) {
+                return false;
+              } else {
+                return pm.getEndDate().isAfter(anchorPm.getStartDate().minusDays(PROGRAMME_BREAK_DAYS));
+              }
+            }).toList();
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
@@ -28,6 +28,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -314,5 +315,35 @@ class ProgrammeMembershipResourceTest {
             .value(is(GoldGuideVersion.GG9.toString())))
         .andExpect(jsonPath("$.conditionsOfJoining.syncedAt")
             .isEmpty());
+  }
+
+  @Test
+  void shouldReturnProgrammeMembershipNewStarterWhenTraineeFound() throws Exception {
+    when(service
+        .isNewStarter("40", "1"))
+        .thenReturn(true);
+
+    MvcResult result = mockMvc.perform(
+            get("/api/programme-membership/isnewstarter/{traineeTisId}/{programmeMembershipId}",
+                "40", "1")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andReturn();
+
+    Boolean resultBoolean = Boolean.parseBoolean(result.getResponse().getContentAsString());
+    assertThat("Unexpected result.", resultBoolean, is(true));
+  }
+
+  @Test
+  void shouldThrowBadRequestWhenProgrammeMembershipNewStarterException() throws Exception {
+    when(service
+        .isNewStarter("triggersError", "1"))
+        .thenThrow(new IllegalArgumentException());
+
+    mockMvc.perform(
+            get("/api/programme-membership/isnewstarter/{traineeTisId}/{programmeMembershipId}",
+                "triggersError", "1")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
@@ -43,6 +43,8 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -317,21 +319,21 @@ class ProgrammeMembershipResourceTest {
             .isEmpty());
   }
 
-  @Test
-  void shouldReturnProgrammeMembershipNewStarterWhenTraineeFound() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldReturnProgrammeMembershipNewStarterWhenTraineeFound(boolean isNewStarter)
+      throws Exception {
     when(service
         .isNewStarter("40", "1"))
-        .thenReturn(true);
+        .thenReturn(isNewStarter);
 
     MvcResult result = mockMvc.perform(
             get("/api/programme-membership/isnewstarter/{traineeTisId}/{programmeMembershipId}",
                 "40", "1")
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
+        .andExpect(content().string(String.valueOf(isNewStarter)))
         .andReturn();
-
-    Boolean resultBoolean = Boolean.parseBoolean(result.getResponse().getContentAsString());
-    assertThat("Unexpected result.", resultBoolean, is(true));
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -552,8 +552,8 @@ class ProgrammeMembershipServiceTest {
   void newStarterShouldBeFalseIfPmHasEnded(LocalDate endDate) {
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setProgrammeMemberships(
-        List.of(getProgrammeMembershipDefault(PROGRAMME_TIS_ID, PROGRAMME_MEMBERSHIP_TYPE, START_DATE,
-            endDate)));
+        List.of(getProgrammeMembershipDefault(PROGRAMME_TIS_ID, PROGRAMME_MEMBERSHIP_TYPE,
+            START_DATE, endDate)));
     when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
 
     boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -663,8 +663,6 @@ class ProgrammeMembershipServiceTest {
 
   @Test
   void newStarterShouldBeFalseIfPrecedingPmWithMultipleCurriculaIsIntraOrRota() {
-    List<ProgrammeMembership> pms
-        = new java.util.ArrayList<>(List.of(getProgrammeMembershipDefault()));
     //preceding PM with non-matching curriculum specialty code
     ProgrammeMembership rotaPm = getProgrammeMembershipWithOneCurriculum("another id",
         PROGRAMME_MEMBERSHIP_TYPE, START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 100),
@@ -675,6 +673,9 @@ class ProgrammeMembershipServiceTest {
     c2.setCurriculumSubType(MEDICAL_CURRICULA.get(0));
     c2.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     rotaPm.setCurricula(List.of(rotaPm.getCurricula().get(0), c2));
+
+    List<ProgrammeMembership> pms
+        = new java.util.ArrayList<>(List.of(getProgrammeMembershipDefault()));
     pms.add(rotaPm);
 
     TraineeProfile traineeProfile = new TraineeProfile();

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -33,6 +33,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.nhs.hee.trainee.details.service.ProgrammeMembershipService.MEDICAL_CURRICULA;
+import static uk.nhs.hee.trainee.details.service.ProgrammeMembershipService.NON_NEW_START_PROGRAMME_MEMBERSHIP_TYPES;
+import static uk.nhs.hee.trainee.details.service.ProgrammeMembershipService.PROGRAMME_BREAK_DAYS;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -40,12 +43,19 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import uk.nhs.hee.trainee.details.dto.enumeration.GoldGuideVersion;
 import uk.nhs.hee.trainee.details.mapper.ProgrammeMembershipMapperImpl;
 import uk.nhs.hee.trainee.details.model.ConditionsOfJoining;
+import uk.nhs.hee.trainee.details.model.Curriculum;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
@@ -69,6 +79,7 @@ class ProgrammeMembershipServiceTest {
   private static final Instant COJ_SIGNED_AT = Instant.now();
   private static final GoldGuideVersion GOLD_GUIDE_VERSION = GoldGuideVersion.GG9;
   private static final Instant COJ_SYNCED_AT = Instant.now();
+  private static final String CURRICULUM_SPECIALTY_CODE = "X75";
 
   private ProgrammeMembershipService service;
   private TraineeProfileRepository repository;
@@ -499,6 +510,228 @@ class ProgrammeMembershipServiceTest {
     verify(repository, never()).save(traineeProfile);
   }
 
+  @Test
+  void newStarterShouldBeFalseIfTraineeNotFound() {
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(null);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(false));
+  }
+
+  @Test
+  void newStarterShouldBeFalseIfPmNotFound() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipDefault("unknown id",
+            PROGRAMME_MEMBERSHIP_TYPE, START_DATE, END_DATE)));
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(false));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @MethodSource("listNonNewStartPmTypes")
+  void newStarterShouldBeFalseIfPmHasWrongType(String pmType) {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipDefault(PROGRAMME_TIS_ID, pmType, START_DATE, END_DATE)));
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(false));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @CsvSource({"1970-01-01"})
+  void newStarterShouldBeFalseIfPmHasEnded(LocalDate endDate) {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipDefault(PROGRAMME_TIS_ID, PROGRAMME_MEMBERSHIP_TYPE, START_DATE,
+            endDate)));
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(false));
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"another subtype"})
+  void newStarterShouldBeFalseIfPmHasNoMedicalCurricula(String curriculumSubtype) {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, START_DATE, END_DATE, MANAGING_DEANERY, curriculumSubtype,
+            CURRICULUM_SPECIALTY_CODE)));
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(false));
+  }
+
+  @Test
+  void newStarterShouldBeTrueIfItIsTheOnlyPm() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(List.of(getProgrammeMembershipDefault()));
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(true));
+  }
+
+  @Test
+  void newStarterShouldBeTrueIfPrecedingPmEndedTooLongAgo() {
+    List<ProgrammeMembership> pms
+        = new java.util.ArrayList<>(List.of(getProgrammeMembershipDefault()));
+    pms.add(getProgrammeMembershipDefault("another id",
+        PROGRAMME_MEMBERSHIP_TYPE, START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 100),
+        START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 1)));
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(pms);
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(true));
+  }
+
+  @Test
+  void newStarterShouldBeTrueIfPrecedingPmIsMissingDateInfo() {
+    List<ProgrammeMembership> pms
+        = new java.util.ArrayList<>(List.of(getProgrammeMembershipDefault()));
+    pms.add(getProgrammeMembershipDefault("another id",
+        PROGRAMME_MEMBERSHIP_TYPE, null, START_DATE.minusDays(1)));
+    pms.add(getProgrammeMembershipDefault("another id2",
+        PROGRAMME_MEMBERSHIP_TYPE, START_DATE.minusDays(500), null));
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(pms);
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(true));
+  }
+
+  @Test
+  void newStarterShouldBeFalseIfOnePrecedingPmEndedNotLongAgoAndIsIntraOrRota() {
+    List<ProgrammeMembership> pms
+        = new java.util.ArrayList<>(List.of(getProgrammeMembershipDefault()));
+    pms.add(getProgrammeMembershipDefault("another id",
+        PROGRAMME_MEMBERSHIP_TYPE, START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 100),
+        START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 1)));
+    pms.add(getProgrammeMembershipDefault("another id2",
+        PROGRAMME_MEMBERSHIP_TYPE, START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 100),
+        START_DATE.minusDays(PROGRAMME_BREAK_DAYS - 1)));
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(pms);
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(false));
+  }
+
+  @Test
+  void newStarterShouldBeTrueIfOnePrecedingPmEndedNotLongAgoButIsNotIntraOrRota() {
+    List<ProgrammeMembership> pms
+        = new java.util.ArrayList<>(List.of(getProgrammeMembershipDefault()));
+    pms.add(getProgrammeMembershipWithOneCurriculum("another id",
+        PROGRAMME_MEMBERSHIP_TYPE, START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 100),
+        START_DATE.minusDays(PROGRAMME_BREAK_DAYS - 1), MANAGING_DEANERY,
+        MEDICAL_CURRICULA.get(0), "a different curriculum specialty"));
+
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(pms);
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(true));
+  }
+
+  @Test
+  void newStarterShouldBeTrueIfIntraOrRotaMissingDeanery() {
+    List<ProgrammeMembership> pms
+        = new java.util.ArrayList<>(List.of(getProgrammeMembershipDefault()));
+    pms.add(getProgrammeMembershipWithOneCurriculum("another id",
+        PROGRAMME_MEMBERSHIP_TYPE, START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 100),
+        START_DATE.minusDays(PROGRAMME_BREAK_DAYS - 1), null,
+        MEDICAL_CURRICULA.get(0), CURRICULUM_SPECIALTY_CODE));
+
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(pms);
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(true));
+  }
+
+  @Test
+  void newStarterShouldBeTrueIfPmMissingDeanery() {
+    List<ProgrammeMembership> pms = new java.util.ArrayList<>(List.of(
+        getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, START_DATE, END_DATE, null, MEDICAL_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE)));
+    pms.add(getProgrammeMembershipDefault("another id",
+        PROGRAMME_MEMBERSHIP_TYPE, START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 100),
+        START_DATE.minusDays(PROGRAMME_BREAK_DAYS - 1)));
+
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(pms);
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(true));
+  }
+
+  @Test
+  void newStarterShouldBeTrueIfIntraOrRotaMissingProgrammeMembershipType() {
+    List<ProgrammeMembership> pms
+        = new java.util.ArrayList<>(List.of(getProgrammeMembershipDefault()));
+    pms.add(getProgrammeMembershipWithOneCurriculum("another id",
+        null, START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 100),
+        START_DATE.minusDays(PROGRAMME_BREAK_DAYS - 1), MANAGING_DEANERY,
+        MEDICAL_CURRICULA.get(0), CURRICULUM_SPECIALTY_CODE));
+
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(pms);
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(true));
+  }
+
+  @Test
+  void newStarterShouldBeTrueIfPmIsMissingStartDateInfo() {
+    List<ProgrammeMembership> pms = new java.util.ArrayList<>(List.of(
+        getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, null, END_DATE, MANAGING_DEANERY,
+            MEDICAL_CURRICULA.get(0), CURRICULUM_SPECIALTY_CODE)));
+    pms.add(getProgrammeMembershipWithOneCurriculum("another id",
+        PROGRAMME_MEMBERSHIP_TYPE, START_DATE.minusDays(100),
+        START_DATE.minusDays(1), MANAGING_DEANERY, MEDICAL_CURRICULA.get(0),
+        CURRICULUM_SPECIALTY_CODE));
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(pms);
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(true));
+  }
+
   /**
    * Create an instance of ProgrammeMembership with default dummy values.
    *
@@ -524,5 +757,74 @@ class ProgrammeMembershipServiceTest {
             GOLD_GUIDE_VERSION, COJ_SYNCED_AT.plus(Duration.ofDays(dateAdjustmentDays))));
 
     return programmeMembership;
+  }
+
+  static Stream<String> listNonNewStartPmTypes() {
+    return NON_NEW_START_PROGRAMME_MEMBERSHIP_TYPES.stream();
+  }
+
+  /**
+   * Create a programme membership with a single curriculum for testing isNewStarter conditions.
+   *
+   * @param programmeMembershipTisId The TIS ID to set on the programmeMembership.
+   * @param programmeMembershipType  The programme membership type.
+   * @param startDate                The start date.
+   * @param endDate                  The end date.
+   * @param managingDeanery          The managing deanery.
+   * @param curriculumSubType        The curriculum subtype.
+   * @param curriculumSpecialtyCode  The curriculum specialty code.
+   * @return The programme membership.
+   */
+  private ProgrammeMembership getProgrammeMembershipWithOneCurriculum(
+      String programmeMembershipTisId, String programmeMembershipType, LocalDate startDate,
+      LocalDate endDate, String managingDeanery, String curriculumSubType,
+      String curriculumSpecialtyCode) {
+    ProgrammeMembership programmeMembership = new ProgrammeMembership();
+    programmeMembership.setTisId(programmeMembershipTisId);
+    programmeMembership.setProgrammeTisId(PROGRAMME_TIS_ID);
+    programmeMembership.setProgrammeName(PROGRAMME_NAME);
+    programmeMembership.setProgrammeNumber(PROGRAMME_NUMBER);
+    programmeMembership.setManagingDeanery(managingDeanery);
+    programmeMembership.setProgrammeMembershipType(programmeMembershipType);
+    programmeMembership.setStartDate(startDate);
+    programmeMembership.setEndDate(endDate);
+    programmeMembership.setProgrammeCompletionDate(COMPLETION_DATE);
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSubType(curriculumSubType);
+    curriculum.setCurriculumSpecialtyCode(curriculumSpecialtyCode);
+    programmeMembership.setCurricula(List.of(curriculum));
+
+    return programmeMembership;
+  }
+
+  /**
+   * Create a default programme membership with a single curriculum for testing
+   * isNewStarter conditions.
+   *
+   * @param programmeMembershipTisId The TIS ID to set on the programmeMembership.
+   * @param programmeMembershipType  The programme membership type.
+   * @param startDate                The start date.
+   * @param endDate                  The end date.
+   * @return The default programme membership.
+   */
+  private ProgrammeMembership getProgrammeMembershipDefault(
+      String programmeMembershipTisId, String programmeMembershipType, LocalDate startDate,
+      LocalDate endDate) {
+    return getProgrammeMembershipWithOneCurriculum(
+        programmeMembershipTisId, programmeMembershipType, startDate,
+        endDate, MANAGING_DEANERY, MEDICAL_CURRICULA.get(0), CURRICULUM_SPECIALTY_CODE);
+  }
+
+  /**
+   * Create a default programme membership with a single curriculum for testing
+   * isNewStarter conditions.
+   *
+   * @return The default programme membership.
+   */
+  private ProgrammeMembership getProgrammeMembershipDefault() {
+    return getProgrammeMembershipWithOneCurriculum(
+        PROGRAMME_TIS_ID, PROGRAMME_MEMBERSHIP_TYPE, START_DATE,
+        END_DATE, MANAGING_DEANERY, MEDICAL_CURRICULA.get(0), CURRICULUM_SPECIALTY_CODE);
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -47,7 +47,6 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -548,7 +547,7 @@ class ProgrammeMembershipServiceTest {
 
   @ParameterizedTest
   @NullSource
-  @CsvSource({"1970-01-01"})
+  @ValueSource(strings = "1970-01-01")
   void newStarterShouldBeFalseIfPmHasEnded(LocalDate endDate) {
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setProgrammeMemberships(

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -641,7 +641,7 @@ class ProgrammeMembershipServiceTest {
   }
 
   @Test
-  void newStarterShouldBeTrueIfOnePrecedingPmEndedNotLongAgoButIsNotIntraOrRota() {
+  void newStarterShouldBeTrueIfPrecedingPmNotIntraOrRota() {
     List<ProgrammeMembership> pms
         = new java.util.ArrayList<>(List.of(getProgrammeMembershipDefault()));
     pms.add(getProgrammeMembershipWithOneCurriculum("another id",
@@ -704,6 +704,26 @@ class ProgrammeMembershipServiceTest {
         START_DATE.minusDays(PROGRAMME_BREAK_DAYS - 1), MANAGING_DEANERY,
         MEDICAL_CURRICULA.get(0), CURRICULUM_SPECIALTY_CODE));
 
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(pms);
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isNewStarter = service.isNewStarter(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isNewStarter value.", isNewStarter, is(true));
+  }
+
+  @Test
+  void newStarterShouldBeTrueIfPrecedingPmNotInIntraOrRotaSet() {
+    List<ProgrammeMembership> pms
+        = new java.util.ArrayList<>(List.of(getProgrammeMembershipDefault()));
+    pms.add(getProgrammeMembershipWithOneCurriculum("another id",
+        PROGRAMME_MEMBERSHIP_TYPE, START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 100),
+        START_DATE.minusDays(PROGRAMME_BREAK_DAYS - 1), "different deanery",
+        MEDICAL_CURRICULA.get(0), CURRICULUM_SPECIALTY_CODE));
+    pms.add(getProgrammeMembershipDefault("another id2",
+        PROGRAMME_MEMBERSHIP_TYPE, START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 100),
+        START_DATE.minusDays(PROGRAMME_BREAK_DAYS + 1)));
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setProgrammeMemberships(pms);
     when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);


### PR DESCRIPTION
One thing to consider is whether the sequencing is going to work correctly. For example, if a new programme membership arrives at tis-trainee-sync from TIS, this will trigger the update in tis-trainee-details, but also be broadcast to e.g. tis-trainee-notifications. If tis-trainee-notifications then calls the tis-trainee-details `isnewstarter` API before tis-trainee-details has processed the new programme membership, it would get a (potentially incorrect) negative response. 🤔 

Andy's proposed solution is to implement a slight delay on the SNS queues to ensure tis-trainee-profile updates the trainee profile before other events are triggered. I'll raise a PR for that separately.

TIS21-5723