### PR TITLE
refactor: rename NTN to training number

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.5.2"
+version = "1.5.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/ProgrammeMembershipDto.java
@@ -37,7 +37,7 @@ public class ProgrammeMembershipDto implements SignedDto {
 
   @NotNull
   private String tisId;
-  private String ntn;
+  private String trainingNumber;
   private String programmeTisId;
   private String programmeName;
   private String programmeNumber;

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/ProgrammeMembershipMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/ProgrammeMembershipMapper.java
@@ -29,10 +29,14 @@ import org.mapstruct.MappingTarget;
 import uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 
+/**
+ * A mapper converted between programme membership types.
+ */
 @Mapper(componentModel = "spring", uses = SignatureMapper.class)
 public interface ProgrammeMembershipMapper {
 
   @Mapping(target = "signature", ignore = true)
+  @Mapping(target = "trainingNumber", ignore = true)
   ProgrammeMembershipDto toDto(ProgrammeMembership entity);
 
   ProgrammeMembership toEntity(ProgrammeMembershipDto dto);

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
@@ -31,7 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.hee.trainee.details.dto.TraineeProfileDto;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
-import uk.nhs.hee.trainee.details.service.NtnGenerator;
+import uk.nhs.hee.trainee.details.service.TrainingNumberGenerator;
 
 /**
  * A mapper to convert Trainee Profiles between entity and DTO representations.
@@ -45,22 +45,22 @@ import uk.nhs.hee.trainee.details.service.NtnGenerator;
 public abstract class TraineeProfileMapper {
 
   @Autowired
-  protected NtnGenerator ntnGenerator;
+  protected TrainingNumberGenerator trainingNumberGenerator;
 
   public abstract TraineeProfileDto toDto(TraineeProfile traineeProfile);
 
   /**
-   * Generate NTN for all programme memberships in the profile.
+   * Generate training numbers for all programme memberships in the profile.
    *
-   * @param dto The trainee profile to generate NTNs for.
+   * @param dto The trainee profile to generate training numbers for.
    */
   @AfterMapping
-  protected void generateNtns(@MappingTarget TraineeProfileDto dto) {
+  protected void generateTrainingNumbers(@MappingTarget TraineeProfileDto dto) {
     try {
-      ntnGenerator.populateNtns(dto);
+      trainingNumberGenerator.populateTrainingNumbers(dto);
     } catch (RuntimeException e) {
-      // Failure to populate the NTN should never block the profile being returned.
-      log.error("Caught and ignoring NTN generation runtime error:", e);
+      // Failure to populate the training number should never block the profile being returned.
+      log.error("Caught and ignoring training number generation runtime error:", e);
     }
   }
 

--- a/src/main/java/uk/nhs/hee/trainee/details/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/ProgrammeMembership.java
@@ -31,7 +31,6 @@ import uk.nhs.hee.trainee.details.dto.enumeration.Status;
 public class ProgrammeMembership {
 
   private String tisId;
-  private String ntn;
   private String programmeTisId;
   private String programmeName;
   private String programmeNumber;

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TrainingNumberGenerator.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TrainingNumberGenerator.java
@@ -36,36 +36,38 @@ import uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto;
 import uk.nhs.hee.trainee.details.dto.TraineeProfileDto;
 
 /**
- * A service for handling trainee NTNs/DRNs.
+ * A service for handling trainee training numbers (NTNs/DRNs).
  */
 @Slf4j
 @Service
-public class NtnGenerator {
+public class TrainingNumberGenerator {
 
   /**
-   * Populate the NTN for all programme memberships in the trainee profile.
+   * Populate the training numbers for all programme memberships in the trainee profile.
    *
-   * @param traineeProfile The trainee profile to populate with NTNs.
+   * @param traineeProfile The trainee profile to populate with training number.
    */
-  public void populateNtns(TraineeProfileDto traineeProfile) {
+  public void populateTrainingNumbers(TraineeProfileDto traineeProfile) {
     PersonalDetailsDto personalDetails = traineeProfile.getPersonalDetails();
 
     if (isExcluded(personalDetails)) {
       return;
     }
 
-    traineeProfile.getProgrammeMemberships().forEach(pm -> populateNtn(personalDetails, pm));
+    traineeProfile.getProgrammeMemberships()
+        .forEach(pm -> popualteTrainingNumber(personalDetails, pm));
   }
 
   /**
-   * Populate the NTN for the given programme membership.
+   * Populate the trainingNumber for the given programme membership.
    *
-   * @param personalDetails     The personal details to use for NTN generation.
-   * @param programmeMembership The programme membership to generate the NTN for.
+   * @param personalDetails     The personal details to use for training number generation.
+   * @param programmeMembership The programme membership to generate the training number for.
    */
-  private void populateNtn(PersonalDetailsDto personalDetails,
+  private void popualteTrainingNumber(PersonalDetailsDto personalDetails,
       ProgrammeMembershipDto programmeMembership) {
-    log.info("Populating NTN for programme membership '{}'.", programmeMembership.getTisId());
+    log.info("Populating training number for programme membership '{}'.",
+        programmeMembership.getTisId());
 
     if (isExcluded(programmeMembership)) {
       return;
@@ -75,9 +77,10 @@ public class NtnGenerator {
     String specialtyConcat = getSpecialtyConcat(programmeMembership);
     String referenceNumber = getReferenceNumber(personalDetails);
     String suffix = getSuffix(programmeMembership);
-    String ntn = parentOrganization + "/" + specialtyConcat + "/" + referenceNumber + "/" + suffix;
-    programmeMembership.setNtn(ntn);
-    log.info("Populated NTN: {}.", ntn);
+    String trainingNumber =
+        parentOrganization + "/" + specialtyConcat + "/" + referenceNumber + "/" + suffix;
+    programmeMembership.setTrainingNumber(trainingNumber);
+    log.info("Populated training number: {}.", trainingNumber);
   }
 
   /**
@@ -133,7 +136,7 @@ public class NtnGenerator {
   }
 
   /**
-   * Get the concatenated specialty string for the programme membership's NTN.
+   * Get the concatenated specialty string for the programme membership's training number.
    *
    * @param programmeMembership The programme membership to get the specialty string for.
    * @return The concatenated specialty string.
@@ -186,10 +189,10 @@ public class NtnGenerator {
   }
 
   /**
-   * Get the NTN suffix for the given programme membership.
+   * Get the training number suffix for the given programme membership.
    *
    * @param programmeMembership The programme membership to get the suffix for.
-   * @return The calculated suffix for the programme membership's NTN.
+   * @return The calculated suffix for the programme membership's training number.
    */
   private String getSuffix(ProgrammeMembershipDto programmeMembership) {
     log.info("Calculating suffix.");
@@ -216,7 +219,7 @@ public class NtnGenerator {
    * Filter a programme membership's curricula and sort them alphanumerically.
    *
    * @param programmeMembership The programme membership to filter and sort the curricula of.
-   * @return The NTN valid curricula for this PM, sorted alphanumerically by subtype and code.
+   * @return The valid curricula for this PM, sorted alphanumerically by subtype and code.
    */
   private List<CurriculumDto> filterAndSortCurricula(ProgrammeMembershipDto programmeMembership) {
     LocalDate startDate = programmeMembership.getStartDate();
@@ -241,14 +244,14 @@ public class NtnGenerator {
   }
 
   /**
-   * Check whether the given personal details excludes NTN generation.
+   * Check whether the given personal details excludes training number generation.
    *
    * @param personalDetails The personal details to check.
-   * @return true if NTN generated cannot continue, else false.
+   * @return true if training number generated cannot continue, else false.
    */
   private boolean isExcluded(PersonalDetailsDto personalDetails) {
     if (personalDetails == null) {
-      log.info("Skipping NTN population as personal details not available.");
+      log.info("Skipping training number population as personal details not available.");
       return true;
     }
 
@@ -258,7 +261,7 @@ public class NtnGenerator {
       String gdcNumber = personalDetails.getGdcNumber();
 
       if (gdcNumber == null || !gdcNumber.matches("\\d{5}.*")) {
-        log.info("Skipping NTN population as reference number not valid.");
+        log.info("Skipping training number population as reference number not valid.");
         return true;
       }
     }
@@ -267,39 +270,39 @@ public class NtnGenerator {
   }
 
   /**
-   * Check whether the given programme membership is excluded for NTN generation.
+   * Check whether the given programme membership is excluded for training number generation.
    *
    * @param programmeMembership The programme membership to check.
-   * @return true if NTN generated cannot continue, else false.
+   * @return true if training number generated cannot continue, else false.
    */
   private boolean isExcluded(ProgrammeMembershipDto programmeMembership) {
     String programmeNumber = programmeMembership.getProgrammeNumber();
     if (programmeNumber == null || programmeNumber.isBlank()) {
-      log.info("Skipping NTN population as programme number is blank.");
+      log.info("Skipping training number population as programme number is blank.");
       return true;
     }
 
     String programmeName = programmeMembership.getProgrammeName();
     if (programmeName == null || programmeName.isBlank()) {
-      log.info("Skipping NTN population as programme name is blank.");
+      log.info("Skipping training number population as programme name is blank.");
       return true;
     }
 
     String lowerProgrammeName = programmeName.toLowerCase();
     if (lowerProgrammeName.contains("foundation")) {
-      log.info("Skipping NTN population as programme name '{}' is excluded.",
+      log.info("Skipping training number population as programme name '{}' is excluded.",
           programmeMembership.getProgrammeName());
       return true;
     }
 
     List<CurriculumDto> validCurricula = filterAndSortCurricula(programmeMembership);
     if (validCurricula.isEmpty()) {
-      log.info("Skipping NTN population as there are no valid curricula.");
+      log.info("Skipping training number population as there are no valid curricula.");
       return true;
     }
 
     if (programmeMembership.getTrainingPathway() == null) {
-      log.error("Unable to generate NTN as training pathway was null.");
+      log.error("Unable to generate training number as training pathway was null.");
       return true;
     }
 

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -70,11 +70,11 @@ import uk.nhs.hee.trainee.details.model.Placement;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 import uk.nhs.hee.trainee.details.model.Site;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
-import uk.nhs.hee.trainee.details.service.NtnGenerator;
 import uk.nhs.hee.trainee.details.service.SignatureService;
 import uk.nhs.hee.trainee.details.service.TraineeProfileService;
+import uk.nhs.hee.trainee.details.service.TrainingNumberGenerator;
 
-@ContextConfiguration(classes = {NtnGenerator.class, TraineeProfileMapperImpl.class,
+@ContextConfiguration(classes = {TrainingNumberGenerator.class, TraineeProfileMapperImpl.class,
     PersonalDetailsMapperImpl.class, PlacementMapperImpl.class, ProgrammeMembershipMapperImpl.class,
     SignatureMapperImpl.class})
 @ExtendWith(SpringExtension.class)
@@ -452,7 +452,7 @@ class TraineeProfileResourceTest {
                 PERSON_EMAIL, PERSON_TITLE, PERSON_SURNAME, PERSON_FORENAME, PERSON_GMC)));
 
     mockMvc.perform(get("/api/trainee-profile/account-details/{tisId}", DEFAULT_TIS_ID_1)
-        .contentType(MediaType.APPLICATION_JSON))
+            .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.email").value(PERSON_EMAIL))

--- a/src/test/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapperTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapperTest.java
@@ -37,7 +37,7 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.nhs.hee.trainee.details.dto.TraineeProfileDto;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
-import uk.nhs.hee.trainee.details.service.NtnGenerator;
+import uk.nhs.hee.trainee.details.service.TrainingNumberGenerator;
 
 @ExtendWith(MockitoExtension.class)
 class TraineeProfileMapperTest {
@@ -53,30 +53,30 @@ class TraineeProfileMapperTest {
   ProgrammeMembershipMapper programmeMembershipMapper = new ProgrammeMembershipMapperImpl();
 
   @Mock
-  private NtnGenerator ntnGenerator;
+  private TrainingNumberGenerator trainingNumberGenerator;
 
   @Test
-  void shouldGenerateNtnsWhenGettingTraineeProfile() {
+  void shouldGenerateTrainingNumberssWhenGettingTraineeProfile() {
     TraineeProfile entity = new TraineeProfile();
 
     TraineeProfileDto dto = mapper.toDto(entity);
 
     ArgumentCaptor<TraineeProfileDto> dtoCaptor = ArgumentCaptor.captor();
-    verify(ntnGenerator).populateNtns(dtoCaptor.capture());
+    verify(trainingNumberGenerator).populateTrainingNumbers(dtoCaptor.capture());
 
     assertThat("Unexpected dto.", dtoCaptor.getValue(), sameInstance(dto));
   }
 
   @Test
-  void shouldIgnoreErrorsWhenGenerateNtnsForTraineeProfile() {
-    doThrow(RuntimeException.class).when(ntnGenerator).populateNtns(any());
+  void shouldIgnoreErrorsWhenGenerateTrainingNumbersForTraineeProfile() {
+    doThrow(RuntimeException.class).when(trainingNumberGenerator).populateTrainingNumbers(any());
 
     TraineeProfile entity = new TraineeProfile();
 
     TraineeProfileDto dto = assertDoesNotThrow(() -> mapper.toDto(entity));
 
     ArgumentCaptor<TraineeProfileDto> dtoCaptor = ArgumentCaptor.captor();
-    verify(ntnGenerator).populateNtns(dtoCaptor.capture());
+    verify(trainingNumberGenerator).populateTrainingNumbers(dtoCaptor.capture());
 
     assertThat("Unexpected dto.", dtoCaptor.getValue(), sameInstance(dto));
   }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -117,7 +117,7 @@ class TraineeProfileServiceTest {
   private TraineeProfileRepository repository;
 
   @Mock
-  private NtnGenerator ntnGenerator;
+  private TrainingNumberGenerator trainingNumberGenerator;
 
   private TraineeProfile traineeProfile = new TraineeProfile();
   private TraineeProfile traineeProfile2 = new TraineeProfile();

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TrainingNumberGeneratorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TrainingNumberGeneratorTest.java
@@ -46,7 +46,7 @@ import uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto;
 import uk.nhs.hee.trainee.details.dto.TraineeProfileDto;
 
 @ExtendWith(OutputCaptureExtension.class)
-class NtnGeneratorTest {
+class TrainingNumberGeneratorTest {
 
   private static final String CURRICULUM_SPECIALTY_CODE = "ABC";
   private static final String CURRICULUM_SUB_TYPE_MC = "MEDICAL_CURRICULUM";
@@ -62,15 +62,15 @@ class NtnGeneratorTest {
   private static final LocalDate PAST = NOW.minusYears(1);
   private static final LocalDate FUTURE = NOW.plusYears(1);
 
-  private NtnGenerator service;
+  private TrainingNumberGenerator service;
 
   @BeforeEach
   void setUp() {
-    service = new NtnGenerator();
+    service = new TrainingNumberGenerator();
   }
 
   @Test
-  void shouldNotPopulateNtnWhenNoPersonalDetails(CapturedOutput output) {
+  void shouldNotPopulateTrainingNumberWhenNoPersonalDetails(CapturedOutput output) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     profile.setPersonalDetails(null);
@@ -89,19 +89,20 @@ class NtnGeneratorTest {
     curriculum.setCurriculumEndDate(FUTURE);
     pm.setCurricula(List.of(curriculum));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    assertThat("Unexpected ntn.", ntn, nullValue());
+    String trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
 
     assertThat("Expected log not found.", output.getOut(),
-        containsString("Skipping NTN population as personal details not available."));
+        containsString("Skipping training number population as personal details not available."));
   }
 
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {" ", "abcd", "1234"})
-  void shouldNotPopulateNtnWhenNoGmcOrGdcNumber(String referenceNumber, CapturedOutput output) {
+  void shouldNotPopulateTrainingNumberWhenNoGmcOrGdcNumber(String referenceNumber,
+      CapturedOutput output) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -123,19 +124,20 @@ class NtnGeneratorTest {
     curriculum.setCurriculumEndDate(FUTURE);
     pm.setCurricula(List.of(curriculum));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    assertThat("Unexpected ntn.", ntn, nullValue());
+    String trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
 
     assertThat("Expected log not found.", output.getOut(),
-        containsString("Skipping NTN population as reference number not valid."));
+        containsString("Skipping training number population as reference number not valid."));
   }
 
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = " ")
-  void shouldNotPopulateNtnWhenNoProgrammeNumber(String programmeNumber, CapturedOutput output) {
+  void shouldNotPopulateTrainingNumberWhenNoProgrammeNumber(String programmeNumber,
+      CapturedOutput output) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -156,54 +158,19 @@ class NtnGeneratorTest {
     curriculum.setCurriculumEndDate(FUTURE);
     pm.setCurricula(List.of(curriculum));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    assertThat("Unexpected ntn.", ntn, nullValue());
+    String trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
 
     assertThat("Expected log not found.", output.getOut(),
-        containsString("Skipping NTN population as programme number is blank."));
+        containsString("Skipping training number population as programme number is blank."));
   }
 
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = " ")
-  void shouldNotPopulateNtnWhenNoProgrammeName(String programmeName, CapturedOutput output) {
-    TraineeProfileDto profile = new TraineeProfileDto();
-
-    PersonalDetailsDto personalDetails = new PersonalDetailsDto();
-    personalDetails.setGmcNumber(GMC_NUMBER);
-    profile.setPersonalDetails(personalDetails);
-
-    ProgrammeMembershipDto pm = new ProgrammeMembershipDto();
-    pm.setManagingDeanery(OWNER_NAME);
-    pm.setProgrammeName(programmeName);
-    pm.setProgrammeNumber(PROGRAMME_NUMBER);
-    pm.setTrainingPathway(TRAINING_PATHWAY);
-    pm.setStartDate(NOW);
-    profile.setProgrammeMemberships(List.of(pm));
-
-    CurriculumDto curriculum = new CurriculumDto();
-    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
-    curriculum.setCurriculumStartDate(PAST);
-    curriculum.setCurriculumEndDate(FUTURE);
-    pm.setCurricula(List.of(curriculum));
-
-    service.populateNtns(profile);
-
-    String ntn = pm.getNtn();
-    assertThat("Unexpected ntn.", ntn, nullValue());
-
-    assertThat("Expected log not found.", output.getOut(),
-        containsString("Skipping NTN population as programme name is blank."));
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {
-      "foundation", "FOUNDATION", "prefix foundation", "foundation suffix",
-      "prefix foundation suffix"
-  })
-  void shouldNotPopulateNtnWhenProgrammeIsFoundation(String programmeName,
+  void shouldNotPopulateTrainingNumberWhenNoProgrammeName(String programmeName,
       CapturedOutput output) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
@@ -225,17 +192,54 @@ class NtnGeneratorTest {
     curriculum.setCurriculumEndDate(FUTURE);
     pm.setCurricula(List.of(curriculum));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    assertThat("Unexpected ntn.", ntn, nullValue());
+    String trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
+
+    assertThat("Expected log not found.", output.getOut(),
+        containsString("Skipping training number population as programme name is blank."));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "foundation", "FOUNDATION", "prefix foundation", "foundation suffix",
+      "prefix foundation suffix"
+  })
+  void shouldNotPopulateTrainingNumberWhenProgrammeIsFoundation(String programmeName,
+      CapturedOutput output) {
+    TraineeProfileDto profile = new TraineeProfileDto();
+
+    PersonalDetailsDto personalDetails = new PersonalDetailsDto();
+    personalDetails.setGmcNumber(GMC_NUMBER);
+    profile.setPersonalDetails(personalDetails);
+
+    ProgrammeMembershipDto pm = new ProgrammeMembershipDto();
+    pm.setManagingDeanery(OWNER_NAME);
+    pm.setProgrammeName(programmeName);
+    pm.setProgrammeNumber(PROGRAMME_NUMBER);
+    pm.setTrainingPathway(TRAINING_PATHWAY);
+    pm.setStartDate(NOW);
+    profile.setProgrammeMemberships(List.of(pm));
+
+    CurriculumDto curriculum = new CurriculumDto();
+    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
+    curriculum.setCurriculumStartDate(PAST);
+    curriculum.setCurriculumEndDate(FUTURE);
+    pm.setCurricula(List.of(curriculum));
+
+    service.populateTrainingNumbers(profile);
+
+    String trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
 
     assertThat("Expected log not found.", output.getOut(), containsString(
-        "Skipping NTN population as programme name '" + programmeName + "' is excluded."));
+        "Skipping training number population as programme name '" + programmeName
+            + "' is excluded."));
   }
 
   @Test
-  void shouldNotPopulateNtnWhenNoCurricula(CapturedOutput output) {
+  void shouldNotPopulateTrainingNumberWhenNoCurricula(CapturedOutput output) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -251,16 +255,16 @@ class NtnGeneratorTest {
     pm.setCurricula(List.of());
     profile.setProgrammeMemberships(List.of(pm));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    assertThat("Unexpected ntn.", ntn, nullValue());
+    String trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
     assertThat("Expected log not found.", output.getOut(),
-        containsString("Skipping NTN population as there are no valid curricula."));
+        containsString("Skipping training number population as there are no valid curricula."));
   }
 
   @Test
-  void shouldNotPopulateNtnWhenNoCurrentCurricula(CapturedOutput output) {
+  void shouldNotPopulateTrainingNumberWhenNoCurrentCurricula(CapturedOutput output) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -287,18 +291,18 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(past, future));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    assertThat("Unexpected ntn.", ntn, nullValue());
+    String trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
     assertThat("Expected log not found.", output.getOut(),
-        containsString("Skipping NTN population as there are no valid curricula."));
+        containsString("Skipping training number population as there are no valid curricula."));
   }
 
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = " ")
-  void shouldNotPopulateNtnWhenNoCurriculaSpecialtyCode(String specialtyCode,
+  void shouldNotPopulateTrainingNumberWhenNoCurriculaSpecialtyCode(String specialtyCode,
       CapturedOutput output) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
@@ -320,16 +324,16 @@ class NtnGeneratorTest {
     curriculum.setCurriculumEndDate(FUTURE);
     pm.setCurricula(List.of(curriculum));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    assertThat("Unexpected ntn.", ntn, nullValue());
+    String trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
     assertThat("Expected log not found.", output.getOut(),
-        containsString("Skipping NTN population as there are no valid curricula."));
+        containsString("Skipping training number population as there are no valid curricula."));
   }
 
   @Test
-  void shouldNotPopulateNtnWhenTrainingPathwayNull(CapturedOutput output) {
+  void shouldNotPopulateTrainingNumberWhenTrainingPathwayNull(CapturedOutput output) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -350,18 +354,18 @@ class NtnGeneratorTest {
     curriculum.setCurriculumEndDate(FUTURE);
     pm.setCurricula(List.of(curriculum));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    assertThat("Unexpected ntn.", ntn, nullValue());
+    String trainingNumber = pm.getTrainingNumber();
+    assertThat("Unexpected training number.", trainingNumber, nullValue());
     assertThat("Expected log not found.", output.getOut(),
-        containsString("Unable to generate NTN as training pathway was null."));
+        containsString("Unable to generate training number as training pathway was null."));
   }
 
   @ParameterizedTest
   @NullAndEmptySource
   @ValueSource(strings = {" ", "Unknown Organization"})
-  void shouldThrowExceptionPopulatingNtnWhenParentOrganizationNull(String ownerName) {
+  void shouldThrowExceptionPopulatingTrainingNumberWhenParentOrganizationNull(String ownerName) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -383,14 +387,14 @@ class NtnGeneratorTest {
     pm.setCurricula(List.of(curriculum));
 
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-        () -> service.populateNtns(profile));
+        () -> service.populateTrainingNumbers(profile));
 
     assertThat("Unexpected message.", exception.getMessage(),
         is("Unable to calculate the parent organization."));
   }
 
   @Test
-  void shouldPopulateFullNtnWhenProgrammeIsCurrent() {
+  void shouldPopulateFullTrainingNumberWhenProgrammeIsCurrent() {
     TraineeProfileDto profile = new TraineeProfileDto();
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
     personalDetails.setGmcNumber(GMC_NUMBER);
@@ -424,13 +428,14 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    assertThat("Unexpected NTN.", pm.getNtn(), is("LDN/ABC.XYZ.123/1234567/D"));
+    assertThat("Unexpected training number.", pm.getTrainingNumber(),
+        is("LDN/ABC.XYZ.123/1234567/D"));
   }
 
   @Test
-  void shouldPopulateFullNtnWhenProgrammeIsFuture() {
+  void shouldPopulateFullTrainingNumberWhenProgrammeIsFuture() {
     TraineeProfileDto profile = new TraineeProfileDto();
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
     personalDetails.setGmcNumber(GMC_NUMBER);
@@ -464,13 +469,14 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    assertThat("Unexpected NTN.", pm.getNtn(), is("LDN/ABC.XYZ.123/1234567/D"));
+    assertThat("Unexpected training number.", pm.getTrainingNumber(),
+        is("LDN/ABC.XYZ.123/1234567/D"));
   }
 
   @Test
-  void shouldPopulateNtnsWhenTraineeProfileHasMultiplePms() {
+  void shouldPopulateTrainingNumbersWhenTraineeProfileHasMultiplePms() {
     TraineeProfileDto traineeProfile = new TraineeProfileDto();
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
     personalDetails.setGmcNumber(GMC_NUMBER);
@@ -520,11 +526,11 @@ class NtnGeneratorTest {
 
     traineeProfile.setProgrammeMemberships(List.of(pm1, pm2, pm3));
 
-    service.populateNtns(traineeProfile);
+    service.populateTrainingNumbers(traineeProfile);
 
-    assertThat("Unexpected NTN.", pm1.getNtn(), nullValue());
-    assertThat("Unexpected NTN.", pm2.getNtn(), is("LDN/123/1234567/D"));
-    assertThat("Unexpected NTN.", pm3.getNtn(), is("LDN/XYZ/1234567/D"));
+    assertThat("Unexpected training number.", pm1.getTrainingNumber(), nullValue());
+    assertThat("Unexpected training number.", pm2.getTrainingNumber(), is("LDN/123/1234567/D"));
+    assertThat("Unexpected training number.", pm3.getTrainingNumber(), is("LDN/XYZ/1234567/D"));
   }
 
   @ParameterizedTest
@@ -546,7 +552,7 @@ class NtnGeneratorTest {
       Severn Deanery                                         | SEV
       South West Peninsula Deanery                           | PEN
       """)
-  void shouldPopulateNtnWithParentOrganizationWhenMappedByOwner(String ownerName,
+  void shouldPopulateTrainingNumberWithParentOrganizationWhenMappedByOwner(String ownerName,
       String ownerCode) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
@@ -568,11 +574,11 @@ class NtnGeneratorTest {
     curriculum.setCurriculumEndDate(FUTURE);
     pm.setCurricula(List.of(curriculum));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[0], is(ownerCode));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[0], is(ownerCode));
   }
 
   @ParameterizedTest
@@ -581,7 +587,7 @@ class NtnGeneratorTest {
       Health Education England South West | ABCYXZ | ABC
       Health Education England South West | XYZABC | XYZ
       """)
-  void shouldPopulateNtnWithParentOrganizationWhenOwnerIsSouthWest(String ownerName,
+  void shouldPopulateTrainingNumberWithParentOrganizationWhenOwnerIsSouthWest(String ownerName,
       String programmeNumber, String ownerCode) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
@@ -603,11 +609,11 @@ class NtnGeneratorTest {
     curriculum.setCurriculumEndDate(FUTURE);
     pm.setCurricula(List.of(curriculum));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[0], is(ownerCode));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[0], is(ownerCode));
   }
 
   @ParameterizedTest
@@ -616,8 +622,9 @@ class NtnGeneratorTest {
       999 | 111 | ZZZ | AAA | ZZZ-AAA-999-111
       001 | 010 | 100 | 111 | 111-100-010-001
       """)
-  void shouldPopulateNtnWithOrderedSpecialtyConcatWhenMultipleSpecialty(String specialty1,
-      String specialty2, String specialty3, String specialty4, String ntnPart) {
+  void shouldPopulateTrainingNumberWithOrderedSpecialtyConcatWhenMultipleSpecialty(
+      String specialty1,
+      String specialty2, String specialty3, String specialty4, String trainingNumberPart) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -658,16 +665,16 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3, curriculum4));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[1], is(ntnPart));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[1], is(trainingNumberPart));
   }
 
   @ParameterizedTest
   @ValueSource(ints = {1, 2, 3, 4, 10})
-  void shouldPopulateNtnWithDotNotatedSpecialtyConcatWhenHasSubSpecialties(
+  void shouldPopulateTrainingNumberWithDotNotatedSpecialtyConcatWhenHasSubSpecialties(
       int additionalCurriculaCount) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
@@ -712,18 +719,18 @@ class NtnGeneratorTest {
       curricula.add(additionalCurriculum);
     }
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[1], endsWith(".999.888"));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[1], endsWith(".999.888"));
 
-    long dotCount = ntnParts[1].chars().filter(ch -> ch == '.').count();
+    long dotCount = trainingNumberParts[1].chars().filter(ch -> ch == '.').count();
     assertThat("Unexpected sub specialty count.", dotCount, is(2L));
   }
 
   @Test
-  void shouldPopulateNtnWithFixedSpecialtyConcatWhenFirstSpecialtyIsAft() {
+  void shouldPopulateTrainingNumberWithFixedSpecialtyConcatWhenFirstSpecialtyIsAft() {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -761,11 +768,11 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[1], is("ACA-FND"));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[1], is("ACA-FND"));
   }
 
   @ParameterizedTest
@@ -777,8 +784,8 @@ class NtnGeneratorTest {
       111 | AAA | ZZZ
       111 | ZZZ | AAA
       """)
-  void shouldFilterCurriculaWhenPopulatingNtnWithOrderedSpecialtyConcatAndCurriculaEnding(
-      String pastSpecialty, String endingSpecialty, String futureSpecialty) {
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberAndCurriculaEnding(String pastSpecialty,
+      String endingSpecialty, String futureSpecialty) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -819,11 +826,11 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3, curriculum4));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[1], is(endingSpecialty));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[1], is(endingSpecialty));
   }
 
   @ParameterizedTest
@@ -835,8 +842,8 @@ class NtnGeneratorTest {
       111 | AAA | ZZZ
       111 | ZZZ | AAA
       """)
-  void shouldFilterCurriculaWhenPopulatingNtnWithOrderedSpecialtyConcatAndCurriculaCurrent(
-      String pastSpecialty, String currentSpecialty, String futureSpecialty) {
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberCurriculaCurrent(String pastSpecialty,
+      String currentSpecialty, String futureSpecialty) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -877,11 +884,11 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3, curriculum4));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[1], is(currentSpecialty));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[1], is(currentSpecialty));
   }
 
   @ParameterizedTest
@@ -893,8 +900,8 @@ class NtnGeneratorTest {
       111 | AAA | ZZZ
       111 | ZZZ | AAA
       """)
-  void shouldFilterCurriculaWhenPopulatingNtnWithOrderedSpecialtyConcatAndCurriculaStarting(
-      String pastSpecialty, String startingSpecialty, String futureSpecialty) {
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberAndCurriculaStarting(String pastSpecialty,
+      String startingSpecialty, String futureSpecialty) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -935,11 +942,11 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3, curriculum4));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[1], is(startingSpecialty));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[1], is(startingSpecialty));
   }
 
   @ParameterizedTest
@@ -951,8 +958,8 @@ class NtnGeneratorTest {
       111 | AAA | ZZZ
       111 | ZZZ | AAA
       """)
-  void shouldFilterCurriculaWhenPopulatingNtnWithOrderedSpecialtyConcatAndProgrammeFuture(
-      String currentSpecialty, String futureSpecialty, String farFutureSpecialty) {
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberAndProgrammeFuture(String currentSpecialty,
+      String futureSpecialty, String farFutureSpecialty) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -993,11 +1000,11 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3, curriculum4));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[1], is(futureSpecialty));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[1], is(futureSpecialty));
   }
 
   @ParameterizedTest
@@ -1009,8 +1016,8 @@ class NtnGeneratorTest {
       111 | AAA | 111
       111 | 111 | AAA
       """)
-  void shouldFilterCurriculaWhenPopulatingNtnWithOrderedSpecialtyConcatAndDuplicateSpecialties(
-      String specialty1, String specialty2, String specialty3) {
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberAndDuplicateSpecialties(String specialty1,
+      String specialty2, String specialty3) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -1051,15 +1058,15 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3, curriculum4));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[1], is("AAA-111"));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[1], is("AAA-111"));
   }
 
   @Test
-  void shouldPopulateNtnWithGmcNumberWhenValid() {
+  void shouldPopulateTrainingNumberWithGmcNumberWhenValid() {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -1080,16 +1087,16 @@ class NtnGeneratorTest {
     curriculum.setCurriculumEndDate(FUTURE);
     pm.setCurricula(List.of(curriculum));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[2], is(GMC_NUMBER));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[2], is(GMC_NUMBER));
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"abc", "12345678"})
-  void shouldPopulateNtnWithGdcNumberWhenValidAndGmcInvalid(String gmcNumber) {
+  void shouldPopulateTrainingNumberWithGdcNumberWhenValidAndGmcInvalid(String gmcNumber) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -1111,11 +1118,11 @@ class NtnGeneratorTest {
     curriculum.setCurriculumEndDate(FUTURE);
     pm.setCurricula(List.of(curriculum));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[2], is(GDC_NUMBER));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[2], is(GDC_NUMBER));
   }
 
   @ParameterizedTest
@@ -1124,7 +1131,7 @@ class NtnGeneratorTest {
       CESR | CP
       N/A  | D
       """)
-  void shouldPopulateNtnWithSuffixWhenMappedByTrainingPathway(String trainingPathway,
+  void shouldPopulateTrainingNumberWithSuffixWhenMappedByTrainingPathway(String trainingPathway,
       String suffix) {
     TraineeProfileDto profile = new TraineeProfileDto();
 
@@ -1146,15 +1153,15 @@ class NtnGeneratorTest {
     curriculum.setCurriculumEndDate(FUTURE);
     pm.setCurricula(List.of(curriculum));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[3], is(suffix));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[3], is(suffix));
   }
 
   @Test
-  void shouldPopulateNtnWithSuffixWhenSpecialtyIsAcademic() {
+  void shouldPopulateTrainingNumberWithSuffixWhenSpecialtyIsAcademic() {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -1183,15 +1190,15 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[3], is("C"));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[3], is("C"));
   }
 
   @Test
-  void shouldFilterCurriculaWhenPopulatingNtnWithSuffixAndCurriculaEnding() {
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberWithSuffixAndCurriculaEnding() {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -1229,15 +1236,15 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[3], is("D"));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[3], is("D"));
   }
 
   @Test
-  void shouldFilterCurriculaWhenPopulatingNtnWithSuffixAndCurriculaCurrent() {
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberWithSuffixAndCurriculaCurrent() {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -1275,15 +1282,15 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[3], is("D"));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[3], is("D"));
   }
 
   @Test
-  void shouldFilterCurriculaWhenPopulatingNtnWithSuffixAndCurriculaStarting() {
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberWithSuffixAndCurriculaStarting() {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -1321,15 +1328,15 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[3], is("D"));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[3], is("D"));
   }
 
   @Test
-  void shouldFilterCurriculaWhenPopulatingNtnWithSuffixAndProgrammeFuture() {
+  void shouldFilterCurriculaWhenPopulatingTrainingNumberWithSuffixAndProgrammeFuture() {
     TraineeProfileDto profile = new TraineeProfileDto();
 
     PersonalDetailsDto personalDetails = new PersonalDetailsDto();
@@ -1374,10 +1381,10 @@ class NtnGeneratorTest {
 
     pm.setCurricula(List.of(curriculum1, curriculum2, curriculum3, curriculum4));
 
-    service.populateNtns(profile);
+    service.populateTrainingNumbers(profile);
 
-    String ntn = pm.getNtn();
-    String[] ntnParts = ntn.split("/");
-    assertThat("Unexpected parent organization.", ntnParts[3], is("D"));
+    String trainingNumber = pm.getTrainingNumber();
+    String[] trainingNumberParts = trainingNumber.split("/");
+    assertThat("Unexpected parent organization.", trainingNumberParts[3], is("D"));
   }
 }


### PR DESCRIPTION
The NTN field is used for both NTN and DRN training numbers, rename the field and other related code to use Training Number instead.

TIS21-6175
TIS21-6182