### PR TITLE
fix(ntn): capitalization of managing deanery

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.4.0"
+version = "1.4.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/NtnGenerator.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/NtnGenerator.java
@@ -104,7 +104,7 @@ public class NtnGenerator {
       case "Health Education England Thames Valley" -> "OXF";
       case "Health Education England Wessex" -> "WES";
       case "Health Education England West Midlands" -> "WMD";
-      case "Health Education England Yorkshire and The Humber" -> "YHD";
+      case "Health Education England Yorkshire and the Humber" -> "YHD";
       case "Severn Deanery" -> "SEV";
       case "South West Peninsula Deanery" -> "PEN";
       default -> null;

--- a/src/test/java/uk/nhs/hee/trainee/details/service/NtnGeneratorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/NtnGeneratorTest.java
@@ -529,7 +529,7 @@ class NtnGeneratorTest {
       Health Education England Thames Valley                 | OXF
       Health Education England Wessex                        | WES
       Health Education England West Midlands                 | WMD
-      Health Education England Yorkshire and The Humber      | YHD
+      Health Education England Yorkshire and the Humber      | YHD
       London LETBs                                           | LDN
       Severn Deanery                                         | SEV
       South West Peninsula Deanery                           | PEN


### PR DESCRIPTION
The managing deanery should be `Health Education England Yorkshire and the Humber` and not `Health Education England Yorkshire and The Humber`.

TIS21-6175
TIS21-6182