### PR TITLE
feat: add endpoint to update GMC number

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.6.1"
+version = "1.7.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/event/GmcDetailsListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/GmcDetailsListener.java
@@ -22,7 +22,6 @@
 package uk.nhs.hee.trainee.details.event;
 
 import io.awspring.cloud.sqs.annotation.SqsListener;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
@@ -58,10 +57,8 @@ public class GmcDetailsListener {
 
     PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
-    Optional<PersonalDetails> optionalEntity = service.updateGmcDetailsByTisId(tisId, entity);
-
-    if (optionalEntity.isEmpty()) {
-      throw new IllegalArgumentException("Trainee not found.");
-    }
+    service
+        .updateGmcDetailsByTisId(tisId, entity, false)
+        .orElseThrow(() -> new IllegalArgumentException("Trainee not found."));
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
@@ -88,13 +88,21 @@ public class PersonalDetailsService {
   /**
    * Update the GMC details for the trainee with the given TIS ID.
    *
-   * @param tisId           The TIS id of the trainee.
-   * @param personalDetails The personal details to add to the trainee.
+   * @param tisId               The TIS id of the trainee.
+   * @param personalDetails     The personal details to add to the trainee.
+   * @param isProvidedByTrainee Whether the GMC details are provided by the trainee.
    * @return The updated personal details or empty if a trainee with the ID was not found.
    */
-  public Optional<PersonalDetails> updateGmcDetailsByTisId(String tisId,
-      PersonalDetails personalDetails) {
-    return updatePersonalDetailsByTisId(tisId, personalDetails, mapper::updateGmcDetails);
+  public Optional<PersonalDetails> updateGmcDetailsByTisId(
+      String tisId, PersonalDetails personalDetails, boolean isProvidedByTrainee) {
+    Optional<PersonalDetails> updatedPersonalDetails =
+        updatePersonalDetailsByTisId(tisId, personalDetails, mapper::updateGmcDetails);
+
+    if (isProvidedByTrainee) {
+      log.info("Trainee {} updated their GMC number to {}.", tisId, personalDetails.getGmcNumber());
+    }
+
+    return updatedPersonalDetails;
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
@@ -21,28 +21,36 @@
 
 package uk.nhs.hee.trainee.details.api;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.nhs.hee.trainee.details.TestJwtUtil;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
@@ -96,5 +104,74 @@ class BasicDetailsResourceTest {
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.publicHealthNumber").value(is("phnValue")));
+  }
+
+  @Test
+  void getShouldNotUpdateGmcNumberWhenTokenNotFound() throws Exception {
+    this.mockMvc
+        .perform(
+            put("/api/basic-details/gmc-number/1234567").contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void getShouldNotUpdateGmcNumberWhenPayloadNotMap() throws Exception {
+    String token = TestJwtUtil.generateToken("[]");
+
+    this.mockMvc.perform(put("/api/basic-details/gmc-number/1234567")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void getShouldNotUpdateGmcNumberWhenTisIdNotInToken() throws Exception {
+    String token = TestJwtUtil.generateToken("{}");
+
+    this.mockMvc.perform(put("/api/basic-details/gmc-number/1234567")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void getShouldNotUpdateGmcNumberWhenTisIdNotExists() throws Exception {
+    String token = TestJwtUtil.generateTokenForTisId("40");
+
+    when(service.updateGmcDetailsByTisId(any(), any(), anyBoolean())).thenReturn(Optional.empty());
+
+    this.mockMvc.perform(put("/api/basic-details/gmc-number/1234567")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void shouldUpdateGmcNumberWhenAuthorizedWhenTisIdInToken() throws Exception {
+    String token = TestJwtUtil.generateTokenForTisId("40");
+
+    ArgumentCaptor<PersonalDetails> personalDetailsCaptor = ArgumentCaptor.captor();
+    when(service.updateGmcDetailsByTisId(eq("40"), personalDetailsCaptor.capture(), anyBoolean()))
+        .thenAnswer(inv -> Optional.of(inv.getArgument(1)));
+
+    this.mockMvc.perform(put("/api/basic-details/gmc-number/1234567")
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.gmcNumber", is("1234567")));
+
+    PersonalDetails entity = personalDetailsCaptor.getValue();
+    assertThat("Unexpected GMC number.", entity.getGmcNumber(), is("1234567"));
+  }
+
+  @Test
+  void shouldSetGmcNumberProvidedByTraineeWhenAuthorizedWhenTisIdInToken() throws Exception {
+    String token = TestJwtUtil.generateTokenForTisId("40");
+
+    this.mockMvc.perform(put("/api/basic-details/gmc-number/1234567")
+        .contentType(MediaType.APPLICATION_JSON)
+        .header(HttpHeaders.AUTHORIZATION, token));
+
+    verify(service).updateGmcDetailsByTisId(any(), any(), eq(true));
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/event/GmcDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/GmcDetailsListenerTest.java
@@ -62,7 +62,8 @@ class GmcDetailsListenerTest {
     Update update = new Update(dto);
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
-    when(service.updateGmcDetailsByTisId(eq(TIS_ID), any())).thenReturn(Optional.empty());
+    when(service.updateGmcDetailsByTisId(eq(TIS_ID), any(), eq(false)))
+        .thenReturn(Optional.empty());
 
     assertThrows(IllegalArgumentException.class, () -> listener.updateGmcDetails(event));
   }
@@ -77,8 +78,8 @@ class GmcDetailsListenerTest {
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
     ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
-    when(service.updateGmcDetailsByTisId(eq(TIS_ID), entityCaptor.capture())).then(
-        inv -> Optional.of(inv.getArgument(1)));
+    when(service.updateGmcDetailsByTisId(eq(TIS_ID), entityCaptor.capture(), eq(false)))
+        .thenAnswer(inv -> Optional.of(inv.getArgument(1)));
 
     listener.updateGmcDetails(event);
 


### PR DESCRIPTION
Add an endpoint at `/api/basic-details/gmc-number` that allows a trainee to update their GMC number via a `PUT` request.

TIS21-6292
TIS21-6347