### PR TITLE
fix: show all programmes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.8.1"
+version = "1.9.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
@@ -85,8 +85,6 @@ public class TraineeProfileResource {
       return ResponseEntity.notFound().build();
     }
 
-    traineeProfile = service.hidePastProgrammes(traineeProfile);
-    traineeProfile = service.hidePastPlacements(traineeProfile);
     return ResponseEntity.ok(mapper.toDto(traineeProfile));
   }
 

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -31,7 +31,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.trainee.details.dto.UserDetails;
 import uk.nhs.hee.trainee.details.dto.enumeration.GoldGuideVersion;
-import uk.nhs.hee.trainee.details.dto.enumeration.Status;
 import uk.nhs.hee.trainee.details.model.ConditionsOfJoining;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
 import uk.nhs.hee.trainee.details.model.Qualification;

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -161,39 +161,6 @@ public class TraineeProfileService {
   }
 
   /**
-   * Remove past programmes from the trainee profile.
-   *
-   * @param traineeProfile The trainee profile to modify.
-   * @return The modified trainee profile.
-   */
-  public TraineeProfile hidePastProgrammes(TraineeProfile traineeProfile) {
-    traineeProfile.getProgrammeMemberships().removeIf(c -> c.getStatus() == Status.PAST);
-    return traineeProfile;
-  }
-
-  /**
-   * Remove deprecated programmes from the trainee profile.
-   *
-   * @param traineeProfile The trainee profile to modify.
-   * @return The modified trainee profile.
-   */
-  public TraineeProfile hideDeprecatedProgrammes(TraineeProfile traineeProfile) {
-    traineeProfile.getProgrammeMemberships().removeIf(c -> c.getTisId().matches("[0-9,]+"));
-    return traineeProfile;
-  }
-
-  /**
-   * Remove past placements from the trainee profile.
-   *
-   * @param traineeProfile The trainee profile to modify.
-   * @return The modified trainee profile.
-   */
-  public TraineeProfile hidePastPlacements(TraineeProfile traineeProfile) {
-    traineeProfile.getPlacements().removeIf(c -> c.getStatus() == Status.PAST);
-    return traineeProfile;
-  }
-
-  /**
    * Delete a trainee profile.
    *
    * @param traineeTisId The TIS ID of the trainee to delete the profile for.

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -276,9 +276,6 @@ class TraineeProfileResourceTest {
   @Test
   void getShouldReturnTraineeProfileWhenTisIdExists() throws Exception {
     when(service.getTraineeProfileByTraineeTisId(DEFAULT_TIS_ID_1)).thenReturn(traineeProfile);
-    when(service.hidePastProgrammes(traineeProfile)).thenReturn(traineeProfile);
-    when(service.hideDeprecatedProgrammes(traineeProfile)).thenReturn(traineeProfile);
-    when(service.hidePastPlacements(traineeProfile)).thenReturn(traineeProfile);
 
     Signature signature = new Signature(Duration.ofMinutes(60));
     signature.setHmac("not-really-a-hmac");

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -239,27 +239,6 @@ class TraineeProfileServiceTest {
   }
 
   @Test
-  void hidePastProgrammesShouldHidePastProgrammes() {
-    var programmeMembership2 = new ProgrammeMembership();
-    programmeMembership2.setStartDate(LocalDate.now().minusYears(2));
-    programmeMembership2.setEndDate(LocalDate.now().minusYears(1));
-
-    List<ProgrammeMembership> programmeMemberships = traineeProfile.getProgrammeMemberships();
-    programmeMemberships.add(programmeMembership2);
-
-    TraineeProfile returnedTraineeProfile = service.hidePastProgrammes(traineeProfile);
-    assertThat(returnedTraineeProfile.getProgrammeMemberships().size(), is(1));
-    assertThat(returnedTraineeProfile.getProgrammeMemberships(), hasItem(programmeMembership));
-  }
-
-  @Test
-  void hidePastPlacementsShouldHidePastPlacements() {
-    TraineeProfile returnedTraineeProfile = service.hidePastPlacements(traineeProfile);
-    assertThat(returnedTraineeProfile.getPlacements(), hasItem(placement1));
-    assertThat(returnedTraineeProfile.getPlacements(), not(hasItem(placement2)));
-  }
-
-  @Test
   void shouldSortQualificationsInDescendingOrder() {
     Qualification qualification1 = new Qualification();
     qualification1.setDateAttained(LocalDate.now());

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -24,7 +24,6 @@ package uk.nhs.hee.trainee.details.service;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
Currently PAST programmes are filtered out, but they now need to be shown.
At the same time an attempt to filter placements in the same way fails because the placement status is only ever `CURRENT` or `null`.

Update TraineeProfileResource to remove the filtering of past data. Update TraineeProfileService to remove the functions that perform the filtering, along with a filter for deprecated programmes which is no longer used.

TIS21-6386
TIS21-6387
TIS21-6388