### PR TITLE
test: create integration test module

### DIFF
--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/DockerImageNames.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/DockerImageNames.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details;
+
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Constants for {@link DockerImageName} values used in tests to ensure consistency.
+ */
+public class DockerImageNames {
+
+  public static final DockerImageName LOCALSTACK = DockerImageName.parse("localstack/localstack:3");
+  public static final DockerImageName MONGO = DockerImageName.parse("mongo:5");
+}

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/TisTraineeDetailsApplicationIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/TisTraineeDetailsApplicationIntegrationTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details;
+
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SNS;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SpringBootTest
+@Testcontainers(disabledWithoutDocker = true)
+class TisTraineeDetailsApplicationIntegrationTest {
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Container
+  private static final LocalStackContainer localstack = new LocalStackContainer(
+      DockerImageNames.LOCALSTACK)
+      .withServices(SNS, SQS);
+
+  @DynamicPropertySource
+  private static void overrideProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.cloud.aws.region.static", localstack::getRegion);
+    registry.add("spring.cloud.aws.credentials.access-key", localstack::getAccessKey);
+    registry.add("spring.cloud.aws.credentials.secret-key", localstack::getSecretKey);
+    registry.add("spring.cloud.aws.endpoint", () -> localstack.getEndpoint().toString());
+  }
+
+  @Test
+  void contextLoads() {
+
+  }
+}

--- a/src/integrationTest/resources/application-test.yml
+++ b/src/integrationTest/resources/application-test.yml
@@ -1,0 +1,16 @@
+application:
+  aws:
+    sns:
+      coj-signed: dummy
+      gmc-details-provided: dummy
+    sqs:
+      event: dummy
+      basic-details-update: dummy
+      contact-details-update: dummy
+      gdc-details-update: dummy
+      gmc-details-update: dummy
+      personal-info-update: dummy
+      person-owner-update: dummy
+
+mongock:
+  enabled: false


### PR DESCRIPTION
Create an integration test module, it should run after unit tests as part of the `check` task.
Create an application integration test to verify that the spring context can load.

Existing "integration like" tests have not been refactored/moved in to the new module yet.

NO-TICKET