### PR TITLE
refactor: inject trainee ID in to controllers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.13.0"
+version = "1.14.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResource.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -37,12 +36,11 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-import uk.nhs.hee.trainee.details.api.util.AuthTokenUtil;
 import uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto;
+import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
 import uk.nhs.hee.trainee.details.mapper.ProgrammeMembershipMapper;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 import uk.nhs.hee.trainee.details.service.EventPublishService;
@@ -60,15 +58,18 @@ public class ProgrammeMembershipResource {
   private final ProgrammeMembershipService service;
   private final ProgrammeMembershipMapper mapper;
   private final EventPublishService eventPublishService;
+  private final TraineeIdentity traineeIdentity;
 
   /**
    * ProgrammeMembershipResource class constructor.
    */
   public ProgrammeMembershipResource(ProgrammeMembershipService service,
-      ProgrammeMembershipMapper mapper, EventPublishService eventPublishService) {
+      ProgrammeMembershipMapper mapper, EventPublishService eventPublishService,
+      TraineeIdentity traineeIdentity) {
     this.service = service;
     this.mapper = mapper;
     this.eventPublishService = eventPublishService;
+    this.traineeIdentity = traineeIdentity;
   }
 
   /**
@@ -149,15 +150,12 @@ public class ProgrammeMembershipResource {
    */
   @PostMapping("/{programmeMembershipId}/sign-coj")
   public ResponseEntity<ProgrammeMembershipDto> signCoj(
-      @PathVariable String programmeMembershipId,
-      @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+      @PathVariable String programmeMembershipId) {
     log.info("Signing COJ with Programme Membership ID {}", programmeMembershipId);
+    String traineeTisId = traineeIdentity.getTraineeId();
 
-    String traineeTisId;
-    try {
-      traineeTisId = AuthTokenUtil.getTraineeTisId(token);
-    } catch (IOException e) {
-      log.warn("Unable to read tisId from token.", e);
+    if (traineeTisId == null) {
+      log.warn("No trainee ID provided.");
       return ResponseEntity.badRequest().build();
     }
 
@@ -176,20 +174,15 @@ public class ProgrammeMembershipResource {
    * Generate programme confirmation PDF of a programme membership.
    *
    * @param programmeMembershipId The ID of the programme membership for generating PDF.
-   * @param token The authorization token from the request header.
    * @return The generated Programme Membership confirmation PDF.
    */
   @GetMapping(value = "/{programmeMembershipId}/confirmation",
       produces = MediaType.APPLICATION_PDF_VALUE)
-  public ResponseEntity<byte[]> downloadPdf(
-      @PathVariable String programmeMembershipId,
-      @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+  public ResponseEntity<byte[]> downloadPdf(@PathVariable String programmeMembershipId) {
+    String traineeTisId = traineeIdentity.getTraineeId();
 
-    String traineeTisId;
-    try {
-      traineeTisId = AuthTokenUtil.getTraineeTisId(token);
-    } catch (IOException e) {
-      log.warn("Unable to read tisId from token.", e);
+    if (traineeTisId == null) {
+      log.warn("No trainee ID provided.");
       return ResponseEntity.badRequest().build();
     }
 

--- a/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/TraineeProfileResource.java
@@ -23,22 +23,19 @@ package uk.nhs.hee.trainee.details.api;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
 import jakarta.validation.constraints.NotNull;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import uk.nhs.hee.trainee.details.api.util.AuthTokenUtil;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
+import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
 import uk.nhs.hee.trainee.details.dto.TraineeProfileDto;
 import uk.nhs.hee.trainee.details.dto.UserDetails;
 import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapper;
@@ -53,28 +50,27 @@ public class TraineeProfileResource {
 
   private final TraineeProfileService service;
   private final TraineeProfileMapper mapper;
+  private final TraineeIdentity traineeIdentity;
 
-  protected TraineeProfileResource(TraineeProfileService service, TraineeProfileMapper mapper) {
+  protected TraineeProfileResource(TraineeProfileService service, TraineeProfileMapper mapper,
+      TraineeIdentity traineeIdentity) {
     this.service = service;
     this.mapper = mapper;
+    this.traineeIdentity = traineeIdentity;
   }
 
   /**
    * Get a trainee's profile.
    *
-   * @param token The authorization token from the request header.
    * @return The {@link PersonalDetailsDto} representing the trainee profile.
    */
   @GetMapping
-  public ResponseEntity<TraineeProfileDto> getTraineeProfile(
-      @RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+  public ResponseEntity<TraineeProfileDto> getTraineeProfile() {
     log.info("Trainee Profile of authenticated user.");
+    String tisId = traineeIdentity.getTraineeId();
 
-    String tisId;
-    try {
-      tisId = AuthTokenUtil.getTraineeTisId(token);
-    } catch (IOException e) {
-      log.warn("Unable to read tisId from token.", e);
+    if (tisId == null) {
+      log.warn("No trainee ID provided.");
       return ResponseEntity.badRequest().build();
     }
 

--- a/src/main/java/uk/nhs/hee/trainee/details/config/InterceptorConfiguration.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/InterceptorConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.annotation.RequestScope;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
+import uk.nhs.hee.trainee.details.interceptor.TraineeIdentityInterceptor;
+
+/**
+ * Configuration for interceptors.
+ */
+@Configuration
+public class InterceptorConfiguration implements WebMvcConfigurer {
+
+  @Override
+  public void addInterceptors(InterceptorRegistry registry) {
+    registry.addInterceptor(traineeIdentityInterceptor());
+  }
+
+  /**
+   * Create an interceptor for creating a {@link TraineeIdentity} from a request.
+   *
+   * @return The trainee identity inteceptor.
+   */
+  @Bean
+  public TraineeIdentityInterceptor traineeIdentityInterceptor() {
+    return new TraineeIdentityInterceptor(traineeIdentity());
+  }
+
+  /**
+   * Create a {@link TraineeIdentity} for each request.
+   *
+   * @return The created trainee identity.
+   */
+  @Bean
+  @RequestScope
+  public TraineeIdentity traineeIdentity() {
+    return new TraineeIdentity();
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/TraineeIdentity.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/TraineeIdentity.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.dto;
+
+import lombok.Data;
+
+/**
+ * Trainee identity data for an authenticated user.
+ */
+@Data
+public class TraineeIdentity {
+
+  String traineeId;
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptor.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptor.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.HandlerInterceptor;
+import uk.nhs.hee.trainee.details.api.util.AuthTokenUtil;
+import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
+
+/**
+ * An interceptor for creating a {@link TraineeIdentity} from a request.
+ */
+@Slf4j
+public class TraineeIdentityInterceptor implements HandlerInterceptor {
+
+  private final TraineeIdentity traineeIdentity;
+
+  public TraineeIdentityInterceptor(TraineeIdentity traineeIdentity) {
+    this.traineeIdentity = traineeIdentity;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+      Object handler) {
+    String authToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+    if (authToken != null) {
+      try {
+        String traineeId = AuthTokenUtil.getTraineeTisId(authToken);
+        traineeIdentity.setTraineeId(traineeId);
+      } catch (IOException e) {
+        log.warn("Unable to extract trainee ID from authorization token.", e);
+      }
+    }
+
+    return true;
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
@@ -56,6 +56,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.nhs.hee.trainee.details.TestJwtUtil;
+import uk.nhs.hee.trainee.details.config.InterceptorConfiguration;
 import uk.nhs.hee.trainee.details.dto.ProgrammeMembershipDto;
 import uk.nhs.hee.trainee.details.dto.enumeration.GoldGuideVersion;
 import uk.nhs.hee.trainee.details.dto.signature.Signature;
@@ -71,7 +72,8 @@ import uk.nhs.hee.trainee.details.service.SignatureService;
 
 // Explicit import seems required when resource not included in Context Configuration.
 @Import(ProgrammeMembershipResource.class)
-@ContextConfiguration(classes = {ProgrammeMembershipMapperImpl.class, SignatureMapperImpl.class})
+@ContextConfiguration(classes = {ProgrammeMembershipMapperImpl.class, SignatureMapperImpl.class,
+    InterceptorConfiguration.class})
 @WebMvcTest(ProgrammeMembershipResource.class)
 class ProgrammeMembershipResourceTest {
 
@@ -280,13 +282,13 @@ class ProgrammeMembershipResourceTest {
   }
 
   @Test
-  void getShouldReturnNotFoundWhenTisIdNotInToken() throws Exception {
+  void getShouldReturnBadRequestWhenTisIdNotInToken() throws Exception {
     String token = TestJwtUtil.generateToken("{}");
 
     mockMvc.perform(post("/api/programme-membership/{programmeMembershipId}/sign-coj", 0)
             .contentType(MediaType.APPLICATION_JSON)
             .header(HttpHeaders.AUTHORIZATION, token))
-        .andExpect(status().isNotFound());
+        .andExpect(status().isBadRequest());
   }
 
   @Test
@@ -421,8 +423,8 @@ class ProgrammeMembershipResourceTest {
 
     String token = TestJwtUtil.generateTokenForTisId("tisIdValue");
     mockMvc.perform(get("/api/programme-membership/{programmeMembershipId}/confirmation", 40)
-        .contentType(MediaType.APPLICATION_JSON)
-        .header(HttpHeaders.AUTHORIZATION, token))
+            .contentType(MediaType.APPLICATION_JSON)
+            .header(HttpHeaders.AUTHORIZATION, token))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_PDF))
         .andExpect(content().bytes(response));

--- a/src/test/java/uk/nhs/hee/trainee/details/config/InterceptorConfigurationIntegrationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/InterceptorConfigurationIntegrationTest.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.web.context.WebApplicationContext;
+import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
+
+@SpringBootTest
+@ContextConfiguration(classes = InterceptorConfiguration.class)
+@WebAppConfiguration
+class InterceptorConfigurationIntegrationTest {
+
+  @Autowired
+  private WebApplicationContext context;
+
+  @Autowired
+  private MockHttpServletRequest request;
+
+  @Autowired
+  private TraineeIdentity traineeIdentity;
+
+  @Test
+  void shouldHaveRequestScopeOnTraineeIdentity() {
+    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
+
+    TraineeIdentity requestIdentity = (TraineeIdentity) request.getAttribute(
+        "scopedTarget.traineeIdentity");
+    assertThat("Unexpected trainee ID.", requestIdentity.getTraineeId(), nullValue());
+
+    TraineeIdentity contextIdentity = context.getBean("traineeIdentity", TraineeIdentity.class);
+    assertThat("Unexpected trainee ID.", contextIdentity.getTraineeId(), nullValue());
+
+    traineeIdentity.setTraineeId("40");
+
+    assertThat("Unexpected trainee ID.", requestIdentity.getTraineeId(), is("40"));
+    assertThat("Unexpected trainee ID.", contextIdentity.getTraineeId(), is("40"));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorIntegrationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorIntegrationTest.java
@@ -1,0 +1,122 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.interceptor;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.beans.HasPropertyWithValue.hasProperty;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.scope.ScopedProxyUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.trainee.details.TestJwtUtil;
+import uk.nhs.hee.trainee.details.config.InterceptorConfiguration;
+import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
+import uk.nhs.hee.trainee.details.interceptor.TraineeIdentityInterceptorIntegrationTest.InterceptorTestController;
+
+@WebMvcTest(InterceptorTestController.class)
+@Import(InterceptorConfiguration.class)
+class TraineeIdentityInterceptorIntegrationTest {
+
+  private static final String API_PATH = "/test/interceptor";
+  private static final String ID_1 = "40";
+  private static final String ID_2 = "41";
+
+  private static final String BEAN_NAME = "traineeIdentity";
+  private static final String TARGET_BEAN_NAME = ScopedProxyUtils.getTargetBeanName(BEAN_NAME);
+  private static final String TRAINEE_ID = "traineeId";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @SpyBean
+  private TraineeIdentityInterceptor interceptor;
+
+  @Test
+  void shouldAddTraineeIdToRequest() throws Exception {
+    mockMvc.perform(get(API_PATH)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(ID_1)))
+        .andExpect(request().attribute(BEAN_NAME, nullValue()))
+        .andExpect(request().attribute(TARGET_BEAN_NAME, hasProperty(TRAINEE_ID, is(ID_1))));
+
+    verify(interceptor).preHandle(any(), any(), any());
+  }
+
+  @Test
+  void shouldAddNewTraineeIdOnEachRequest() throws Exception {
+    mockMvc.perform(get(API_PATH)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(ID_1)))
+        .andExpect(request().attribute(BEAN_NAME, nullValue()))
+        .andExpect(request().attribute(TARGET_BEAN_NAME, hasProperty(TRAINEE_ID, is(ID_1))));
+
+    mockMvc.perform(get(API_PATH)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(ID_2)))
+        .andExpect(request().attribute(BEAN_NAME, nullValue()))
+        .andExpect(request().attribute(TARGET_BEAN_NAME, hasProperty(TRAINEE_ID, is(ID_2))));
+
+    verify(interceptor, times(2)).preHandle(any(), any(), any());
+  }
+
+  @Test
+  void shouldMakeTraineeIdentityAvailableToControllers() throws Exception {
+    mockMvc.perform(get(API_PATH)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(ID_1)))
+        .andExpect(content().string(ID_1));
+
+    mockMvc.perform(get(API_PATH)
+            .header(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId(ID_2)))
+        .andExpect(content().string(ID_2));
+  }
+
+  @SpringBootApplication
+  @RestController
+  public static class InterceptorTestController {
+
+    private final TraineeIdentity traineeIdentity;
+
+    public InterceptorTestController(TraineeIdentity traineeIdentity) {
+      this.traineeIdentity = traineeIdentity;
+    }
+
+    @GetMapping(API_PATH)
+    public String testInterceptor() {
+      assertThat("Unexpected trainee identity.", traineeIdentity, notNullValue());
+      return traineeIdentity.getTraineeId();
+    }
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.interceptor;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import uk.nhs.hee.trainee.details.TestJwtUtil;
+import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
+
+class TraineeIdentityInterceptorTest {
+
+  private TraineeIdentityInterceptor interceptor;
+  private TraineeIdentity traineeIdentity;
+
+  @BeforeEach
+  void setUp() {
+    traineeIdentity = new TraineeIdentity();
+    interceptor = new TraineeIdentityInterceptor(traineeIdentity);
+  }
+
+  @Test
+  void shouldNotSetTraineeIdWhenNoAuthToken() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(true));
+    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
+  }
+
+  @Test
+  void shouldNotSetTraineeIdWhenTokenNotMap() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("[]"));
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(true));
+    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
+  }
+
+  @Test
+  void shouldNotSetTraineeIdWhenNoTisIdInAuthToken() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("{}"));
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(true));
+    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
+  }
+
+  @Test
+  void shouldSetTraineeIdWhenTisIdInAuthToken() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId("40"));
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(true));
+    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), is("40"));
+  }
+}


### PR DESCRIPTION
# feat: create interceptor to inject trainee ID

Create a TraineeIdentityInterceptor to inject trainee identity details
(traineeTisId) in to the request scope.

The interceptor will run on each request and provides a single place
where the JWT token needs to be handled to extract the trainee ID. The
TraineeIdentity can be autowired in to any existing controllers and will
be auto-populated with the trainee ID.

---
# refactor: controllers to use TraineeIdentity

Refactor the existing controllers which are currently handling
extracting the trainee ID from the auth token themselves. Autowire a
TraineeIdentity to the controllers and get the trainee ID from it.
