### PR TITLE
feat: exclude non-onboarded trainees

### DIFF
--- a/src/main/java/uk/nhs/hee/trainee/details/api/PlacementResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/PlacementResource.java
@@ -77,8 +77,8 @@ public class PlacementResource {
   /**
    * Delete the placement for the trainee.
    *
-   * @param traineeTisId    The ID of the trainee to update.
-   * @param placementTisId  The ID of the placement to delete.
+   * @param traineeTisId   The ID of the trainee to update.
+   * @param placementTisId The ID of the placement to delete.
    * @return True if the placement was deleted.
    */
   @DeleteMapping("/{traineeTisId}/{placementTisId}")
@@ -115,7 +115,9 @@ public class PlacementResource {
     log.info("Assess 2024 pilot status: placement {} of trainee with TIS ID {}",
         placementId, traineeTisId);
     try {
-      boolean isPilot2024 = service.isPilot2024(traineeTisId, placementId);
+      boolean isPilot2024 =
+          service.canBeOnboarded(traineeTisId, placementId) && service.isPilot2024(traineeTisId,
+              placementId);
       return ResponseEntity.ok(isPilot2024);
     } catch (IllegalArgumentException | InvalidDataAccessApiUsageException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getLocalizedMessage());
@@ -136,7 +138,9 @@ public class PlacementResource {
     log.info("Assess 2024 pilot rollout status: placement {} of trainee with TIS ID {}",
         placementId, traineeTisId);
     try {
-      boolean isPilotRollout2024 = service.isPilotRollout2024(traineeTisId, placementId);
+      boolean isPilotRollout2024 =
+          service.canBeOnboarded(traineeTisId, placementId) && service.isPilotRollout2024(
+              traineeTisId, placementId);
       return ResponseEntity.ok(isPilotRollout2024);
     } catch (IllegalArgumentException | InvalidDataAccessApiUsageException e) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, e.getLocalizedMessage());

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PlacementService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PlacementService.java
@@ -144,7 +144,7 @@ public class PlacementService {
   private boolean canBeOnboarded(TraineeProfile traineeProfile, Placement placement) {
     String grade = placement.getGrade();
 
-    if (NON_ONBOARDED_GRADES.contains(grade)) {
+    if (NON_ONBOARDED_GRADES.contains(grade.toUpperCase())) {
       log.info("Placement not valid for onboarding with grade '{}'.", grade);
       return false;
     }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PlacementService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PlacementService.java
@@ -25,6 +25,7 @@ import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.trainee.details.mapper.PlacementMapper;
@@ -38,12 +39,21 @@ import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 @Slf4j
 public class PlacementService {
 
+  private static final Set<String> NON_ONBOARDED_GRADES = Set.of(
+      "DCT1", // Dental Core Training Year 1
+      "DCT2", // Dental Core Training Year 2
+      "DCT3", // Dental Core Training Year 3
+      "DFT", // Dental Foundation Training
+      "F1", // Foundation Year 1
+      "F2" // Foundation Year 2
+  );
+
   private final TraineeProfileRepository repository;
   private final PlacementMapper mapper;
   private final ProgrammeMembershipService programmeMembershipService;
 
   PlacementService(TraineeProfileRepository repository, PlacementMapper mapper,
-                   ProgrammeMembershipService programmeMembershipService) {
+      ProgrammeMembershipService programmeMembershipService) {
     this.repository = repository;
     this.mapper = mapper;
     this.programmeMembershipService = programmeMembershipService;
@@ -88,7 +98,6 @@ public class PlacementService {
    * @return True, or False if a trainee with the ID was not found or the placement was not found.
    */
   public boolean deletePlacementForTrainee(String traineeTisId, String placementTisId) {
-    boolean hasDeleted = false;
     TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
 
     if (traineeProfile == null) {
@@ -96,13 +105,52 @@ public class PlacementService {
     }
     List<Placement> placements = traineeProfile.getPlacements();
 
-    hasDeleted = placements.removeIf(p -> p.getTisId().equals(placementTisId));
+    boolean hasDeleted = placements.removeIf(p -> p.getTisId().equals(placementTisId));
 
     if (hasDeleted) {
       repository.save(traineeProfile);
       return true;
     }
     return false;
+  }
+
+  /**
+   * Check whether a trainee can be onboarded based on the given placement.
+   *
+   * @param traineeTisId The TIS id of the trainee.
+   * @param placementId  The ID of the placement to assess.
+   * @return Whether the trainee can be onboarded based on this placement.
+   */
+  public boolean canBeOnboarded(String traineeTisId, String placementId) {
+    TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
+
+    if (traineeProfile == null) {
+      log.info("Placement not valid for onboarding as no profile found for ID '{}'.", traineeTisId);
+      return false;
+    }
+
+    return traineeProfile.getPlacements().stream()
+        .filter(p -> p.getTisId().equals(placementId))
+        .anyMatch(p -> canBeOnboarded(traineeProfile, p));
+  }
+
+  /**
+   * Check whether a trainee can be onboarded based on the given placement.
+   *
+   * @param traineeProfile The profile of the trainee.
+   * @param placement      The placement to assess.
+   * @return Whether the trainee can be onboarded based on this placement.
+   */
+  private boolean canBeOnboarded(TraineeProfile traineeProfile, Placement placement) {
+    String grade = placement.getGrade();
+
+    if (NON_ONBOARDED_GRADES.contains(grade)) {
+      log.info("Placement not valid for onboarding with grade '{}'.", grade);
+      return false;
+    }
+
+    return getPossiblePlacementProgrammes(traineeProfile, placement).stream()
+        .anyMatch(programmeMembershipService::canBeOnboarded);
   }
 
   private Optional<Placement> pilotPreflightChecks(String traineeTisId, String placementId) {
@@ -136,16 +184,11 @@ public class PlacementService {
     if (optionalPlacement.isEmpty()) {
       return false;
     }
-    Placement placement = optionalPlacement.get();
-    LocalDate dayAfterPlacementStart = placement.getStartDate().plusDays(1);
-    LocalDate dayBeforePlacementStart = placement.getStartDate().minusDays(1);
 
     TraineeProfile traineeProfile = repository.findByTraineeTisId(traineeTisId);
-    return traineeProfile.getProgrammeMemberships().stream().filter(pm ->
-            pm.getStartDate().withDayOfMonth(1).isBefore(dayAfterPlacementStart)
-                && pm.getProgrammeCompletionDate().isAfter(dayBeforePlacementStart))
-        .anyMatch(pmInPeriod ->
-            programmeMembershipService.isPilot2024(traineeTisId, pmInPeriod.getTisId()));
+    return getPossiblePlacementProgrammes(traineeProfile, optionalPlacement.get()).stream()
+        .anyMatch(pmInPeriod -> programmeMembershipService.isPilot2024(traineeTisId,
+            pmInPeriod.getTisId()));
   }
 
   /**
@@ -186,5 +229,23 @@ public class PlacementService {
               : LocalDate.of(2024, 10, 31);
           return (placement.getStartDate().isAfter(notificationEpoch));
         });
+  }
+
+  /**
+   * Get the possible programme memberships associated with the given placement.
+   *
+   * @param traineeProfile The trainee profile to check PMs of.
+   * @param placement      The placement to assess.
+   * @return A list of possible programme memberships.
+   */
+  private List<ProgrammeMembership> getPossiblePlacementProgrammes(TraineeProfile traineeProfile,
+      Placement placement) {
+    LocalDate dayAfterPlacementStart = placement.getStartDate().plusDays(1);
+    LocalDate dayBeforePlacementStart = placement.getStartDate().minusDays(1);
+
+    return traineeProfile.getProgrammeMemberships().stream().filter(pm ->
+            pm.getStartDate().withDayOfMonth(1).isBefore(dayAfterPlacementStart)
+                && pm.getProgrammeCompletionDate().isAfter(dayBeforePlacementStart))
+        .toList();
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -298,6 +298,22 @@ public class ProgrammeMembershipService {
   }
 
   /**
+   * Check whether a trainee can be onboarded based on the given programme membership.
+   *
+   * @param programmeMembership The programme membership to assess.
+   * @return Whether the trainee can be onboarded based on this placement.
+   */
+  public boolean canBeOnboarded(ProgrammeMembership programmeMembership) {
+    if (!hasProgrammeMembershipTypeOfInterest(programmeMembership)) {
+      log.info("Programme Membership not valid for onboarding with type '{}'.",
+          programmeMembership.getProgrammeMembershipType());
+      return false;
+    }
+
+    return !getPmsTssCurricula(List.of(programmeMembership)).isEmpty();
+  }
+
+  /**
    * Assess if the programme membership for a trainee is in the 2024 pilot. Hopefully a temporary
    * kludge.
    *

--- a/src/test/java/uk/nhs/hee/trainee/details/api/PlacementResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/PlacementResourceTest.java
@@ -314,7 +314,7 @@ class PlacementResourceTest {
   }
 
   @Test
-  void shouldReturnTrueWhenBothCanBeOnboardedAndInPilotRollout2024False() throws Exception {
+  void shouldReturnFalseWhenBothCanBeOnboardedAndInPilotRollout2024False() throws Exception {
     when(service.canBeOnboarded("40", "1")).thenReturn(false);
     when(service.isPilotRollout2024("40", "1")).thenReturn(false);
 
@@ -329,7 +329,7 @@ class PlacementResourceTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void shouldReturnTrueWhenOneOfCanBeOnboardedOrInPilotRollout2024False(boolean isValid)
+  void shouldReturnFalseWhenOneOfCanBeOnboardedOrInPilotRollout2024False(boolean isValid)
       throws Exception {
     when(service.canBeOnboarded("40", "1")).thenReturn(isValid);
     when(service.isPilotRollout2024("40", "1")).thenReturn(!isValid);

--- a/src/test/java/uk/nhs/hee/trainee/details/api/PlacementResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/PlacementResourceTest.java
@@ -226,26 +226,66 @@ class PlacementResourceTest {
         .andExpect(status().isBadRequest());
   }
 
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void shouldReturnPlacementPilot2024WhenTraineeFound(boolean isPilot2024)
-      throws Exception {
-    when(service
-        .isPilot2024("40", "1"))
-        .thenReturn(isPilot2024);
+  @Test
+  void shouldReturnTrueWhenCanBeOnboardedAndInPilot2024() throws Exception {
+    when(service.canBeOnboarded("40", "1")).thenReturn(true);
+    when(service.isPilot2024("40", "1")).thenReturn(true);
 
     mockMvc.perform(
             get("/api/placement/ispilot2024/{traineeTisId}/{placementId}",
                 "40", "1")
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(content().string(String.valueOf(isPilot2024)))
+        .andExpect(content().string("true"))
         .andReturn();
   }
 
   @Test
+  void shouldReturnFalseWhenBothCanBeOnboardedAndInPilot2024False() throws Exception {
+    when(service.canBeOnboarded("40", "1")).thenReturn(false);
+    when(service.isPilot2024("40", "1")).thenReturn(false);
+
+    mockMvc.perform(
+            get("/api/placement/ispilot2024/{traineeTisId}/{placementId}",
+                "40", "1")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().string("false"))
+        .andReturn();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldReturnFalseWhenOneOfCanBeOnboardedOrInPilot2024False(boolean isValid)
+      throws Exception {
+    when(service.canBeOnboarded("40", "1")).thenReturn(isValid);
+    when(service.isPilot2024("40", "1")).thenReturn(!isValid);
+
+    mockMvc.perform(
+            get("/api/placement/ispilot2024/{traineeTisId}/{placementId}",
+                "40", "1")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().string("false"))
+        .andReturn();
+  }
+
+  @Test
+  void shouldThrowBadRequestWhenCanBeOnboardedException() throws Exception {
+    when(service
+        .canBeOnboarded("triggersError", "1"))
+        .thenThrow(new IllegalArgumentException());
+
+    mockMvc.perform(
+            get("/api/placement/ispilot2024/{traineeTisId}/{placementId}",
+                "triggersError", "1")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
   void shouldThrowBadRequestWhenPlacementPilot2024Exception() throws Exception {
+    when(service.canBeOnboarded("triggersError", "1")).thenReturn(true);
     when(service
         .isPilot2024("triggersError", "1"))
         .thenThrow(new IllegalArgumentException());
@@ -259,23 +299,66 @@ class PlacementResourceTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void shouldReturnPlacementPilotRollout2024WhenTraineeFound(boolean isPilotRollout2024)
+  void shouldReturnTrueWhenCanBeOnboardedAndInPilotRollout2024(boolean isPilotRollout2024)
       throws Exception {
-    when(service
-        .isPilotRollout2024("40", "1"))
-        .thenReturn(isPilotRollout2024);
+    when(service.canBeOnboarded("40", "1")).thenReturn(true);
+    when(service.isPilotRollout2024("40", "1")).thenReturn(true);
 
     mockMvc.perform(
             get("/api/placement/isrollout2024/{traineeTisId}/{placementId}",
                 "40", "1")
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(content().string(String.valueOf(isPilotRollout2024)))
+        .andExpect(content().string("true"))
         .andReturn();
   }
 
   @Test
+  void shouldReturnTrueWhenBothCanBeOnboardedAndInPilotRollout2024False() throws Exception {
+    when(service.canBeOnboarded("40", "1")).thenReturn(false);
+    when(service.isPilotRollout2024("40", "1")).thenReturn(false);
+
+    mockMvc.perform(
+            get("/api/placement/isrollout2024/{traineeTisId}/{placementId}",
+                "40", "1")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().string("false"))
+        .andReturn();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldReturnTrueWhenOneOfCanBeOnboardedOrInPilotRollout2024False(boolean isValid)
+      throws Exception {
+    when(service.canBeOnboarded("40", "1")).thenReturn(isValid);
+    when(service.isPilotRollout2024("40", "1")).thenReturn(!isValid);
+
+    mockMvc.perform(
+            get("/api/placement/isrollout2024/{traineeTisId}/{placementId}",
+                "40", "1")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().string("false"))
+        .andReturn();
+  }
+
+  @Test
+  void shouldThrowBadRequestWhenPlacementCanBeOnboardedException() throws Exception {
+    when(service
+        .canBeOnboarded("triggersError", "1"))
+        .thenThrow(new IllegalArgumentException());
+
+    mockMvc.perform(
+            get("/api/placement/isrollout2024/{traineeTisId}/{placementId}",
+                "triggersError", "1")
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
   void shouldThrowBadRequestWhenPlacementPilotRollout2024Exception() throws Exception {
+    when(service.canBeOnboarded("triggersError", "1")).thenReturn(true);
     when(service
         .isPilotRollout2024("triggersError", "1"))
         .thenThrow(new IllegalArgumentException());

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PlacementServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PlacementServiceTest.java
@@ -265,7 +265,7 @@ class PlacementServiceTest {
     placement.setGrade(grade);
 
     TraineeProfile traineeProfile = new TraineeProfile();
-    traineeProfile.getPlacements().add(createPlacement(EXISTING_PLACEMENT_ID, ORIGINAL_SUFFIX, 0));
+    traineeProfile.getPlacements().add(placement);
 
     when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
 

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PlacementServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PlacementServiceTest.java
@@ -254,11 +254,11 @@ class PlacementServiceTest {
   @ParameterizedTest
   @ValueSource(strings = {
       "DCT1", // Dental Core Training Year 1
-      "DCT2", // Dental Core Training Year 2
+      "dct2", // Dental Core Training Year 2
       "DCT3", // Dental Core Training Year 3
       "DFT", // Dental Foundation Training
       "F1", // Foundation Year 1
-      "F2" // Foundation Year 2
+      "f2" // Foundation Year 2
   })
   void shouldNotBeOnboardableWhenNonOnBoardedGrade(String grade) {
     Placement placement = createPlacement(EXISTING_PLACEMENT_ID, ORIGINAL_SUFFIX, 0);
@@ -266,12 +266,17 @@ class PlacementServiceTest {
 
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.getPlacements().add(placement);
+    traineeProfile.getProgrammeMemberships()
+        .add(getProgrammeMembership("pm1", START_DATE, END_DATE));
+    traineeProfile.getProgrammeMemberships()
+        .add(getProgrammeMembership("pm2", START_DATE, END_DATE));
 
     when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
 
     boolean canBeOnboarded = service.canBeOnboarded(TRAINEE_TIS_ID, EXISTING_PLACEMENT_ID);
 
     assertThat("Unexpected canBeOnboarded result.", canBeOnboarded, is(false));
+    verifyNoInteractions(programmeMembershipService);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Exclude non-onboarded trainees when assessing pilot placement inclusion, this category includes Dental, Foundation and Public Health trainees.

Placement exclusion can be based on the grade matching one of
 - `DCT1`
 - `DCT2`
 - `DCT3`
 - `DFT`
 - `F1`
 - `F2`

Programme Membership exclusion can be based on the specialty name matching one of
 - "Public Health Medicine"
 - "Foundation"

Or Programme Membership type matching one of
 - `VISITOR`
 - `LAT`

Or no curricula sub-type matching
 - `MEDICAL_CURRICULUM`
 - `MEDICAL_SPR`

TIS21-6643