### PR TITLE
fix: handle null GMC number during NTN generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.9.0"
+version = "1.9.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TrainingNumberGenerator.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TrainingNumberGenerator.java
@@ -184,7 +184,8 @@ public class TrainingNumberGenerator {
    */
   private String getReferenceNumber(PersonalDetailsDto personalDetails) {
     String gmcNumber = personalDetails.getGmcNumber();
-    return gmcNumber.matches("\\d{7}") ? gmcNumber : personalDetails.getGdcNumber();
+    return gmcNumber != null && gmcNumber.matches("\\d{7}") ? gmcNumber
+        : personalDetails.getGdcNumber();
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TrainingNumberGeneratorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TrainingNumberGeneratorTest.java
@@ -1072,6 +1072,7 @@ class TrainingNumberGeneratorTest {
   }
 
   @ParameterizedTest
+  @NullAndEmptySource
   @ValueSource(strings = {"abc", "12345678"})
   void shouldPopulateTrainingNumberWithGdcNumberWhenValidAndGmcInvalid(String gmcNumber) {
     TraineeProfileDto profile = new TraineeProfileDto();


### PR DESCRIPTION
The NTN generation will fail if the GMC number is `null` instead of falling back to an existing GDC number.

TIS21-6425