### PR TITLE
chore: upgrade sentry

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,8 @@ dependencies {
   implementation("io.mongock:mongodb-springdata-v4-driver:${mongockVersion}")
 
   // Sentry reporting
-  implementation("io.sentry:sentry-spring-boot-starter:7.4.0")
+  val sentryVersion = "7.6.0"
+  implementation("io.sentry:sentry-spring-boot-starter-jakarta:$sentryVersion")
 
   // Amazon AWS
   implementation("io.awspring.cloud:spring-cloud-aws-starter-sqs")


### PR DESCRIPTION
Sentry should use a different dependency for Spring Boot 3 compatibility.

TIS21-SHED