### PR TITLE
fix: add default Local Office contact message for null contact

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.13.0"
+version = "1.13.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -68,6 +68,8 @@ public class ProgrammeMembershipService {
 
   protected static final String API_GET_OWNER_CONTACT
       = "/api/local-office-contact-by-lo-name/{localOfficeName}";
+  protected static final String DEFAULT_NO_CONTACT_MESSAGE
+      = "your local office";
   protected static final List<String> MEDICAL_CURRICULA
       = List.of("DENTAL_CURRICULUM", "DENTAL_POST_CCST", "MEDICAL_CURRICULUM");
   protected static final List<String> TSS_CURRICULA
@@ -525,7 +527,7 @@ public class ProgrammeMembershipService {
                 getOwnerContactList(programmeMembership.getManagingDeanery());
             String contact = getOwnerContact(ownerContactList,
                 LocalOfficeContactType.ONBOARDING_SUPPORT,
-                LocalOfficeContactType.TSS_SUPPORT, "");
+                LocalOfficeContactType.TSS_SUPPORT, DEFAULT_NO_CONTACT_MESSAGE);
 
             Map<String, Object> templateVariables = new HashMap<>();
             templateVariables.put("pm", programmeMembership);

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -41,6 +41,7 @@ import static uk.nhs.hee.trainee.details.model.HrefType.NON_HREF;
 import static uk.nhs.hee.trainee.details.model.HrefType.PROTOCOL_EMAIL;
 import static uk.nhs.hee.trainee.details.service.ProgrammeMembershipService.CONTACT_FIELD;
 import static uk.nhs.hee.trainee.details.service.ProgrammeMembershipService.CONTACT_TYPE_FIELD;
+import static uk.nhs.hee.trainee.details.service.ProgrammeMembershipService.DEFAULT_NO_CONTACT_MESSAGE;
 import static uk.nhs.hee.trainee.details.service.ProgrammeMembershipService.MEDICAL_CURRICULA;
 import static uk.nhs.hee.trainee.details.service.ProgrammeMembershipService.NON_RELEVANT_PROGRAMME_MEMBERSHIP_TYPES;
 import static uk.nhs.hee.trainee.details.service.ProgrammeMembershipService.NOT_TSS_SPECIALTIES;
@@ -1654,7 +1655,8 @@ class ProgrammeMembershipServiceTest {
     contacts.add(contact2);
 
     String ownerContact = service.getOwnerContact(contacts,
-        LocalOfficeContactType.TSS_SUPPORT, LocalOfficeContactType.DEFERRAL, "");
+        LocalOfficeContactType.TSS_SUPPORT, LocalOfficeContactType.DEFERRAL,
+        DEFAULT_NO_CONTACT_MESSAGE);
 
     assertThat("Unexpected owner contact.", ownerContact, is(contact1.get(CONTACT_FIELD)));
   }
@@ -1668,9 +1670,24 @@ class ProgrammeMembershipServiceTest {
     contacts.add(contact1);
 
     String ownerContact = service.getOwnerContact(contacts,
-        LocalOfficeContactType.ONBOARDING_SUPPORT, LocalOfficeContactType.TSS_SUPPORT, "");
+        LocalOfficeContactType.ONBOARDING_SUPPORT, LocalOfficeContactType.TSS_SUPPORT,
+        DEFAULT_NO_CONTACT_MESSAGE);
 
     assertThat("Unexpected owner contact.", ownerContact, is(contact1.get(CONTACT_FIELD)));
+  }
+
+  @Test
+  void shouldGetDefaultNoContactWhenContactMissingAndFallbackNull() {
+    List<Map<String, String>> contacts = new ArrayList<>();
+    Map<String, String> contact1 = new HashMap<>();
+    contact1.put(CONTACT_TYPE_FIELD, LocalOfficeContactType.TSS_SUPPORT.getContactTypeName());
+    contact1.put(CONTACT_FIELD, "one@email.com, another@email.com");
+    contacts.add(contact1);
+
+    String ownerContact = service.getOwnerContact(contacts,
+        LocalOfficeContactType.ONBOARDING_SUPPORT, null, DEFAULT_NO_CONTACT_MESSAGE);
+
+    assertThat("Unexpected owner contact.", ownerContact, is(DEFAULT_NO_CONTACT_MESSAGE));
   }
 
   @Test


### PR DESCRIPTION
to make sure the LO contact is not displayed as blank when the contact is null