### PR TITLE
fix(ntn): South West NTN prefix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.6.0"
+version = "1.6.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TrainingNumberGenerator.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TrainingNumberGenerator.java
@@ -55,7 +55,7 @@ public class TrainingNumberGenerator {
     }
 
     traineeProfile.getProgrammeMemberships()
-        .forEach(pm -> popualteTrainingNumber(personalDetails, pm));
+        .forEach(pm -> populateTrainingNumber(personalDetails, pm));
   }
 
   /**
@@ -64,7 +64,7 @@ public class TrainingNumberGenerator {
    * @param personalDetails     The personal details to use for training number generation.
    * @param programmeMembership The programme membership to generate the training number for.
    */
-  private void popualteTrainingNumber(PersonalDetailsDto personalDetails,
+  private void populateTrainingNumber(PersonalDetailsDto personalDetails,
       ProgrammeMembershipDto programmeMembership) {
     log.info("Populating training number for programme membership '{}'.",
         programmeMembership.getTisId());
@@ -104,14 +104,11 @@ public class TrainingNumberGenerator {
           "London LETBs" -> "LDN";
       case "Health Education England North East" -> "NTH";
       case "Health Education England North West" -> "NWE";
-      case "Health Education England South West" ->
-          getSouthWestParentOrganization(programmeMembership);
+      case "Health Education England South West" -> "SWN";
       case "Health Education England Thames Valley" -> "OXF";
       case "Health Education England Wessex" -> "WES";
       case "Health Education England West Midlands" -> "WMD";
       case "Health Education England Yorkshire and the Humber" -> "YHD";
-      case "Severn Deanery" -> "SEV";
-      case "South West Peninsula Deanery" -> "PEN";
       default -> null;
     };
 
@@ -121,18 +118,6 @@ public class TrainingNumberGenerator {
 
     log.info("Calculated parent organization: '{}'.", parentOrganization);
     return parentOrganization;
-  }
-
-  /**
-   * Get the parent organization for a programme in the South West.
-   *
-   * @param programmeMembership The SW programme membership.
-   * @return The calculated parent organization.
-   */
-  private String getSouthWestParentOrganization(ProgrammeMembershipDto programmeMembership) {
-    String programmeNumber = programmeMembership.getProgrammeNumber();
-    log.info("Using programme number '{}' to calculate parent organization.", programmeNumber);
-    return programmeNumber.startsWith("SWP") ? "PEN" : programmeNumber.substring(0, 3);
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TrainingNumberGeneratorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TrainingNumberGeneratorTest.java
@@ -544,13 +544,12 @@ class TrainingNumberGeneratorTest {
       Health Education England North West                    | NWE
       Health Education England North West London             | LDN
       Health Education England South London                  | LDN
+      Health Education England South West                    | SWN
       Health Education England Thames Valley                 | OXF
       Health Education England Wessex                        | WES
       Health Education England West Midlands                 | WMD
       Health Education England Yorkshire and the Humber      | YHD
       London LETBs                                           | LDN
-      Severn Deanery                                         | SEV
-      South West Peninsula Deanery                           | PEN
       """)
   void shouldPopulateTrainingNumberWithParentOrganizationWhenMappedByOwner(String ownerName,
       String ownerCode) {
@@ -564,41 +563,6 @@ class TrainingNumberGeneratorTest {
     pm.setManagingDeanery(ownerName);
     pm.setProgrammeName(PROGRAMME_NAME);
     pm.setProgrammeNumber(PROGRAMME_NUMBER);
-    pm.setTrainingPathway(TRAINING_PATHWAY);
-    pm.setStartDate(NOW);
-    profile.setProgrammeMemberships(List.of(pm));
-
-    CurriculumDto curriculum = new CurriculumDto();
-    curriculum.setCurriculumSpecialtyCode(CURRICULUM_SPECIALTY_CODE);
-    curriculum.setCurriculumStartDate(PAST);
-    curriculum.setCurriculumEndDate(FUTURE);
-    pm.setCurricula(List.of(curriculum));
-
-    service.populateTrainingNumbers(profile);
-
-    String trainingNumber = pm.getTrainingNumber();
-    String[] trainingNumberParts = trainingNumber.split("/");
-    assertThat("Unexpected parent organization.", trainingNumberParts[0], is(ownerCode));
-  }
-
-  @ParameterizedTest
-  @CsvSource(delimiter = '|', textBlock = """
-      Health Education England South West | SWPABC | PEN
-      Health Education England South West | ABCYXZ | ABC
-      Health Education England South West | XYZABC | XYZ
-      """)
-  void shouldPopulateTrainingNumberWithParentOrganizationWhenOwnerIsSouthWest(String ownerName,
-      String programmeNumber, String ownerCode) {
-    TraineeProfileDto profile = new TraineeProfileDto();
-
-    PersonalDetailsDto personalDetails = new PersonalDetailsDto();
-    personalDetails.setGmcNumber(GMC_NUMBER);
-    profile.setPersonalDetails(personalDetails);
-
-    ProgrammeMembershipDto pm = new ProgrammeMembershipDto();
-    pm.setManagingDeanery(ownerName);
-    pm.setProgrammeName(PROGRAMME_NAME);
-    pm.setProgrammeNumber(programmeNumber);
     pm.setTrainingPathway(TRAINING_PATHWAY);
     pm.setStartDate(NOW);
     profile.setProgrammeMemberships(List.of(pm));


### PR DESCRIPTION
The prefix used by South West has been changed to a single value of `SWN` instead of `PEN` or `SEV`.
Update the TrainingNumberGenerator to map directly and remove any special handling.

TIS21-6340
TIS21-6343