### PR TITLE
chore: increase task cpu to 512

### DIFF
--- a/.aws/task-definition-template.json
+++ b/.aws/task-definition-template.json
@@ -145,6 +145,6 @@
   "executionRoleArn": "ecsTaskExecutionRole",
   "taskRoleArn": "tis-trainee-details_task-role_${environment}",
   "networkMode": "awsvpc",
-  "cpu": "256",
+  "cpu": "512",
   "memory": "1024"
 }


### PR DESCRIPTION
A bit of a stab in the dark in terms of fixing deployment, but we are seeing single tasks maxing out CPU so we should give it a little more either way.