### PR TITLE
Feat/generate ntn

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.2.8"
+version = "1.3.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/ProgrammeMembershipDto.java
@@ -48,7 +48,7 @@ public class ProgrammeMembershipDto implements SignedDto {
   private LocalDate programmeCompletionDate;
   private Status status;
   private List<CurriculumDto> curricula;
-  private String trainingPathway; // TODO: sync from TIS
+  private String trainingPathway;
   private ConditionsOfJoiningDto conditionsOfJoining;
   private Signature signature;
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/ProgrammeMembershipDto.java
@@ -37,6 +37,7 @@ public class ProgrammeMembershipDto implements SignedDto {
 
   @NotNull
   private String tisId;
+  private String ntn;
   private String programmeTisId;
   private String programmeName;
   private String programmeNumber;
@@ -47,6 +48,7 @@ public class ProgrammeMembershipDto implements SignedDto {
   private LocalDate programmeCompletionDate;
   private Status status;
   private List<CurriculumDto> curricula;
+  private String trainingPathway; // TODO: sync from TIS
   private ConditionsOfJoiningDto conditionsOfJoining;
   private Signature signature;
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/ProgrammeMembership.java
@@ -41,7 +41,7 @@ public class ProgrammeMembership {
   private LocalDate endDate;
   private LocalDate programmeCompletionDate;
   private List<Curriculum> curricula = new ArrayList<>();
-  private String trainingPathway; // TODO: sync from TIS
+  private String trainingPathway;
   private ConditionsOfJoining conditionsOfJoining;
 
   /**

--- a/src/main/java/uk/nhs/hee/trainee/details/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/ProgrammeMembership.java
@@ -31,6 +31,7 @@ import uk.nhs.hee.trainee.details.dto.enumeration.Status;
 public class ProgrammeMembership {
 
   private String tisId;
+  private String ntn;
   private String programmeTisId;
   private String programmeName;
   private String programmeNumber;
@@ -40,6 +41,7 @@ public class ProgrammeMembership {
   private LocalDate endDate;
   private LocalDate programmeCompletionDate;
   private List<Curriculum> curricula = new ArrayList<>();
+  private String trainingPathway; // TODO: sync from TIS
   private ConditionsOfJoining conditionsOfJoining;
 
   /**

--- a/src/main/java/uk/nhs/hee/trainee/details/service/NtnGenerator.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/NtnGenerator.java
@@ -1,0 +1,296 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.service;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.trainee.details.model.Curriculum;
+import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
+import uk.nhs.hee.trainee.details.model.TraineeProfile;
+
+/**
+ * A service for handling trainee NTNs/DRNs.
+ */
+@Slf4j
+@Service
+public class NtnGenerator {
+
+  /**
+   * Populate the NTN for all programme memberships in the trainee profile.
+   *
+   * @param traineeProfile The trainee profile to populate with NTNs.
+   */
+  public void populateNtns(TraineeProfile traineeProfile) {
+    PersonalDetails personalDetails = traineeProfile.getPersonalDetails();
+
+    if (isExcluded(personalDetails)) {
+      return;
+    }
+
+    traineeProfile.getProgrammeMemberships().forEach(pm -> populateNtn(personalDetails, pm));
+  }
+
+  /**
+   * Populate the NTN for the given programme membership.
+   *
+   * @param personalDetails     The personal details to use for NTN generation.
+   * @param programmeMembership The programme membership to generate the NTN for.
+   */
+  private void populateNtn(PersonalDetails personalDetails,
+      ProgrammeMembership programmeMembership) {
+    log.info("Populating NTN for programme membership '{}'.", programmeMembership.getTisId());
+
+    if (isExcluded(programmeMembership)) {
+      return;
+    }
+
+    String parentOrganization = getParentOrganization(programmeMembership);
+    String specialtyConcat = getSpecialtyConcat(programmeMembership);
+    String referenceNumber = getReferenceNumber(personalDetails);
+    String suffix = getSuffix(programmeMembership);
+    String ntn = parentOrganization + "/" + specialtyConcat + "/" + referenceNumber + "/" + suffix;
+    programmeMembership.setNtn(ntn);
+    log.info("Populated NTN: {}.", ntn);
+  }
+
+  /**
+   * Get the parent organization for the given programme membership.
+   *
+   * @param programmeMembership The programme membership to calculate the parent organization for.
+   * @return The calculated parent organization.
+   */
+  private String getParentOrganization(ProgrammeMembership programmeMembership) {
+    String managingDeanery = programmeMembership.getManagingDeanery();
+    log.info("Calculating parent organization for managing deanery '{}'.", managingDeanery);
+
+    String parentOrganization = managingDeanery == null ? null : switch (managingDeanery) {
+      case "Defence Postgraduate Medical Deanery" -> "TSD";
+      case "Health Education England East Midlands" -> "EMD";
+      case "Health Education England East of England" -> "EAN";
+      case "Health Education England Kent, Surrey and Sussex" -> "KSS";
+      case "Health Education England North Central and East London",
+          "Health Education England South London",
+          "Health Education England North West London",
+          "London LETBs" -> "LDN";
+      case "Health Education England North East" -> "NTH";
+      case "Health Education England North West" -> "NWE";
+      case "Health Education England South West" ->
+          getSouthWestParentOrganization(programmeMembership);
+      case "Health Education England Thames Valley" -> "OXF";
+      case "Health Education England Wessex" -> "WES";
+      case "Health Education England West Midlands" -> "WMD";
+      case "Health Education England Yorkshire and The Humber" -> "YHD";
+      case "Severn Deanery" -> "SEV";
+      case "South West Peninsula Deanery" -> "PEN";
+      default -> null;
+    };
+
+    if (parentOrganization == null) {
+      throw new IllegalArgumentException("Unable to calculate the parent organization.");
+    }
+
+    log.info("Calculated parent organization: '{}'.", parentOrganization);
+    return parentOrganization;
+  }
+
+  /**
+   * Get the parent organization for a programme in the South West.
+   *
+   * @param programmeMembership The SW programme membership.
+   * @return The calculated parent organization.
+   */
+  private String getSouthWestParentOrganization(ProgrammeMembership programmeMembership) {
+    String programmeNumber = programmeMembership.getProgrammeNumber();
+    log.info("Using programme number '{}' to calculate parent organization.", programmeNumber);
+    return programmeNumber.startsWith("SWP") ? "PEN" : programmeNumber.substring(0, 3);
+  }
+
+  /**
+   * Get the concatenated specialty string for the programme membership's NTN.
+   *
+   * @param programmeMembership The programme membership to get the specialty string for.
+   * @return The concatenated specialty string.
+   */
+  private String getSpecialtyConcat(ProgrammeMembership programmeMembership) {
+    log.info("Calculating specialty concat.");
+    List<Curriculum> curricula = programmeMembership.getCurricula();
+    List<Curriculum> sortedCurricula = filterAndSortCurricula(curricula);
+
+    StringBuilder sb = new StringBuilder();
+
+    for (ListIterator<Curriculum> curriculaIterator = sortedCurricula.listIterator();
+        curriculaIterator.hasNext(); ) {
+      int index = curriculaIterator.nextIndex();
+      Curriculum curriculum = curriculaIterator.next();
+      String specialtyCode = curriculum.getCurriculumSpecialtyCode();
+
+      if (index > 0) {
+        if (curriculum.getCurriculumSubType().equals("SUB_SPECIALTY")) {
+          log.info("Appending sub-specialty '{}'.", specialtyCode);
+          sb.append(".");
+        } else {
+          log.info("Appending specialty '{}'.", specialtyCode);
+          sb.append("-");
+        }
+      } else {
+        log.info("Using '{}' as first specialty.", specialtyCode);
+      }
+
+      sb.append(specialtyCode);
+
+      if (index == 0 && Objects.equals(curriculum.getCurriculumName(), "AFT")) {
+        sb.append("-FND");
+        break;
+      }
+    }
+
+    log.info("Calculated specialty concat: '{}'.", sb);
+    return sb.toString();
+  }
+
+  /**
+   * Get the GMC/GDC reference number for the given personal details.
+   *
+   * @param personalDetails The personal details to get the reference number for.
+   * @return The GMC/GDC number, depending on which is valid.
+   */
+  private String getReferenceNumber(PersonalDetails personalDetails) {
+    String gmcNumber = personalDetails.getGmcNumber();
+    return gmcNumber.matches("\\d{7}") ? gmcNumber : personalDetails.getGdcNumber();
+  }
+
+  /**
+   * Get the NTN suffix for the given programme membership.
+   *
+   * @param programmeMembership The programme membership to get the suffix for.
+   * @return The calculated suffix for the programme membership's NTN.
+   */
+  private String getSuffix(ProgrammeMembership programmeMembership) {
+    log.info("Calculating suffix.");
+    String trainingPathway = programmeMembership.getTrainingPathway();
+    log.info("Using training pathway '{}' to calculate suffix.", trainingPathway);
+
+    String suffix = switch (trainingPathway) {
+      case "CCT" -> "C";
+      case "CESR" -> "CP";
+      default -> {
+        List<Curriculum> curricula = programmeMembership.getCurricula();
+        List<Curriculum> sortedCurricula = filterAndSortCurricula(curricula);
+        String firstSpecialtyCode = sortedCurricula.get(0).getCurriculumSpecialtyCode();
+        log.info("Using specialty code '{}' to calculate suffix.", trainingPathway);
+
+        yield Objects.equals(firstSpecialtyCode, "ACA") ? "C" : "D";
+      }
+    };
+
+    log.info("Calculated suffix: '{}'.", suffix);
+    return suffix;
+  }
+
+  /**
+   * Filter the given curricula to only those that are current and sort them alphanumerically.
+   *
+   * @param curricula The curricula to filter and sort.
+   * @return The current curricula, sorted alphanumerically by subtype and code.
+   */
+  private List<Curriculum> filterAndSortCurricula(List<Curriculum> curricula) {
+    LocalDate now = LocalDate.now();
+
+    return curricula.stream()
+        .filter(c -> c.getCurriculumStartDate().isBefore(now))
+        .filter(c -> c.getCurriculumEndDate().isAfter(now))
+        .sorted(Comparator
+            .comparing(Curriculum::getCurriculumSubType)
+            .reversed()
+            .thenComparing(Curriculum::getCurriculumSpecialtyCode)
+            .reversed()
+        )
+        .toList();
+  }
+
+  /**
+   * Check whether the given personal details excludes NTN generation.
+   *
+   * @param personalDetails The personal details to check.
+   * @return true if NTN generated cannot continue, else false.
+   */
+  private boolean isExcluded(PersonalDetails personalDetails) {
+    if (personalDetails == null) {
+      log.info("Skipping NTN population as personal details not available.");
+      return true;
+    }
+
+    String gmcNumber = personalDetails.getGmcNumber();
+
+    if (gmcNumber == null || !gmcNumber.matches("\\d{7}")) {
+      String gdcNumber = personalDetails.getGdcNumber();
+
+      if (gdcNumber == null || !gdcNumber.matches("\\d{5}.*")) {
+        log.info("Skipping NTN population as reference number not valid.");
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Check whether the given programme membership is excluded for NTN generation.
+   *
+   * @param programmeMembership The programme membership to check.
+   * @return true if NTN generated cannot continue, else false.
+   */
+  private boolean isExcluded(ProgrammeMembership programmeMembership) {
+    String programmeNumber = programmeMembership.getProgrammeNumber();
+    if (programmeNumber == null || programmeNumber.isBlank()) {
+      log.info("Skipping NTN population as programme number is blank.");
+      return true;
+    }
+
+    String programmeName = programmeMembership.getProgrammeName();
+    if (programmeName == null || programmeName.isBlank()) {
+      log.info("Skipping NTN population as programme name is blank.");
+      return true;
+    }
+
+    String lowerProgrammeName = programmeName.toLowerCase();
+    if (lowerProgrammeName.contains("foundation")) {
+      log.info("Skipping NTN population as programme name '{}' is excluded.",
+          programmeMembership.getProgrammeName());
+      return true;
+    }
+
+    List<Curriculum> validCurricula = filterAndSortCurricula(programmeMembership.getCurricula());
+    if (validCurricula.isEmpty()) {
+      log.info("Skipping NTN population as there are no valid curricula.");
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/service/NtnGenerator.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/NtnGenerator.java
@@ -222,6 +222,8 @@ public class NtnGenerator {
     LocalDate now = LocalDate.now();
 
     return curricula.stream()
+        .filter(c ->
+            c.getCurriculumSpecialtyCode() != null && !c.getCurriculumSpecialtyCode().isBlank())
         .filter(c -> c.getCurriculumStartDate().isBefore(now))
         .filter(c -> c.getCurriculumEndDate().isAfter(now))
         .sorted(Comparator
@@ -288,6 +290,11 @@ public class NtnGenerator {
     List<Curriculum> validCurricula = filterAndSortCurricula(programmeMembership.getCurricula());
     if (validCurricula.isEmpty()) {
       log.info("Skipping NTN population as there are no valid curricula.");
+      return true;
+    }
+
+    if (programmeMembership.getTrainingPathway() == null) {
+      log.error("Unable to generate NTN as training pathway was null.");
       return true;
     }
 

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -42,9 +42,11 @@ import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 public class TraineeProfileService {
 
   private final TraineeProfileRepository repository;
+  private final NtnGenerator ntnGenerator;
 
-  TraineeProfileService(TraineeProfileRepository repository) {
+  TraineeProfileService(TraineeProfileRepository repository, NtnGenerator ntnGenerator) {
     this.repository = repository;
+    this.ntnGenerator = ntnGenerator;
   }
 
   /**
@@ -83,6 +85,9 @@ public class TraineeProfileService {
           .filter(pm -> pm.getConditionsOfJoining() == null
               || pm.getConditionsOfJoining().signedAt() == null)
           .forEach(pm -> pm.setConditionsOfJoining(coj));
+
+      // TODO: move generation to scheduled job/create/update.
+      ntnGenerator.populateNtns(traineeProfile);
     }
 
     return traineeProfile;

--- a/src/test/java/uk/nhs/hee/trainee/details/service/NtnGeneratorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/NtnGeneratorTest.java
@@ -1,0 +1,797 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.service;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import uk.nhs.hee.trainee.details.model.Curriculum;
+import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
+import uk.nhs.hee.trainee.details.model.TraineeProfile;
+
+@ExtendWith(OutputCaptureExtension.class)
+class NtnGeneratorTest {
+
+  private static final String CURRICULUM_SUB_TYPE_MC = "MEDICAL_CURRICULUM";
+  private static final String CURRICULUM_SUB_TYPE_SS = "SUB_SPECIALTY";
+  private static final String GDC_NUMBER = "12345";
+  private static final String GMC_NUMBER = "1234567";
+  private static final String OWNER_NAME = "London LETBs";
+  private static final String PROGRAMME_NAME = "Programme Name";
+  private static final String PROGRAMME_NUMBER = "PROG123";
+  private static final String TRAINING_PATHWAY = "N/A";
+
+  private static final LocalDate START_DATE = LocalDate.now().minusYears(1);
+  private static final LocalDate END_DATE = LocalDate.now().plusYears(1);
+
+  private NtnGenerator service;
+
+  @BeforeEach
+  void setUp() {
+    service = new NtnGenerator();
+  }
+
+  @Test
+  void shouldNotPopulateNtnWhenNoPersonalDetails(CapturedOutput output) {
+    TraineeProfile profile = new TraineeProfile();
+
+    profile.setPersonalDetails(null);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    assertThat("Unexpected ntn.", ntn, nullValue());
+
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping NTN population as personal details not available."));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" ", "abcd", "1234"})
+  void shouldNotPopulateNtnWhenNoGmcOrGdcNumber(String referenceNumber, CapturedOutput output) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(referenceNumber);
+    personalDetails.setGdcNumber(referenceNumber);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    assertThat("Unexpected ntn.", ntn, nullValue());
+
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping NTN population as reference number not valid."));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = " ")
+  void shouldNotPopulateNtnWhenNoProgrammeNumber(String programmeNumber, CapturedOutput output) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(programmeNumber);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    assertThat("Unexpected ntn.", ntn, nullValue());
+
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping NTN population as programme number is blank."));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = " ")
+  void shouldNotPopulateNtnWhenNoProgrammeName(String programmeName, CapturedOutput output) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(programmeName);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    assertThat("Unexpected ntn.", ntn, nullValue());
+
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping NTN population as programme name is blank."));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "foundation", "FOUNDATION", "prefix foundation", "foundation suffix",
+      "prefix foundation suffix"
+  })
+  void shouldNotPopulateNtnWhenProgrammeIsFoundation(String programmeName,
+      CapturedOutput output) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(programmeName);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    assertThat("Unexpected ntn.", ntn, nullValue());
+
+    assertThat("Expected log not found.", output.getOut(), containsString(
+        "Skipping NTN population as programme name '" + programmeName + "' is excluded."));
+  }
+
+  @Test
+  void shouldNotPopulateNtnWhenNoCurricula(CapturedOutput output) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setCurricula(List.of());
+    profile.setProgrammeMemberships(List.of(pm));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    assertThat("Unexpected ntn.", ntn, nullValue());
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping NTN population as there are no valid curricula."));
+  }
+
+  @Test
+  void shouldNotPopulateNtnWhenNoCurrentCurricula(CapturedOutput output) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    LocalDate now = LocalDate.now();
+
+    Curriculum past = new Curriculum();
+    past.setCurriculumStartDate(now.minusYears(1));
+    past.setCurriculumEndDate(now.minusDays(1));
+
+    Curriculum future = new Curriculum();
+    future.setCurriculumStartDate(now.plusDays(1));
+    future.setCurriculumEndDate(now.plusYears(1));
+
+    pm.setCurricula(List.of(past, future));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    assertThat("Unexpected ntn.", ntn, nullValue());
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping NTN population as there are no valid curricula."));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = {" ", "Unknown Organization"})
+  void shouldThrowExceptionPopulatingNtnWhenParentOrganizationNull(String ownerName) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(ownerName);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
+
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+        () -> service.populateNtns(profile));
+
+    assertThat("Unexpected message.", exception.getMessage(),
+        is("Unable to calculate the parent organization."));
+  }
+
+  @Test
+  void shouldPopulateFullNtn() {
+    TraineeProfile profile = new TraineeProfile();
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setCurriculumSpecialtyCode("ABC");
+    curriculum1.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum1.setCurriculumStartDate(START_DATE);
+    curriculum1.setCurriculumEndDate(END_DATE);
+
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setCurriculumSpecialtyCode("123");
+    curriculum2.setCurriculumSubType(CURRICULUM_SUB_TYPE_SS);
+    curriculum2.setCurriculumStartDate(START_DATE);
+    curriculum2.setCurriculumEndDate(END_DATE);
+
+    pm.setCurricula(List.of(curriculum1, curriculum2));
+
+    service.populateNtns(profile);
+
+    assertThat("Unexpected NTN.", pm.getNtn(), is("LDN/ABC.123/1234567/D"));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      Defence Postgraduate Medical Deanery                   | TSD
+      Health Education England East Midlands                 | EMD
+      Health Education England East of England               | EAN
+      Health Education England Kent, Surrey and Sussex       | KSS
+      Health Education England North Central and East London | LDN
+      Health Education England North East                    | NTH
+      Health Education England North West                    | NWE
+      Health Education England North West London             | LDN
+      Health Education England South London                  | LDN
+      Health Education England Thames Valley                 | OXF
+      Health Education England Wessex                        | WES
+      Health Education England West Midlands                 | WMD
+      Health Education England Yorkshire and The Humber      | YHD
+      London LETBs                                           | LDN
+      Severn Deanery                                         | SEV
+      South West Peninsula Deanery                           | PEN
+      """)
+  void shouldPopulateNtnWithParentOrganizationWhenMappedByOwner(String ownerName,
+      String ownerCode) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(ownerName);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    String[] ntnParts = ntn.split("/");
+    assertThat("Unexpected parent organization.", ntnParts[0], is(ownerCode));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      Health Education England South West | SWPABC | PEN
+      Health Education England South West | ABCYXZ | ABC
+      Health Education England South West | XYZABC | XYZ
+      """)
+  void shouldPopulateNtnWithParentOrganizationWhenOwnerIsSouthWest(String ownerName,
+      String programmeNumber, String ownerCode) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(ownerName);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(programmeNumber);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    String[] ntnParts = ntn.split("/");
+    assertThat("Unexpected parent organization.", ntnParts[0], is(ownerCode));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      AAA | ZZZ | 111 | 999 | ZZZ-AAA-999-111
+      999 | 111 | ZZZ | AAA | ZZZ-AAA-999-111
+      001 | 010 | 100 | 111 | 111-100-010-001
+      """)
+  void shouldPopulateNtnWithOrderedSpecialtyConcatWhenMultipleSpecialty(String specialty1,
+      String specialty2, String specialty3, String specialty4, String ntnPart) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum1.setCurriculumSpecialtyCode(specialty1);
+    curriculum1.setCurriculumStartDate(START_DATE);
+    curriculum1.setCurriculumEndDate(END_DATE);
+
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum2.setCurriculumSpecialtyCode(specialty2);
+    curriculum2.setCurriculumStartDate(START_DATE);
+    curriculum2.setCurriculumEndDate(END_DATE);
+
+    Curriculum curriculum3 = new Curriculum();
+    curriculum3.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum3.setCurriculumSpecialtyCode(specialty3);
+    curriculum3.setCurriculumStartDate(START_DATE);
+    curriculum3.setCurriculumEndDate(END_DATE);
+
+    Curriculum curriculum4 = new Curriculum();
+    curriculum4.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum4.setCurriculumSpecialtyCode(specialty4);
+    curriculum4.setCurriculumStartDate(START_DATE);
+    curriculum4.setCurriculumEndDate(END_DATE);
+
+    pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3, curriculum4));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    String[] ntnParts = ntn.split("/");
+    assertThat("Unexpected parent organization.", ntnParts[1], is(ntnPart));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3, 4, 10})
+  void shouldPopulateNtnWithDotNotatedSpecialtyConcatWhenHasSubSpecialties(
+      int additionalCurriculaCount) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    List<Curriculum> curricula = new ArrayList<>();
+    pm.setCurricula(curricula);
+
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setCurriculumName("A sub spec 1");
+    curriculum1.setCurriculumSubType(CURRICULUM_SUB_TYPE_SS);
+    curriculum1.setCurriculumSpecialtyCode("888");
+    curriculum1.setCurriculumStartDate(START_DATE);
+    curriculum1.setCurriculumEndDate(END_DATE);
+    curricula.add(curriculum1);
+
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setCurriculumName("A sub spec 2");
+    curriculum2.setCurriculumSubType(CURRICULUM_SUB_TYPE_SS);
+    curriculum2.setCurriculumSpecialtyCode("999");
+    curriculum2.setCurriculumStartDate(START_DATE);
+    curriculum2.setCurriculumEndDate(END_DATE);
+    curricula.add(curriculum2);
+
+    for (int i = 1; i <= additionalCurriculaCount; i++) {
+      Curriculum additionalCurriculum = new Curriculum();
+      additionalCurriculum.setCurriculumName("Not sub spec " + i);
+      additionalCurriculum.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+      additionalCurriculum.setCurriculumSpecialtyCode(String.format("%03d", i));
+      additionalCurriculum.setCurriculumStartDate(START_DATE);
+      additionalCurriculum.setCurriculumEndDate(END_DATE);
+      curricula.add(additionalCurriculum);
+    }
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    String[] ntnParts = ntn.split("/");
+    assertThat("Unexpected parent organization.", ntnParts[1], endsWith(".999.888"));
+
+    long dotCount = ntnParts[1].chars().filter(ch -> ch == '.').count();
+    assertThat("Unexpected sub specialty count.", dotCount, is(2L));
+  }
+
+  @Test
+  void shouldPopulateNtnWithFixedSpecialtyConcatWhenFirstSpecialtyIsAft() {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setCurriculumName("AFT");
+    curriculum1.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum1.setCurriculumSpecialtyCode("ACA");
+    curriculum1.setCurriculumStartDate(START_DATE);
+    curriculum1.setCurriculumEndDate(END_DATE);
+
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setCurriculumName("Not AFT 2");
+    curriculum2.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum2.setCurriculumSpecialtyCode("003");
+    curriculum2.setCurriculumStartDate(START_DATE);
+    curriculum2.setCurriculumEndDate(END_DATE);
+
+    Curriculum curriculum3 = new Curriculum();
+    curriculum3.setCurriculumName("Not AFT 1");
+    curriculum3.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum3.setCurriculumSpecialtyCode("777");
+    curriculum3.setCurriculumStartDate(START_DATE);
+    curriculum3.setCurriculumEndDate(END_DATE);
+
+    pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    String[] ntnParts = ntn.split("/");
+    assertThat("Unexpected parent organization.", ntnParts[1], is("ACA-FND"));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      AAA | ZZZ | 111
+      AAA | 111 | ZZZ
+      ZZZ | AAA | 111
+      ZZZ | 111 | AAA
+      111 | AAA | ZZZ
+      111 | ZZZ | AAA
+      """)
+  void shouldFilterCurriculaWhenPopulatingNtnWithOrderedSpecialtyConcat(String pastSpecialty,
+      String currentSpecialty, String futureSpecialty) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum1.setCurriculumSpecialtyCode(pastSpecialty);
+    curriculum1.setCurriculumStartDate(START_DATE);
+    curriculum1.setCurriculumEndDate(START_DATE);
+
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum2.setCurriculumSpecialtyCode(futureSpecialty);
+    curriculum2.setCurriculumStartDate(END_DATE);
+    curriculum2.setCurriculumEndDate(END_DATE);
+
+    Curriculum curriculum3 = new Curriculum();
+    curriculum3.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum3.setCurriculumSpecialtyCode(currentSpecialty);
+    curriculum3.setCurriculumStartDate(START_DATE);
+    curriculum3.setCurriculumEndDate(END_DATE);
+
+    pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    String[] ntnParts = ntn.split("/");
+    assertThat("Unexpected parent organization.", ntnParts[1], is(currentSpecialty));
+  }
+
+  @Test
+  void shouldPopulateNtnWithGmcNumberWhenValid() {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    String[] ntnParts = ntn.split("/");
+    assertThat("Unexpected parent organization.", ntnParts[2], is(GMC_NUMBER));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"abc", "12345678"})
+  void shouldPopulateNtnWithGdcNumberWhenValidAndGmcInvalid(String gmcNumber) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(gmcNumber);
+    personalDetails.setGdcNumber(GDC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    String[] ntnParts = ntn.split("/");
+    assertThat("Unexpected parent organization.", ntnParts[2], is(GDC_NUMBER));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      CCT  | C
+      CESR | CP
+      N/A  | D
+      """)
+  void shouldPopulateNtnWithSuffixWhenMappedByTrainingPathway(String trainingPathway,
+      String suffix) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(trainingPathway);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    String[] ntnParts = ntn.split("/");
+    assertThat("Unexpected parent organization.", ntnParts[3], is(suffix));
+  }
+
+  @Test
+  void shouldPopulateNtnWithSuffixWhenSpecialtyIsAcademic() {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setCurriculumSpecialtyCode("123");
+    curriculum1.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum1.setCurriculumStartDate(START_DATE);
+    curriculum1.setCurriculumEndDate(END_DATE);
+
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setCurriculumSpecialtyCode("ACA");
+    curriculum2.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum2.setCurriculumStartDate(START_DATE);
+    curriculum2.setCurriculumEndDate(END_DATE);
+
+    pm.setCurricula(List.of(curriculum1, curriculum2));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    String[] ntnParts = ntn.split("/");
+    assertThat("Unexpected parent organization.", ntnParts[3], is("C"));
+  }
+
+  @Test
+  void shouldFilterCurriculaWhenPopulatingNtnWithSuffix() {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum1 = new Curriculum();
+    curriculum1.setCurriculumSpecialtyCode("123");
+    curriculum1.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum1.setCurriculumStartDate(START_DATE);
+    curriculum1.setCurriculumEndDate(END_DATE);
+
+    Curriculum curriculum2 = new Curriculum();
+    curriculum2.setCurriculumSpecialtyCode("ACA");
+    curriculum2.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum2.setCurriculumStartDate(START_DATE);
+    curriculum2.setCurriculumEndDate(START_DATE);
+
+    Curriculum curriculum3 = new Curriculum();
+    curriculum3.setCurriculumSpecialtyCode("ACA");
+    curriculum3.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum3.setCurriculumStartDate(END_DATE);
+    curriculum3.setCurriculumEndDate(END_DATE);
+
+    pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    String[] ntnParts = ntn.split("/");
+    assertThat("Unexpected parent organization.", ntnParts[3], is("D"));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/service/NtnGeneratorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/NtnGeneratorTest.java
@@ -48,6 +48,7 @@ import uk.nhs.hee.trainee.details.model.TraineeProfile;
 @ExtendWith(OutputCaptureExtension.class)
 class NtnGeneratorTest {
 
+  private static final String CURRICULUM_SPECIALTY_CODE = "ABC";
   private static final String CURRICULUM_SUB_TYPE_MC = "MEDICAL_CURRICULUM";
   private static final String CURRICULUM_SUB_TYPE_SS = "SUB_SPECIALTY";
   private static final String GDC_NUMBER = "12345";
@@ -81,6 +82,7 @@ class NtnGeneratorTest {
     profile.setProgrammeMemberships(List.of(pm));
 
     Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     curriculum.setCurriculumStartDate(START_DATE);
     curriculum.setCurriculumEndDate(END_DATE);
     pm.setCurricula(List.of(curriculum));
@@ -113,6 +115,7 @@ class NtnGeneratorTest {
     profile.setProgrammeMemberships(List.of(pm));
 
     Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     curriculum.setCurriculumStartDate(START_DATE);
     curriculum.setCurriculumEndDate(END_DATE);
     pm.setCurricula(List.of(curriculum));
@@ -144,6 +147,7 @@ class NtnGeneratorTest {
     profile.setProgrammeMemberships(List.of(pm));
 
     Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     curriculum.setCurriculumStartDate(START_DATE);
     curriculum.setCurriculumEndDate(END_DATE);
     pm.setCurricula(List.of(curriculum));
@@ -175,6 +179,7 @@ class NtnGeneratorTest {
     profile.setProgrammeMemberships(List.of(pm));
 
     Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     curriculum.setCurriculumStartDate(START_DATE);
     curriculum.setCurriculumEndDate(END_DATE);
     pm.setCurricula(List.of(curriculum));
@@ -209,6 +214,7 @@ class NtnGeneratorTest {
     profile.setProgrammeMemberships(List.of(pm));
 
     Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     curriculum.setCurriculumStartDate(START_DATE);
     curriculum.setCurriculumEndDate(END_DATE);
     pm.setCurricula(List.of(curriculum));
@@ -264,14 +270,48 @@ class NtnGeneratorTest {
     LocalDate now = LocalDate.now();
 
     Curriculum past = new Curriculum();
+    past.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     past.setCurriculumStartDate(now.minusYears(1));
     past.setCurriculumEndDate(now.minusDays(1));
 
     Curriculum future = new Curriculum();
+    future.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     future.setCurriculumStartDate(now.plusDays(1));
     future.setCurriculumEndDate(now.plusYears(1));
 
     pm.setCurricula(List.of(past, future));
+
+    service.populateNtns(profile);
+
+    String ntn = pm.getNtn();
+    assertThat("Unexpected ntn.", ntn, nullValue());
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping NTN population as there are no valid curricula."));
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @ValueSource(strings = " ")
+  void shouldNotPopulateNtnWhenNoCurriculaSpecialtyCode(String specialtyCode,
+      CapturedOutput output) {
+    TraineeProfile profile = new TraineeProfile();
+
+    PersonalDetails personalDetails = new PersonalDetails();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(PROGRAMME_NAME);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(specialtyCode);
+    curriculum.setCurriculumStartDate(START_DATE);
+    curriculum.setCurriculumEndDate(END_DATE);
+    pm.setCurricula(List.of(curriculum));
 
     service.populateNtns(profile);
 
@@ -299,6 +339,7 @@ class NtnGeneratorTest {
     profile.setProgrammeMemberships(List.of(pm));
 
     Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     curriculum.setCurriculumStartDate(START_DATE);
     curriculum.setCurriculumEndDate(END_DATE);
     pm.setCurricula(List.of(curriculum));
@@ -378,6 +419,7 @@ class NtnGeneratorTest {
     profile.setProgrammeMemberships(List.of(pm));
 
     Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     curriculum.setCurriculumStartDate(START_DATE);
     curriculum.setCurriculumEndDate(END_DATE);
     pm.setCurricula(List.of(curriculum));
@@ -411,6 +453,7 @@ class NtnGeneratorTest {
     profile.setProgrammeMemberships(List.of(pm));
 
     Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     curriculum.setCurriculumStartDate(START_DATE);
     curriculum.setCurriculumEndDate(END_DATE);
     pm.setCurricula(List.of(curriculum));
@@ -619,6 +662,12 @@ class NtnGeneratorTest {
     curriculum3.setCurriculumStartDate(START_DATE);
     curriculum3.setCurriculumEndDate(END_DATE);
 
+    Curriculum curriculum4 = new Curriculum();
+    curriculum4.setCurriculumSubType(CURRICULUM_SUB_TYPE_MC);
+    curriculum4.setCurriculumSpecialtyCode(null);
+    curriculum4.setCurriculumStartDate(START_DATE);
+    curriculum4.setCurriculumEndDate(END_DATE);
+
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3));
 
     service.populateNtns(profile);
@@ -644,6 +693,7 @@ class NtnGeneratorTest {
     profile.setProgrammeMemberships(List.of(pm));
 
     Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     curriculum.setCurriculumStartDate(START_DATE);
     curriculum.setCurriculumEndDate(END_DATE);
     pm.setCurricula(List.of(curriculum));
@@ -673,6 +723,7 @@ class NtnGeneratorTest {
     profile.setProgrammeMemberships(List.of(pm));
 
     Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     curriculum.setCurriculumStartDate(START_DATE);
     curriculum.setCurriculumEndDate(END_DATE);
     pm.setCurricula(List.of(curriculum));
@@ -706,6 +757,7 @@ class NtnGeneratorTest {
     profile.setProgrammeMemberships(List.of(pm));
 
     Curriculum curriculum = new Curriculum();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
     curriculum.setCurriculumStartDate(START_DATE);
     curriculum.setCurriculumEndDate(END_DATE);
     pm.setCurricula(List.of(curriculum));

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -116,6 +116,9 @@ class TraineeProfileServiceTest {
   @Mock
   private TraineeProfileRepository repository;
 
+  @Mock
+  private NtnGenerator ntnGenerator;
+
   private TraineeProfile traineeProfile = new TraineeProfile();
   private TraineeProfile traineeProfile2 = new TraineeProfile();
   private PersonalDetails personalDetails;
@@ -377,6 +380,15 @@ class TraineeProfileServiceTest {
     assertThat("Unexpected CoJ signed at timestamp", coj.signedAt(), is(now));
     assertThat("Unexpected CoJ version", coj.version(), is(GG9));
     assertThat("Unexpected CoJ synced at", coj.syncedAt(), nullValue());
+  }
+
+  @Test
+  void shouldGenerateNtnsWhenGettingTraineeProfile() {
+    when(repository.findByTraineeTisId(DEFAULT_TIS_ID_1)).thenReturn(this.traineeProfile);
+
+    service.getTraineeProfileByTraineeTisId(DEFAULT_TIS_ID_1);
+
+    verify(ntnGenerator).populateNtns(traineeProfile);
   }
 
   @Test


### PR DESCRIPTION
# feat: create NTN generator

Create an NtnGenerator service which can populate the NTN a profile's
programme memberships.

The logic follows the existing Tableau/SQL implementation with the
exception of the limitation on more than four specialties being removed.
As a result the NTN will include as many specialties as exist and
sub-specialties will add use the `.XYZ` notation instead of only the
final one.

TIS21-6175
TIS21-6182

--- 

# feat: generate NTNs when retrieving trainee data

The NTN should eventually be generated and stored against the PM on
create/update and on a daily schedule to account for the starting and
ending of curricula.
However, temporarily it can be generated when retrieving the trainee
profile so that it is available to trainees while the rest of the work
is being done to make it available via metabase.

TIS21-6183
TIS21-6175