### PR TITLE
feat: GET and POST CCT calculations endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.14.1"
+version = "1.15.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/TestJwtUtil.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/TestJwtUtil.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2022 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,31 +19,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.model;
+package uk.nhs.hee.trainee.details;
 
-import java.util.ArrayList;
-import java.util.List;
-import lombok.Data;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Version;
-import org.springframework.data.mongodb.core.index.Indexed;
-import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
-@Document(collection = "TraineeProfile")
-@Data
-public class TraineeProfile {
+/**
+ * A utility for generating test JWT tokens.
+ */
+public class TestJwtUtil {
 
-  @Id
-  private String id;
+  public static final String TIS_ID_ATTRIBUTE = "custom:tisId";
 
-  @Field(value = "traineeTisId")
-  private String traineeTisId;
-  private PersonalDetails personalDetails;
-  private List<Qualification> qualifications = new ArrayList<>();
-  private List<ProgrammeMembership> programmeMemberships = new ArrayList<>();
-  private List<Placement> placements = new ArrayList<>();
+  /**
+   * Generate a token with the given payload.
+   *
+   * @param payload The payload to inject in to the token.
+   * @return The generated token.
+   */
+  public static String generateToken(String payload) {
+    String encodedPayload = Base64.getUrlEncoder()
+        .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    return String.format("aGVhZGVy.%s.c2lnbmF0dXJl", encodedPayload);
+  }
 
-  @Version
-  Long version;
+  /**
+   * Generate a token with the TIS ID attribute as the payload.
+   *
+   * @param traineeTisId The TIS ID to inject in to the payload.
+   * @return The generated token.
+   */
+  public static String generateTokenForTisId(String traineeTisId) {
+    String payload = String.format("{\"%s\":\"%s\"}", TIS_ID_ATTRIBUTE, traineeTisId);
+    return generateToken(payload);
+  }
 }

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/TisTraineeDetailsApplicationIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/TisTraineeDetailsApplicationIntegrationTest.java
@@ -34,7 +34,7 @@ import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@SpringBootTest
+@SpringBootTest(properties = {"spring.cloud.aws.sqs.enabled=true"})
 @Testcontainers(disabledWithoutDocker = true)
 class TisTraineeDetailsApplicationIntegrationTest {
 

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -1,0 +1,187 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.jayway.jsonpath.JsonPath;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.trainee.details.DockerImageNames;
+import uk.nhs.hee.trainee.details.TestJwtUtil;
+import uk.nhs.hee.trainee.details.model.CctCalculation;
+
+@SpringBootTest
+@Testcontainers(disabledWithoutDocker = true)
+@AutoConfigureMockMvc
+class CctResourceIntegrationTest {
+
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate template;
+
+  @AfterEach
+  void tearDown() {
+    template.findAllAndRemove(new Query(), CctCalculation.class);
+  }
+
+  @Test
+  void shouldNotGetCalculationWhenNotOwnedByUser() throws Exception {
+    ObjectId id = ObjectId.get();
+    CctCalculation entity = CctCalculation.builder()
+        .id(id)
+        .traineeId(TRAINEE_ID)
+        .build();
+    template.insert(entity);
+
+    String token = TestJwtUtil.generateTokenForTisId(UUID.randomUUID().toString());
+    mockMvc.perform(get("/api/cct/calculation/{id}", id)
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$").doesNotExist());
+  }
+
+  @Test
+  void shouldGetCalculationWhenOwnedByUser() throws Exception {
+    ObjectId id = ObjectId.get();
+    CctCalculation entity = CctCalculation.builder()
+        .id(id)
+        .traineeId(TRAINEE_ID)
+        .build();
+    template.insert(entity);
+
+    String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
+    mockMvc.perform(get("/api/cct/calculation/{id}", id)
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").value(id.toString()))
+        .andExpect(jsonPath("$.traineeId").doesNotExist());
+  }
+
+  @Test
+  void shouldNotCreateCalculationWhenIdPopulated() throws Exception {
+    String body = """
+        {
+          "id": "%s",
+          "name": "Test Calculation"
+        }
+        """.formatted(ObjectId.get());
+
+    String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
+    mockMvc.perform(post("/api/cct/calculation")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().contentType(MediaType.APPLICATION_PROBLEM_JSON))
+        .andExpect(jsonPath("$.type", is("about:blank")))
+        .andExpect(jsonPath("$.title", is("Validation failure")))
+        .andExpect(jsonPath("$.status", is(HttpStatus.BAD_REQUEST.value())))
+        .andExpect(jsonPath("$.instance", is("/api/cct/calculation")))
+        .andExpect(jsonPath("$.errors").isArray())
+        .andExpect(jsonPath("$.errors", hasSize(1)))
+        .andExpect(jsonPath("$.errors[0].pointer", is("#/id")))
+        .andExpect(jsonPath("$.errors[0].detail", is("must be null")));
+  }
+
+  @Test
+  void shouldReturnCreatedCalculationJsonWhenIdNotPopulated() throws Exception {
+    String body = """
+        {
+          "name": "Test Calculation"
+        }
+        """;
+
+    String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
+    mockMvc.perform(post("/api/cct/calculation")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isCreated())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.id").exists())
+        .andExpect(jsonPath("$.traineeId").doesNotExist())
+        .andExpect(jsonPath("$.name").value("Test Calculation"));
+  }
+
+  @Test
+  void shouldReturnLocationOfCreatedCalculationWhenIdNotPopulated() throws Exception {
+    String body = """
+        {
+          "name": "Test Calculation"
+        }
+        """;
+
+    String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
+    MvcResult result = mockMvc.perform(
+            post("/api/cct/calculation")
+                .header(HttpHeaders.AUTHORIZATION, token)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andReturn();
+
+    MockHttpServletResponse response = result.getResponse();
+    String location = response.getHeader(HttpHeaders.LOCATION);
+    String id = JsonPath.read(response.getContentAsString(), "$.id");
+
+    assertThat("Unexpected location.", location, is("/api/cct/calculation/" + id));
+
+    mockMvc.perform(get(location)
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(jsonPath("$.id").value(id))
+        .andExpect(jsonPath("$.name").value("Test Calculation"));
+  }
+}

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -78,6 +78,22 @@ class CctResourceIntegrationTest {
   }
 
   @Test
+  void shouldBeForbiddenGettingCalculationWhenNoToken() throws Exception {
+    mockMvc.perform(get("/api/cct/calculation/{id}", "1"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$").doesNotExist());
+  }
+
+  @Test
+  void shouldBeForbiddenGettingCalculationWhenNoTraineeId() throws Exception {
+    String token = TestJwtUtil.generateToken("{}");
+    mockMvc.perform(get("/api/cct/calculation/{id}", "1")
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$").doesNotExist());
+  }
+
+  @Test
   void shouldNotGetCalculationWhenNotOwnedByUser() throws Exception {
     ObjectId id = ObjectId.get();
     CctCalculation entity = CctCalculation.builder()
@@ -109,6 +125,38 @@ class CctResourceIntegrationTest {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").value(id.toString()))
         .andExpect(jsonPath("$.traineeId").doesNotExist());
+  }
+
+  @Test
+  void shouldBeForbiddenCreatingCalculationWhenNoToken() throws Exception {
+    String body = """
+        {
+          "name": "Test Calculation"
+        }
+        """;
+
+    mockMvc.perform(post("/api/cct/calculation")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$").doesNotExist());
+  }
+
+  @Test
+  void shouldBeForbiddenCreatingCalculationWhenNoTraineeId() throws Exception {
+    String body = """
+        {
+          "name": "Test Calculation"
+        }
+        """;
+
+    String token = TestJwtUtil.generateToken("{}");
+    mockMvc.perform(post("/api/cct/calculation")
+            .header(HttpHeaders.AUTHORIZATION, token)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(body))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$").doesNotExist());
   }
 
   @Test

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/repository/CctCalculationRepositoryIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/repository/CctCalculationRepositoryIntegrationTest.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.repository;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.data.domain.Sort.Direction.ASC;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.IndexField;
+import org.springframework.data.mongodb.core.index.IndexInfo;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.trainee.details.DockerImageNames;
+import uk.nhs.hee.trainee.details.model.CctCalculation;
+
+@DataMongoTest
+@Testcontainers(disabledWithoutDocker = true)
+class CctCalculationRepositoryIntegrationTest {
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(
+      DockerImageNames.MONGO);
+
+  @Autowired
+  private MongoTemplate template;
+
+  @Test
+  void shouldHaveIndexes() {
+    IndexOperations indexOps = template.indexOps(CctCalculation.class);
+
+    assertThat("Unexpected index count.", indexOps.getIndexInfo().size(), is(3));
+  }
+
+  @ParameterizedTest
+  @CsvSource(delimiter = '|', textBlock = """
+      _id_                   | _id
+      traineeId              | traineeId
+      programmeMembership.id | programmeMembership.id
+      """)
+  void shouldHaveIndex(String name, String key) {
+    IndexOperations indexOps = template.indexOps(CctCalculation.class);
+
+    IndexInfo indexInfo = indexOps.getIndexInfo().stream()
+        .filter(idx -> idx.getName().equals(name))
+        .findAny()
+        .orElseThrow(() -> new AssertionError("Expected index not found."));
+
+    assertThat("Unexpected index name.", indexInfo.getName(), is(name));
+    assertThat("Unexpected index hashed flag.", indexInfo.isHashed(), is(false));
+    assertThat("Unexpected index hidden flag.", indexInfo.isHidden(), is(false));
+    assertThat("Unexpected index sparse flag.", indexInfo.isSparse(), is(false));
+    assertThat("Unexpected index unique flag.", indexInfo.isUnique(), is(false));
+    assertThat("Unexpected index wildcard flag.", indexInfo.isWildcard(), is(false));
+
+    List<IndexField> indexFields = indexInfo.getIndexFields();
+    assertThat("Unexpected index field count.", indexFields.size(), is(1));
+
+    IndexField indexField = indexFields.get(0);
+    assertThat("Unexpected index field key.", indexField.getKey(), is(key));
+    assertThat("Unexpected index field direction.", indexField.getDirection(), is(ASC));
+  }
+}

--- a/src/integrationTest/resources/application-test.yml
+++ b/src/integrationTest/resources/application-test.yml
@@ -14,3 +14,11 @@ application:
 
 mongock:
   enabled: false
+
+spring:
+  cloud:
+    aws:
+      region:
+        static: eu-west-2
+      sqs:
+        enabled: false

--- a/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.api;
+
+import com.amazonaws.xray.spring.aop.XRayEnabled;
+import java.net.URI;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
+import uk.nhs.hee.trainee.details.dto.validation.Create;
+import uk.nhs.hee.trainee.details.service.CctService;
+
+/**
+ * A REST controller for CCT related endpoints.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/cct")
+@XRayEnabled
+public class CctResource {
+
+  private final CctService service;
+
+  /**
+   * Construct a REST controller for CCT related endpoints.
+   *
+   * @param service A service providing CCT functionality.
+   */
+  public CctResource(CctService service) {
+    this.service = service;
+  }
+
+  /**
+   * Get the details of a CCT calculation with the given ID.
+   *
+   * @param id The ID of the calculation to return.
+   * @return The found CCT calculation details.
+   */
+  @GetMapping("/calculation/{id}")
+  public ResponseEntity<CctCalculationDetailDto> getCalculationDetails(@PathVariable ObjectId id) {
+    log.info("Request to get details for CCT calculation[{}]", id);
+    Optional<CctCalculationDetailDto> calculation = service.getCalculation(id);
+    return ResponseEntity.of(calculation);
+  }
+
+  /**
+   * Create a new CCT calculation with the given details.
+   *
+   * @param calculation The CCT calculation details.
+   * @return The created CCT calculation details.
+   */
+  @PostMapping("/calculation")
+  public ResponseEntity<CctCalculationDetailDto> createCalculation(
+      @Validated(Create.class) @RequestBody CctCalculationDetailDto calculation) {
+    log.info("Request to create CCT calculation [{}]", calculation.name());
+    CctCalculationDetailDto savedCalculation = service.createCalculation(calculation);
+
+    log.info("Created CCT calculation [{}] with id [{}]", savedCalculation.name(),
+        savedCalculation.id());
+    return ResponseEntity.created(URI.create("/api/cct/calculation/" + savedCalculation.id()))
+        .body(savedCalculation);
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
@@ -23,12 +23,17 @@ package uk.nhs.hee.trainee.details.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import org.bson.types.ObjectId;
+import org.hibernate.validator.constraints.Range;
 import uk.nhs.hee.trainee.details.dto.enumeration.CctChangeType;
 import uk.nhs.hee.trainee.details.dto.validation.Create;
 
@@ -42,11 +47,20 @@ import uk.nhs.hee.trainee.details.dto.validation.Create;
  */
 @Builder
 public record CctCalculationDetailDto(
+
     @JsonSerialize(using = ToStringSerializer.class)
     @Null(groups = Create.class)
     ObjectId id,
+
+    @NotBlank
     String name,
+
+    @NotNull
+    @Valid
     CctProgrammeMembershipDto programmeMembership,
+
+    @NotEmpty
+    @Valid
     List<CctChangeDto> changes) {
 
   /**
@@ -60,11 +74,22 @@ public record CctCalculationDetailDto(
    */
   @Builder
   public record CctProgrammeMembershipDto(
+
+      @NotNull
       UUID id,
+
+      @NotBlank
       String name,
+
+      @NotNull
       LocalDate startDate,
+
+      @NotNull
       LocalDate endDate,
-      double wte) {
+
+      @NotNull
+      @Range(min = 0, max = 1)
+      Double wte) {
 
   }
 
@@ -77,9 +102,16 @@ public record CctCalculationDetailDto(
    */
   @Builder
   public record CctChangeDto(
+
+      @NotNull
       CctChangeType type,
+
+      @NotNull
       LocalDate startDate,
-      double wte) {
+
+      @NotNull
+      @Range(min = 0, max = 1)
+      Double wte) {
 
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import jakarta.validation.constraints.Null;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.bson.types.ObjectId;
+import uk.nhs.hee.trainee.details.dto.enumeration.CctChangeType;
+import uk.nhs.hee.trainee.details.dto.validation.Create;
+
+/**
+ * A representation of a CCT calculation's detail.
+ *
+ * @param id                  The ID of the calculation.
+ * @param name                A name for the calculation.
+ * @param programmeMembership The programme membership data for the calculation.
+ * @param changes             The CCT changes to be calculated.
+ */
+@Builder
+public record CctCalculationDetailDto(
+    @JsonSerialize(using = ToStringSerializer.class)
+    @Null(groups = Create.class)
+    ObjectId id,
+    String name,
+    CctProgrammeMembershipDto programmeMembership,
+    List<CctChangeDto> changes) {
+
+  /**
+   * Programme membership data for a calculation.
+   *
+   * @param id        The ID of the programme membership.
+   * @param name      The name of the programme.
+   * @param startDate The start date of the programme.
+   * @param endDate   The end date of the programme.
+   * @param wte       The whole time equivalent of the programme membership.
+   */
+  @Builder
+  public record CctProgrammeMembershipDto(
+      UUID id,
+      String name,
+      LocalDate startDate,
+      LocalDate endDate,
+      double wte) {
+
+  }
+
+  /**
+   * A CCT changes associated with a calculation.
+   *
+   * @param type      The type of CCT change.
+   * @param startDate The start date of the CCT change.
+   * @param wte       The new desired whole time equivalent.
+   */
+  @Builder
+  public record CctChangeDto(
+      CctChangeType type,
+      LocalDate startDate,
+      double wte) {
+
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/enumeration/CctChangeType.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/enumeration/CctChangeType.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,31 +19,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.model;
+package uk.nhs.hee.trainee.details.dto.enumeration;
 
-import java.util.ArrayList;
-import java.util.List;
-import lombok.Data;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Version;
-import org.springframework.data.mongodb.core.index.Indexed;
-import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
-
-@Document(collection = "TraineeProfile")
-@Data
-public class TraineeProfile {
-
-  @Id
-  private String id;
-
-  @Field(value = "traineeTisId")
-  private String traineeTisId;
-  private PersonalDetails personalDetails;
-  private List<Qualification> qualifications = new ArrayList<>();
-  private List<ProgrammeMembership> programmeMemberships = new ArrayList<>();
-  private List<Placement> placements = new ArrayList<>();
-
-  @Version
-  Long version;
+/**
+ * Supported CCT Change types.
+ */
+public enum CctChangeType {
+  LTFT
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/validation/Create.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/validation/Create.java
@@ -21,9 +21,11 @@
 
 package uk.nhs.hee.trainee.details.dto.validation;
 
+import jakarta.validation.groups.Default;
+
 /**
  * A validation group used when a resource is being created.
  */
-public interface Create {
+public interface Create extends Default {
 
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/validation/Create.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/validation/Create.java
@@ -21,6 +21,9 @@
 
 package uk.nhs.hee.trainee.details.dto.validation;
 
+/**
+ * A validation group used when a resource is being created.
+ */
 public interface Create {
 
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/exception/NotRecordOwnerException.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/exception/NotRecordOwnerException.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,31 +19,24 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.model;
+package uk.nhs.hee.trainee.details.exception;
 
-import java.util.ArrayList;
-import java.util.List;
-import lombok.Data;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Version;
-import org.springframework.data.mongodb.core.index.Indexed;
-import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
-@Document(collection = "TraineeProfile")
-@Data
-public class TraineeProfile {
+/**
+ * An exception to be thrown if the requested record is not owned by the current user.
+ */
+@ResponseStatus(HttpStatus.FORBIDDEN)
+public class NotRecordOwnerException extends RuntimeException {
 
-  @Id
-  private String id;
-
-  @Field(value = "traineeTisId")
-  private String traineeTisId;
-  private PersonalDetails personalDetails;
-  private List<Qualification> qualifications = new ArrayList<>();
-  private List<ProgrammeMembership> programmeMemberships = new ArrayList<>();
-  private List<Placement> placements = new ArrayList<>();
-
-  @Version
-  Long version;
+  /**
+   * Construct a new NotRecordOwnerException indicating that the requested record is not owned by
+   * the requesting user.
+   *
+   * @param message The exception detail.
+   */
+  public NotRecordOwnerException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptor.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptor.java
@@ -26,6 +26,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.servlet.HandlerInterceptor;
 import uk.nhs.hee.trainee.details.api.util.AuthTokenUtil;
 import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
@@ -54,6 +55,14 @@ public class TraineeIdentityInterceptor implements HandlerInterceptor {
       } catch (IOException e) {
         log.warn("Unable to extract trainee ID from authorization token.", e);
       }
+    }
+
+    // Non-CCT endpoints are a mix of authenticated (public) and unauthenticated (internal), limit
+    // trainee ID verification to CCT endpoints for now.
+    if (traineeIdentity.getTraineeId() == null
+        && request.getRequestURI().matches("^/api/cct(/.+)?$")) {
+      response.setStatus(HttpStatus.FORBIDDEN.value());
+      return false;
     }
 
     return true;

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/CctMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/CctMapper.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.mapper;
+
+import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
+import uk.nhs.hee.trainee.details.model.CctCalculation;
+
+/**
+ * A mapper to convert between CCT related entities and DTOs.
+ */
+@Mapper(componentModel = SPRING)
+public interface CctMapper {
+
+  /**
+   * Convert a {@link CctCalculation} entity to a {@link CctCalculationDetailDto} DTO.
+   *
+   * @param entity The entity to convert to a DTO.
+   * @return The equivalent detail DTO.
+   */
+  CctCalculationDetailDto toDetailDto(CctCalculation entity);
+
+  /**
+   * Convert a {@link CctCalculationDetailDto} DTO to a {@link CctCalculation} entity.
+   *
+   * @param dto       The DTO to convert to an entity.
+   * @param traineeId The ID of the trainee the calculation is for.
+   * @return The equivalent entity with trainee ID injected.
+   */
+  @Mapping(target = "traineeId", source = "traineeId")
+  CctCalculation toEntity(CctCalculationDetailDto dto, String traineeId);
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
@@ -85,7 +85,7 @@ public record CctCalculation(
   public record CctChange(
       CctChangeType type,
       LocalDate startDate,
-      double wte) {
+      Double wte) {
 
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.model;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import lombok.Builder;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import uk.nhs.hee.trainee.details.dto.enumeration.CctChangeType;
+
+/**
+ * A representation of a CCT calculation.
+ *
+ * @param id                  The ID of the calculation.
+ * @param traineeId           The ID of the trainee associated with the calculation.
+ * @param name                A name for the calculation.
+ * @param programmeMembership The programme membership data for the calculation.
+ * @param changes             The CCT changes to be calculated.
+ */
+@Document("CctCalculation")
+@Builder
+public record CctCalculation(
+    @Id
+    ObjectId id,
+    @Indexed
+    String traineeId,
+    String name,
+    CctProgrammeMembership programmeMembership,
+    List<CctChange> changes
+) {
+
+  /**
+   * Programme membership data for a calculation.
+   *
+   * @param id        The ID of the programme membership.
+   * @param name      The name of the programme.
+   * @param startDate The start date of the programme.
+   * @param endDate   The end date of the programme.
+   * @param wte       The whole time equivalent of the programme membership.
+   */
+  @Builder
+  public record CctProgrammeMembership(
+      @Indexed
+      @Field("id")
+      UUID id,
+      String name,
+      LocalDate startDate,
+      LocalDate endDate,
+      double wte) {
+
+  }
+
+  /**
+   * A CCT changes associated with a calculation.
+   *
+   * @param type      The type of CCT change.
+   * @param startDate The start date of the CCT change.
+   * @param wte       The new desired whole time equivalent.
+   */
+  @Builder
+  public record CctChange(
+      CctChangeType type,
+      LocalDate startDate,
+      double wte) {
+
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/repository/CctCalculationRepository.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/repository/CctCalculationRepository.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2024 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,31 +19,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.model;
+package uk.nhs.hee.trainee.details.repository;
 
-import java.util.ArrayList;
-import java.util.List;
-import lombok.Data;
-import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Version;
-import org.springframework.data.mongodb.core.index.Indexed;
-import org.springframework.data.mongodb.core.mapping.Document;
-import org.springframework.data.mongodb.core.mapping.Field;
+import org.bson.types.ObjectId;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+import uk.nhs.hee.trainee.details.model.CctCalculation;
 
-@Document(collection = "TraineeProfile")
-@Data
-public class TraineeProfile {
+/**
+ * A repository for CCT calculations.
+ */
+@Repository
+public interface CctCalculationRepository extends MongoRepository<CctCalculation, ObjectId> {
 
-  @Id
-  private String id;
-
-  @Field(value = "traineeTisId")
-  private String traineeTisId;
-  private PersonalDetails personalDetails;
-  private List<Qualification> qualifications = new ArrayList<>();
-  private List<ProgrammeMembership> programmeMemberships = new ArrayList<>();
-  private List<Placement> placements = new ArrayList<>();
-
-  @Version
-  Long version;
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.service;
+
+import com.amazonaws.xray.spring.aop.XRayEnabled;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
+import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
+import uk.nhs.hee.trainee.details.exception.NotRecordOwnerException;
+import uk.nhs.hee.trainee.details.mapper.CctMapper;
+import uk.nhs.hee.trainee.details.model.CctCalculation;
+import uk.nhs.hee.trainee.details.repository.CctCalculationRepository;
+
+/**
+ * A service for CCT related functionality.
+ */
+@Slf4j
+@Service
+@XRayEnabled
+public class CctService {
+
+  private final TraineeIdentity traineeIdentity;
+
+  private final CctCalculationRepository calculationRepository;
+  private final CctMapper mapper;
+
+  /**
+   * Create a service for CCT functionality.
+   *
+   * @param traineeIdentity       The identity of the current user.
+   * @param calculationRepository The repository for CCT calculations.
+   * @param mapper                A mapper to convert between CCT data types.
+   */
+  public CctService(TraineeIdentity traineeIdentity, CctCalculationRepository calculationRepository,
+      CctMapper mapper) {
+    this.traineeIdentity = traineeIdentity;
+    this.calculationRepository = calculationRepository;
+    this.mapper = mapper;
+  }
+
+  /**
+   * Get a CCT calculation with the given ID, it must belong to the currently authenticated user.
+   *
+   * @param id The ID of the CCT calculation to retrieve.
+   * @return The found CCT calculation, or empty when not found.
+   * @throws NotRecordOwnerException If the found CCT calculation does not belong to the current
+   *                                 user.
+   */
+  public Optional<CctCalculationDetailDto> getCalculation(ObjectId id) {
+    log.info("Getting CCT calculation [{}]", id);
+    String traineeId = traineeIdentity.getTraineeId();
+    Optional<CctCalculation> entity = calculationRepository.findById(id);
+
+    if (entity.isPresent() && !entity.get().traineeId().equals(traineeId)) {
+      String message = "CCT Calculation [%s] does not belong to authenticated user [%s]."
+          .formatted(id, traineeId);
+      throw new NotRecordOwnerException(message);
+    }
+
+    log.info("CCT calculation found: [{}]", entity.isPresent());
+    return entity.map(mapper::toDetailDto);
+  }
+
+  /**
+   * Create a new CCT calculation.
+   *
+   * @param dto The detail of the CCT calculation.
+   * @return The created CCT calculation.
+   */
+  public CctCalculationDetailDto createCalculation(CctCalculationDetailDto dto) {
+    log.info("Creating CCT calculation [{}]", dto.name());
+    CctCalculation entity = mapper.toEntity(dto, traineeIdentity.getTraineeId());
+    entity = calculationRepository.insert(entity);
+
+    log.info("Created CCT calculation [{}] with id [{}]", dto.name(), entity.id());
+    return mapper.toDetailDto(entity);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,7 @@ spring:
   data:
     mongodb:
       uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:trainee}?authSource=admin
+      auto-index-creation: true
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}

--- a/src/test/java/uk/nhs/hee/trainee/details/api/CctResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/CctResourceTest.java
@@ -1,0 +1,131 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.OK;
+
+import java.net.URI;
+import java.util.Optional;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
+import uk.nhs.hee.trainee.details.service.CctService;
+
+class CctResourceTest {
+
+  private CctResource controller;
+  private CctService service;
+
+  @BeforeEach
+  void setUp() {
+    service = mock(CctService.class);
+    controller = new CctResource(service);
+  }
+
+  @Test
+  void shouldNotGetCalculationDetailWhenCalculationNotExists() {
+    ObjectId id = ObjectId.get();
+    when(service.getCalculation(id)).thenReturn(Optional.empty());
+
+    ResponseEntity<CctCalculationDetailDto> response = controller.getCalculationDetails(id);
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(NOT_FOUND));
+    assertThat("Unexpected response code.", response.getBody(), nullValue());
+  }
+
+  @Test
+  void shouldGetCalculationDetailWhenCalculationExists() {
+    ObjectId id = ObjectId.get();
+    CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
+        .id(id)
+        .name("Test Calculation")
+        .build();
+    when(service.getCalculation(id)).thenReturn(Optional.of(dto));
+
+    ResponseEntity<CctCalculationDetailDto> response = controller.getCalculationDetails(id);
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
+    assertThat("Unexpected response body.", response.getBody(), sameInstance(dto));
+  }
+
+  @Test
+  void shouldReturnCreatedCalculation() {
+    CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
+        .name("Test Calculation")
+        .build();
+
+    ObjectId id = ObjectId.get();
+    when(service.createCalculation(any())).thenAnswer(inv -> {
+      CctCalculationDetailDto arg = inv.getArgument(0);
+      return CctCalculationDetailDto.builder()
+          .id(id)
+          .name(arg.name())
+          .build();
+    });
+
+    ResponseEntity<CctCalculationDetailDto> response = controller.createCalculation(dto);
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(CREATED));
+
+    CctCalculationDetailDto responseBody = response.getBody();
+    assertThat("Unexpected response body.", responseBody, notNullValue());
+    assertThat("Unexpected ID.", responseBody.id(), is(id));
+    assertThat("Unexpected name.", responseBody.name(), is("Test Calculation"));
+
+
+  }
+
+  @Test
+  void shouldReturnCreatedCalculationLocation() {
+    CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
+        .name("Test Calculation")
+        .build();
+
+    ObjectId id = ObjectId.get();
+    when(service.createCalculation(any())).thenAnswer(inv -> {
+      CctCalculationDetailDto arg = inv.getArgument(0);
+      return CctCalculationDetailDto.builder()
+          .id(id)
+          .name(arg.name())
+          .build();
+    });
+
+    ResponseEntity<CctCalculationDetailDto> response = controller.createCalculation(dto);
+
+    HttpHeaders headers = response.getHeaders();
+    assertThat("Unexpected response code.", headers.getLocation(),
+        is(URI.create("/api/cct/calculation/" + id)));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorTest.java
@@ -46,6 +46,17 @@ class TraineeIdentityInterceptorTest {
     interceptor = new TraineeIdentityInterceptor(traineeIdentity);
   }
 
+  @Test
+  void shouldReturnTrueAndNotSetTraineeIdWhenNoAuthTokenAndNonCctEndpoint() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/api/test");
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(true));
+    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"/api/cct", "/api/cct/calculator", "/api/cct/calculator/1",
       "/api/cct/test/1"})
@@ -56,6 +67,18 @@ class TraineeIdentityInterceptorTest {
     boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
 
     assertThat("Unexpected result.", result, is(false));
+    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
+  }
+
+  @Test
+  void shouldReturnTrueAndNotSetTraineeIdWhenTokenNotMapAndNonCctEndpoint() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("[]"));
+    request.setRequestURI("/api/test");
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(true));
     assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
   }
 
@@ -73,10 +96,22 @@ class TraineeIdentityInterceptorTest {
     assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
   }
 
+  @Test
+  void shouldReturnTrueAndNotSetTraineeIdWhenNoTisIdInAuthTokenAndNonCctEndpoint() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("{}"));
+    request.setRequestURI("/api/test");
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(true));
+    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"/api/cct", "/api/cct/calculator", "/api/cct/calculator/1",
       "/api/cct/test/1"})
-  void shouldReturnTrueAndNotSetTraineeIdWhenNoTisIdInAuthToken(String uri) {
+  void shouldReturnFalseAndNotSetTraineeIdWhenNoTisIdInAuthTokenAndCctEndpoint(String uri) {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("{}"));
     request.setRequestURI(uri);
@@ -87,45 +122,10 @@ class TraineeIdentityInterceptorTest {
     assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
   }
 
-  @Test
-  void shouldReturnTrueAndNotSetTraineeIdWhenNoAuthToken() {
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    request.setRequestURI("/api/test");
-
-    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
-
-    assertThat("Unexpected result.", result, is(true));
-    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
-  }
-
-  @Test
-  void shouldReturnTrueAndNotSetTraineeIdWhenTokenNotMapAndNonCctEndpoint() {
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("[]"));
-    request.setRequestURI("/api/test");
-
-    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
-
-    assertThat("Unexpected result.", result, is(true));
-    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
-  }
-
-  @Test
-  void shouldReturnTrueAndNotSetTraineeIdWhenNoTisIdInAuthToken() {
-    MockHttpServletRequest request = new MockHttpServletRequest();
-    request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("{}"));
-    request.setRequestURI("/api/test");
-
-    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
-
-    assertThat("Unexpected result.", result, is(true));
-    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
-  }
-
   @ParameterizedTest
   @ValueSource(strings = {"/api/cct", "/api/cct/calculator", "/api/cct/calculator/1",
       "/api/cct/test/1", "/api/test"})
-  void shouldReturnTrueAndSetTraineeIdWhenTisIdInAuthToken() {
+  void shouldReturnTrueAndSetTraineeIdWhenTisIdInAuthTokenAndCctEndpoint() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId("40"));
 

--- a/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
@@ -1,0 +1,220 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2024 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.service;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.nhs.hee.trainee.details.dto.enumeration.CctChangeType.LTFT;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
+import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto.CctChangeDto;
+import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto.CctProgrammeMembershipDto;
+import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
+import uk.nhs.hee.trainee.details.exception.NotRecordOwnerException;
+import uk.nhs.hee.trainee.details.mapper.CctMapperImpl;
+import uk.nhs.hee.trainee.details.model.CctCalculation;
+import uk.nhs.hee.trainee.details.model.CctCalculation.CctChange;
+import uk.nhs.hee.trainee.details.model.CctCalculation.CctProgrammeMembership;
+import uk.nhs.hee.trainee.details.repository.CctCalculationRepository;
+
+class CctServiceTest {
+
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+
+  private CctService service;
+  private CctCalculationRepository calculationRepository;
+
+  @BeforeEach
+  void setUp() {
+    TraineeIdentity traineeIdentity = new TraineeIdentity();
+    traineeIdentity.setTraineeId(TRAINEE_ID);
+
+    calculationRepository = mock(CctCalculationRepository.class);
+
+    service = new CctService(traineeIdentity, calculationRepository, new CctMapperImpl());
+  }
+
+  @Test
+  void shouldReturnEmptyGettingCalculationWhenNotFound() {
+    ObjectId id = ObjectId.get();
+
+    when(calculationRepository.findById(id)).thenReturn(Optional.empty());
+
+    Optional<CctCalculationDetailDto> result = service.getCalculation(id);
+
+    assertThat("Unexpected calculation presence.", result.isPresent(), is(false));
+  }
+
+  @Test
+  void shouldThrowExceptionGettingCalculationWhenNotBelongsToUser() {
+    ObjectId id = ObjectId.get();
+    CctCalculation entity = CctCalculation.builder()
+        .id(id)
+        .traineeId(UUID.randomUUID().toString())
+        .build();
+
+    when(calculationRepository.findById(id)).thenReturn(Optional.of(entity));
+
+    assertThrows(NotRecordOwnerException.class, () -> service.getCalculation(id));
+  }
+
+  @Test
+  void shouldGetCalculationWhenBelongsToUser() {
+    ObjectId calculationId = ObjectId.get();
+    UUID pmId = UUID.randomUUID();
+
+    CctCalculation entity = CctCalculation.builder()
+        .id(calculationId)
+        .traineeId(TRAINEE_ID)
+        .name("Test Calculation")
+        .programmeMembership(CctProgrammeMembership.builder()
+            .id(pmId)
+            .name("Test Programme")
+            .startDate(LocalDate.EPOCH)
+            .endDate(LocalDate.EPOCH.plusYears(1))
+            .wte(1.0)
+            .build())
+        .changes(List.of(
+            CctChange.builder().type(LTFT).startDate(LocalDate.MIN).wte(0.5).build(),
+            CctChange.builder().type(LTFT).startDate(LocalDate.MAX).wte(0.75).build()
+        ))
+        .build();
+
+    when(calculationRepository.findById(calculationId)).thenReturn(Optional.of(entity));
+
+    Optional<CctCalculationDetailDto> result = service.getCalculation(calculationId);
+
+    assertThat("Unexpected calculation presence.", result.isPresent(), is(true));
+
+    CctCalculationDetailDto dto = result.get();
+    assertThat("Unexpected calculation ID.", dto.id(), is(calculationId));
+    assertThat("Unexpected calculation name.", dto.name(), is("Test Calculation"));
+
+    CctProgrammeMembershipDto pm = dto.programmeMembership();
+    assertThat("Unexpected PM ID.", pm.id(), is(pmId));
+    assertThat("Unexpected PM name.", pm.name(), is("Test Programme"));
+    assertThat("Unexpected PM start date.", pm.startDate(), is(LocalDate.EPOCH));
+    assertThat("Unexpected PM end date.", pm.endDate(), is(LocalDate.EPOCH.plusYears(1)));
+    assertThat("Unexpected PM WTE.", pm.wte(), is(1.0));
+
+    List<CctChangeDto> changes = dto.changes();
+    assertThat("Unexpected change count.", changes.size(), is(2));
+
+    CctChangeDto change1 = changes.get(0);
+    assertThat("Unexpected change type.", change1.type(), is(LTFT));
+    assertThat("Unexpected change type.", change1.startDate(), is(LocalDate.MIN));
+    assertThat("Unexpected change type.", change1.wte(), is(0.5));
+
+    CctChangeDto change2 = changes.get(1);
+    assertThat("Unexpected change type.", change2.type(), is(LTFT));
+    assertThat("Unexpected change type.", change2.startDate(), is(LocalDate.MAX));
+    assertThat("Unexpected change type.", change2.wte(), is(0.75));
+  }
+
+  @Test
+  void shouldCreateCalculation() {
+    UUID pmId = UUID.randomUUID();
+
+    CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
+        .name("Test Calculation")
+        .programmeMembership(CctProgrammeMembershipDto.builder()
+            .id(pmId)
+            .name("Test Programme")
+            .startDate(LocalDate.EPOCH)
+            .endDate(LocalDate.EPOCH.plusYears(1))
+            .wte(1.0)
+            .build())
+        .changes(List.of(
+            CctChangeDto.builder().type(LTFT).startDate(LocalDate.MIN).wte(0.5).build(),
+            CctChangeDto.builder().type(LTFT).startDate(LocalDate.MAX).wte(0.75).build()
+        ))
+        .build();
+
+    ObjectId calculationId = ObjectId.get();
+    when(calculationRepository.insert(any(CctCalculation.class))).thenAnswer(inv -> {
+      CctCalculation entity = inv.getArgument(0);
+      CctProgrammeMembership pm = entity.programmeMembership();
+      CctChange change1 = entity.changes().get(0);
+      CctChange change2 = entity.changes().get(1);
+
+      return CctCalculation.builder()
+          .id(calculationId)
+          .traineeId(entity.traineeId())
+          .name(entity.name())
+          .programmeMembership(CctProgrammeMembership.builder()
+              .id(pm.id())
+              .name(pm.name())
+              .startDate(pm.startDate())
+              .endDate(pm.endDate())
+              .wte(pm.wte())
+              .build())
+          .changes(List.of(
+              CctChange.builder()
+                  .type(change1.type())
+                  .startDate(change1.startDate())
+                  .wte(change1.wte())
+                  .build(),
+              CctChange.builder()
+                  .type(change2.type())
+                  .startDate(change2.startDate())
+                  .wte(change2.wte()).build()
+          ))
+          .build();
+    });
+
+    CctCalculationDetailDto savedDto = service.createCalculation(dto);
+    assertThat("Unexpected calculation ID.", savedDto.id(), is(calculationId));
+    assertThat("Unexpected calculation name.", savedDto.name(), is("Test Calculation"));
+
+    CctProgrammeMembershipDto pm = savedDto.programmeMembership();
+    assertThat("Unexpected PM ID.", pm.id(), is(pmId));
+    assertThat("Unexpected PM name.", pm.name(), is("Test Programme"));
+    assertThat("Unexpected PM start date.", pm.startDate(), is(LocalDate.EPOCH));
+    assertThat("Unexpected PM end date.", pm.endDate(), is(LocalDate.EPOCH.plusYears(1)));
+    assertThat("Unexpected PM WTE.", pm.wte(), is(1.0));
+
+    List<CctChangeDto> changes = savedDto.changes();
+    assertThat("Unexpected change count.", changes.size(), is(2));
+
+    CctChangeDto change1 = changes.get(0);
+    assertThat("Unexpected change type.", change1.type(), is(LTFT));
+    assertThat("Unexpected change type.", change1.startDate(), is(LocalDate.MIN));
+    assertThat("Unexpected change type.", change1.wte(), is(0.5));
+
+    CctChangeDto change2 = changes.get(1);
+    assertThat("Unexpected change type.", change2.type(), is(LTFT));
+    assertThat("Unexpected change type.", change2.startDate(), is(LocalDate.MAX));
+    assertThat("Unexpected change type.", change2.wte(), is(0.75));
+  }
+}


### PR DESCRIPTION
# feat: GET and POST CCT calculations endpoints
Create GET and POST endpoints for CCT calculations, the GET path should
be `/api/cct/calculation/{calculationId}` and the POST should be
`/api/cct/calculation`.
The only currently supported CCT change type is LTFT.

# feat: forbid CCT requests with no trainee ID
Previously each endpoint that required a trainee ID checked for the ID
and returned `400 Bad Request` if the ID was missing. Now there is a
centralised place for managing the `custom:tisId` token property the
trainee ID check can be done in a single place.
However, several existing endpoints are private/internal and do not
receive a token at all.

Update the TraineeIdentityInterceptor to reject only requests to the CCT
controller if the trainee ID is missing. In such cases a `403 Forbidden`
should be returned.
The interceptor can take over verification for other endpoints once the
unauthorised endpoints are refactored to allow sensible filtering based
on the request URI.

TIS21-6544
TIS21-6623