### PR TITLE
refactor: include new local office names

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.8.0"
+version = "1.8.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -54,16 +54,25 @@ public class ProgrammeMembershipService {
       = List.of("VISITOR", "LAT");
   protected static final Long PROGRAMME_BREAK_DAYS = 355L;
 
+  // TODO: remove Health Education England deaneries once renaming is complete.
   protected static final List<String> PILOT_2024_LOCAL_OFFICES_ALL_PROGRAMMES
       = List.of("London LETBs",
       "Health Education England North Central and East London",
+      "North Central and East London",
       "Health Education England South London",
+      "South London",
       "Health Education England North West London",
+      "North West London",
       "Health Education England Kent, Surrey and Sussex",
+      "Kent, Surrey and Sussex",
       "Health Education England East Midlands",
+      "East Midlands",
       "Health Education England West Midlands",
+      "West Midlands",
       "Health Education England East of England",
-      "Health Education England Wessex");
+      "East of England",
+      "Health Education England Wessex",
+      "Wessex");
 
   protected static final List<String> PILOT_2024_NW_SPECIALTIES = List.of(
       "Cardiothoracic surgery",
@@ -317,25 +326,28 @@ public class ProgrammeMembershipService {
       return true;
     }
 
-    if (managingDeanery
-        .equalsIgnoreCase("Health Education England Yorkshire and the Humber")
+    // TODO: remove Health Education England deanery once renaming is complete.
+    if ((managingDeanery.equalsIgnoreCase("Health Education England Yorkshire and the Humber")
+        || managingDeanery.equalsIgnoreCase("Yorkshire and the Humber"))
         && (startDate.isAfter(dayBefore01082024) && startDate.isBefore(dayAfter31102024))
         && programmeMembership.getCurricula().stream().noneMatch(
-          c -> c.getCurriculumSpecialty().equalsIgnoreCase("General Practice"))) {
+        c -> c.getCurriculumSpecialty().equalsIgnoreCase("General Practice"))) {
       return true;
     }
 
-    if (managingDeanery
-        .equalsIgnoreCase("Health Education England South West")
+    // TODO: remove Health Education England deanery once renaming is complete.
+    if ((managingDeanery.equalsIgnoreCase("Health Education England South West")
+        || managingDeanery.equalsIgnoreCase("South West"))
         && (startDate.isAfter(dayBefore01082024) && startDate.isBefore(dayAfter31102024))
         && programmeMembership.getCurricula().stream().noneMatch(
-          c -> c.getCurriculumSpecialty().equalsIgnoreCase("General Practice"))) {
+        c -> c.getCurriculumSpecialty().equalsIgnoreCase("General Practice"))) {
       return true;
     }
 
+    // TODO: remove Health Education England deanery once renaming is complete.
     LocalDate dayAfter31082024 = LocalDate.of(2024, 9, 1);
-    return managingDeanery
-        .equalsIgnoreCase("Health Education England North West")
+    return (managingDeanery.equalsIgnoreCase("Health Education England North West")
+        || managingDeanery.equalsIgnoreCase("North West"))
         && (startDate.isAfter(dayBefore01082024) && startDate.isBefore(dayAfter31082024))
         && (programmeMembership.getCurricula().stream().anyMatch(c ->
         PILOT_2024_NW_SPECIALTIES.stream().anyMatch(

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TrainingNumberGenerator.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TrainingNumberGenerator.java
@@ -94,21 +94,35 @@ public class TrainingNumberGenerator {
     log.info("Calculating parent organization for managing deanery '{}'.", managingDeanery);
 
     String parentOrganization = managingDeanery == null ? null : switch (managingDeanery) {
+      // TODO: remove Health Education England deanery once renaming is complete.
       case "Defence Postgraduate Medical Deanery" -> "TSD";
-      case "Health Education England East Midlands" -> "EMD";
-      case "Health Education England East of England" -> "EAN";
-      case "Health Education England Kent, Surrey and Sussex" -> "KSS";
+      case "Health Education England East Midlands",
+          "East Midlands" -> "EMD";
+      case "Health Education England East of England",
+          "East of England" -> "EAN";
+      case "Health Education England Kent, Surrey and Sussex",
+          "Kent, Surrey and Sussex" -> "KSS";
       case "Health Education England North Central and East London",
+          "North Central and East London",
           "Health Education England South London",
+          "South London",
           "Health Education England North West London",
+          "North West London",
           "London LETBs" -> "LDN";
-      case "Health Education England North East" -> "NTH";
-      case "Health Education England North West" -> "NWE";
-      case "Health Education England South West" -> "SWN";
-      case "Health Education England Thames Valley" -> "OXF";
-      case "Health Education England Wessex" -> "WES";
-      case "Health Education England West Midlands" -> "WMD";
-      case "Health Education England Yorkshire and the Humber" -> "YHD";
+      case "Health Education England North East",
+          "North East" -> "NTH";
+      case "Health Education England North West",
+          "North West" -> "NWE";
+      case "Health Education England South West",
+          "South West" -> "SWN";
+      case "Health Education England Thames Valley",
+          "Thames Valley" -> "OXF";
+      case "Health Education England Wessex",
+          "Wessex" -> "WES";
+      case "Health Education England West Midlands",
+          "West Midlands" -> "WMD";
+      case "Health Education England Yorkshire and the Humber",
+          "Yorkshire and the Humber" -> "YHD";
       default -> null;
     };
 

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -89,7 +89,7 @@ class TraineeProfileResourceTest {
   private static final String PERSON_KNOWNAS = "Ivy";
   private static final String PERSON_MAIDENNAME = "N/A";
   private static final String PERSON_TITLE = "Mr";
-  private static final String PERSON_PERSONOWNER = "Health Education England Thames Valley";
+  private static final String PERSON_PERSONOWNER = "Thames Valley";
   private static final LocalDate PERSON_DATEOFBIRTH = LocalDate.parse("1991-11-11",
       DateTimeFormatter.ofPattern("yyyy-MM-dd"));
   private static final String PERSON_GENDER = "Male";

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -935,9 +935,13 @@ class ProgrammeMembershipServiceTest {
     assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
   }
 
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
   @ParameterizedTest
   @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
-  void pilot2024ShouldBeTrueForYhWithCorrectDateAndCurriculumSpecialty(String specialty) {
+  void pilot2024ShouldBeTrueForYhWithCorrectDateAndCurriculumSpecialty_old(String specialty) {
     LocalDate date = LocalDate.of(2024, 8, 15);
     String deanery = "Health Education England Yorkshire and the Humber";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -953,8 +957,30 @@ class ProgrammeMembershipServiceTest {
     assertThat("Unexpected isPilot2024 value.", isPilot2024, is(true));
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
+  void pilot2024ShouldBeTrueForYhWithCorrectDateAndCurriculumSpecialty(String specialty) {
+    LocalDate date = LocalDate.of(2024, 8, 15);
+    String deanery = "Yorkshire and the Humber";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, date, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, specialty)));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(true));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
   @Test
-  void pilot2024ShouldBeFalseForYhGeneralPractice() {
+  void pilot2024ShouldBeFalseForYhGeneralPractice_old() {
     LocalDate date = LocalDate.of(2024, 8, 7);
     String deanery = "Health Education England Yorkshire and the Humber";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -970,9 +996,30 @@ class ProgrammeMembershipServiceTest {
     assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
   }
 
+  @Test
+  void pilot2024ShouldBeFalseForYhGeneralPractice() {
+    LocalDate date = LocalDate.of(2024, 8, 7);
+    String deanery = "Yorkshire and the Humber";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, date, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, "General Practice")));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
   @ParameterizedTest
   @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
-  void pilot2024ShouldBeFalseForYhWithTooLateDateAndCorrectCurriculumSpecialty(String specialty) {
+  void pilot2024ShouldBeFalseForYhWithTooLateDateAndCorrectCurriculumSpecialty_old(String specialty) {
     LocalDate wrongDate = LocalDate.of(2024, 11, 1);
     String deanery = "Health Education England Yorkshire and the Humber";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -990,8 +1037,30 @@ class ProgrammeMembershipServiceTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
-  void pilot2024ShouldBeFalseForYhWithTooEarlyDateAndCorrectCurriculumSpecialty(String specialty) {
-    LocalDate wrongDate = LocalDate.of(2024, 07, 1);
+  void pilot2024ShouldBeFalseForYhWithTooLateDateAndCorrectCurriculumSpecialty(String specialty) {
+    LocalDate wrongDate = LocalDate.of(2024, 11, 1);
+    String deanery = "Yorkshire and the Humber";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, wrongDate, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, specialty)));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
+  @ParameterizedTest
+  @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
+  void pilot2024ShouldBeFalseForYhWithTooEarlyDateAndCorrectCurriculumSpecialty_old(String specialty) {
+    LocalDate wrongDate = LocalDate.of(2024, 7, 1);
     String deanery = "Health Education England Yorkshire and the Humber";
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setProgrammeMemberships(
@@ -1008,7 +1077,29 @@ class ProgrammeMembershipServiceTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
-  void pilot2024ShouldBeFalseIfYhLoWithGpSpecialtyInMultipleCurricula(String specialty) {
+  void pilot2024ShouldBeFalseForYhWithTooEarlyDateAndCorrectCurriculumSpecialty(String specialty) {
+    LocalDate wrongDate = LocalDate.of(2024, 7, 1);
+    String deanery = "Yorkshire and the Humber";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, wrongDate, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, specialty)));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
+  @ParameterizedTest
+  @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
+  void pilot2024ShouldBeFalseIfYhLoWithGpSpecialtyInMultipleCurricula_old(String specialty) {
     LocalDate dateInRange = LocalDate.of(2024, 8, 15);
     String deanery = "Health Education England Yorkshire and the Humber";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -1031,7 +1122,34 @@ class ProgrammeMembershipServiceTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
-  void pilot2024ShouldBeTrueIfSwLoWithCorrectStartDateAndSpecialty(String specialty) {
+  void pilot2024ShouldBeFalseIfYhLoWithGpSpecialtyInMultipleCurricula(String specialty) {
+    LocalDate dateInRange = LocalDate.of(2024, 8, 15);
+    String deanery = "Yorkshire and the Humber";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    Curriculum curriculum = createCurriculum(MEDICAL_CURRICULA.get(0),
+        CURRICULUM_SPECIALTY_CODE, specialty);
+    Curriculum curriculumGp = createCurriculum(MEDICAL_CURRICULA.get(1),
+        CURRICULUM_SPECIALTY_CODE, "General Practice");
+    ProgrammeMembership programmeMembership =
+        getProgrammeMembershipWithMultipleCurriculum(PROGRAMME_TIS_ID, PROGRAMME_MEMBERSHIP_TYPE,
+            dateInRange, END_DATE, deanery, List.of(curriculum, curriculumGp));
+
+    traineeProfile.setProgrammeMemberships(List.of(programmeMembership));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
+  @ParameterizedTest
+  @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
+  void pilot2024ShouldBeTrueIfSwLoWithCorrectStartDateAndSpecialty_old(String specialty) {
     LocalDate dateInRange = LocalDate.of(2024, 10, 31);
     String deanery = "Health Education England South West";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -1049,7 +1167,29 @@ class ProgrammeMembershipServiceTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
-  void pilot2024ShouldBeFalseIfSwLoWithTooEarlyStartDate(String specialty) {
+  void pilot2024ShouldBeTrueIfSwLoWithCorrectStartDateAndSpecialty(String specialty) {
+    LocalDate dateInRange = LocalDate.of(2024, 10, 31);
+    String deanery = "South West";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, dateInRange, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, specialty)));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(true));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
+  @ParameterizedTest
+  @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
+  void pilot2024ShouldBeFalseIfSwLoWithTooEarlyStartDate_old(String specialty) {
     LocalDate dateInRange = LocalDate.of(2024, 6, 2);
     String deanery = "Health Education England South West";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -1067,7 +1207,29 @@ class ProgrammeMembershipServiceTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
-  void pilot2024ShouldBeFalseIfSwLoWithTooLateStartDate(String specialty) {
+  void pilot2024ShouldBeFalseIfSwLoWithTooEarlyStartDate(String specialty) {
+    LocalDate dateInRange = LocalDate.of(2024, 6, 2);
+    String deanery = "South West";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, dateInRange, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, specialty)));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
+  @ParameterizedTest
+  @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
+  void pilot2024ShouldBeFalseIfSwLoWithTooLateStartDate_old(String specialty) {
     LocalDate dateInRange = LocalDate.of(2024, 11, 1);
     String deanery = "Health Education England South West";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -1082,9 +1244,30 @@ class ProgrammeMembershipServiceTest {
 
     assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
   }
+  @ParameterizedTest
+  @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
+  void pilot2024ShouldBeFalseIfSwLoWithTooLateStartDate(String specialty) {
+    LocalDate dateInRange = LocalDate.of(2024, 11, 1);
+    String deanery = "South West";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, dateInRange, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, specialty)));
 
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
   @Test
-  void pilot2024ShouldBeFalseIfSwLoWithGpSpecialty() {
+  void pilot2024ShouldBeFalseIfSwLoWithGpSpecialty_old() {
     LocalDate dateInRange = LocalDate.of(2024, 8, 5);
     String deanery = "Health Education England South West";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -1100,9 +1283,30 @@ class ProgrammeMembershipServiceTest {
     assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
   }
 
+  @Test
+  void pilot2024ShouldBeFalseIfSwLoWithGpSpecialty() {
+    LocalDate dateInRange = LocalDate.of(2024, 8, 5);
+    String deanery = "South West";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, dateInRange, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, "General Practice")));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
   @ParameterizedTest
   @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
-  void pilot2024ShouldBeFalseIfSwLoWithGpSpecialtyInMultipleCurricula(String specialty) {
+  void pilot2024ShouldBeFalseIfSwLoWithGpSpecialtyInMultipleCurricula_old(String specialty) {
     LocalDate dateInRange = LocalDate.of(2024, 10, 31);
     String deanery = "Health Education England South West";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -1124,8 +1328,35 @@ class ProgrammeMembershipServiceTest {
   }
 
   @ParameterizedTest
+  @ValueSource(strings = {"Internal Medicine Stage One", "Core surgical training"})
+  void pilot2024ShouldBeFalseIfSwLoWithGpSpecialtyInMultipleCurricula(String specialty) {
+    LocalDate dateInRange = LocalDate.of(2024, 10, 31);
+    String deanery = "South West";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    Curriculum curriculum = createCurriculum(MEDICAL_CURRICULA.get(0),
+        CURRICULUM_SPECIALTY_CODE, specialty);
+    Curriculum curriculumGp = createCurriculum(MEDICAL_CURRICULA.get(1),
+        CURRICULUM_SPECIALTY_CODE, "General Practice");
+    ProgrammeMembership programmeMembership =
+        getProgrammeMembershipWithMultipleCurriculum(PROGRAMME_TIS_ID, PROGRAMME_MEMBERSHIP_TYPE,
+            dateInRange, END_DATE, deanery, List.of(curriculum, curriculumGp));
+
+    traineeProfile.setProgrammeMemberships(List.of(programmeMembership));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
+  @ParameterizedTest
   @MethodSource("listNwPilot2024AllSpecialties")
-  void pilot2024ShouldBeTrueIfNwLoWithCorrectStartDateAndSpecialty(String specialty) {
+  void pilot2024ShouldBeTrueIfNwLoWithCorrectStartDateAndSpecialty_old(String specialty) {
     LocalDate dateInRange = LocalDate.of(2024, 8, 1);
     String deanery = "Health Education England North West";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -1143,8 +1374,70 @@ class ProgrammeMembershipServiceTest {
 
   @ParameterizedTest
   @MethodSource("listNwPilot2024AllSpecialties")
+  void pilot2024ShouldBeTrueIfNwLoWithCorrectStartDateAndSpecialty(String specialty) {
+    LocalDate dateInRange = LocalDate.of(2024, 8, 1);
+    String deanery = "North West";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, dateInRange, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, specialty)));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(true));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
+  @ParameterizedTest
+  @MethodSource("listNwPilot2024AllSpecialties")
+  void pilot2024ShouldBeFalseIfNwLoWithIncorrectStartDateAndOkSpecialty_old(String specialty) {
+    LocalDate dateOutOfRange = LocalDate.of(2024, 7, 1);
+    String deanery = "Health Education England North West";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, dateOutOfRange, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, specialty)));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("listNwPilot2024AllSpecialties")
   void pilot2024ShouldBeFalseIfNwLoWithIncorrectStartDateAndOkSpecialty(String specialty) {
     LocalDate dateOutOfRange = LocalDate.of(2024, 7, 1);
+    String deanery = "North West";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, dateOutOfRange, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, specialty)));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
+  @ParameterizedTest
+  @MethodSource("listNwPilot2024AllSpecialties")
+  void pilot2024ShouldBeFalseIfNwLoWithTooLateStartDateAndOkSpecialty_old(String specialty) {
+    LocalDate dateOutOfRange = LocalDate.of(2024, 12, 1);
     String deanery = "Health Education England North West";
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setProgrammeMemberships(
@@ -1163,7 +1456,7 @@ class ProgrammeMembershipServiceTest {
   @MethodSource("listNwPilot2024AllSpecialties")
   void pilot2024ShouldBeFalseIfNwLoWithTooLateStartDateAndOkSpecialty(String specialty) {
     LocalDate dateOutOfRange = LocalDate.of(2024, 12, 1);
-    String deanery = "Health Education England North West";
+    String deanery = "North West";
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setProgrammeMemberships(
         List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
@@ -1177,10 +1470,14 @@ class ProgrammeMembershipServiceTest {
     assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
   }
 
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
   @ParameterizedTest
   @ValueSource(strings = {"Cardio-thoracic surgery (run through)",
       "Oral and maxillo-facial surgery (run through)"})
-  void pilot2024ShouldBeTrueIfNwLoWithCorrectStartDateAndProgramme(String programme) {
+  void pilot2024ShouldBeTrueIfNwLoWithCorrectStartDateAndProgramme_old(String programme) {
     LocalDate dateInRange = LocalDate.of(2024, 8, 1);
     String deanery = "Health Education England North West";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -1200,7 +1497,31 @@ class ProgrammeMembershipServiceTest {
   @ParameterizedTest
   @ValueSource(strings = {"Cardio-thoracic surgery (run through)",
       "Oral and maxillo-facial surgery (run through)"})
-  void pilot2024ShouldBeFalseIfNwLoWithIncorrectStartDateAndOkProgramme(String programme) {
+  void pilot2024ShouldBeTrueIfNwLoWithCorrectStartDateAndProgramme(String programme) {
+    LocalDate dateInRange = LocalDate.of(2024, 8, 1);
+    String deanery = "North West";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, dateInRange, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, CURRICULUM_SPECIALTY)));
+    traineeProfile.getProgrammeMemberships().get(0).setProgrammeName(programme);
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(true));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
+  @ParameterizedTest
+  @ValueSource(strings = {"Cardio-thoracic surgery (run through)",
+      "Oral and maxillo-facial surgery (run through)"})
+  void pilot2024ShouldBeFalseIfNwLoWithIncorrectStartDateAndOkProgramme_old(String programme) {
     LocalDate dateOutOfRange = LocalDate.of(2024, 7, 1);
     String deanery = "Health Education England North West";
     TraineeProfile traineeProfile = new TraineeProfile();
@@ -1217,12 +1538,55 @@ class ProgrammeMembershipServiceTest {
     assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"Cardio-thoracic surgery (run through)",
+      "Oral and maxillo-facial surgery (run through)"})
+  void pilot2024ShouldBeFalseIfNwLoWithIncorrectStartDateAndOkProgramme(String programme) {
+    LocalDate dateOutOfRange = LocalDate.of(2024, 7, 1);
+    String deanery = "North West";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, dateOutOfRange, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, CURRICULUM_SPECIALTY)));
+    traineeProfile.getProgrammeMemberships().get(0).setProgrammeName(programme);
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
+  /**
+   * @deprecated remove once Local Office renaming is complete, the new name is covered below.
+   */
+  @Deprecated
+  @Test
+  void pilot2024ShouldBeFalseIfConditionsNotMet_old() {
+    //obviously there are a number of scenarios that could (should) be tested here
+    LocalDate dateInRange = LocalDate.of(2024, 8, 1);
+    String invalidSpecialty = "some specialty";
+    String deanery = "Health Education England North West";
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setProgrammeMemberships(
+        List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
+            PROGRAMME_MEMBERSHIP_TYPE, dateInRange, END_DATE, deanery, TSS_CURRICULA.get(0),
+            CURRICULUM_SPECIALTY_CODE, invalidSpecialty)));
+
+    when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
+
+    boolean isPilot2024 = service.isPilot2024(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
+
+    assertThat("Unexpected isPilot2024 value.", isPilot2024, is(false));
+  }
+
   @Test
   void pilot2024ShouldBeFalseIfConditionsNotMet() {
     //obviously there are a number of scenarios that could (should) be tested here
     LocalDate dateInRange = LocalDate.of(2024, 8, 1);
     String invalidSpecialty = "some specialty";
-    String deanery = "Health Education England North West";
+    String deanery = "North West";
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setProgrammeMemberships(
         List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -75,7 +75,7 @@ class TraineeProfileServiceTest {
   private static final String PERSON_KNOWNAS = "Ivy";
   private static final String PERSON_MAIDENNAME = "N/A";
   private static final String PERSON_TITLE = "Mr";
-  private static final String PERSON_PERSONOWNER = "Health Education England Thames Valley";
+  private static final String PERSON_PERSONOWNER = "Thames Valley";
   private static final LocalDate PERSON_DATEOFBIRTH = LocalDate.parse("1991-11-11",
       DateTimeFormatter.ofPattern("yyyy-MM-dd"));
   private static final String PERSON_GENDER = "Male";

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TrainingNumberGeneratorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TrainingNumberGeneratorTest.java
@@ -537,18 +537,31 @@ class TrainingNumberGeneratorTest {
   @CsvSource(delimiter = '|', textBlock = """
       Defence Postgraduate Medical Deanery                   | TSD
       Health Education England East Midlands                 | EMD
+      East Midlands                                          | EMD
       Health Education England East of England               | EAN
+      East of England                                        | EAN
       Health Education England Kent, Surrey and Sussex       | KSS
+      Kent, Surrey and Sussex                                | KSS
       Health Education England North Central and East London | LDN
+      North Central and East London                          | LDN
       Health Education England North East                    | NTH
+      North East                                             | NTH
       Health Education England North West                    | NWE
+      North West                                             | NWE
       Health Education England North West London             | LDN
+      North West London                                      | LDN
       Health Education England South London                  | LDN
+      South London                                           | LDN
       Health Education England South West                    | SWN
+      South West                                             | SWN
       Health Education England Thames Valley                 | OXF
+      Thames Valley                                          | OXF
       Health Education England Wessex                        | WES
+      Wessex                                                 | WES
       Health Education England West Midlands                 | WMD
+      West Midlands                                          | WMD
       Health Education England Yorkshire and the Humber      | YHD
+      Yorkshire and the Humber                               | YHD
       London LETBs                                           | LDN
       """)
   void shouldPopulateTrainingNumberWithParentOrganizationWhenMappedByOwner(String ownerName,


### PR DESCRIPTION
The Local Office names are being renamed to remove the "Health Education England" prefix, as there is no clean cut switch-over period both the new and old names will have to be handled for a short time. Once the new local office names are fully synced the old ones can be removed.

TIS21-6418
TIS21-6419