### PR TITLE
fix: allow to generate PM confiramtion PDF within 12 weeks inclusively

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.14.1"
+version = "1.14.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -517,7 +517,7 @@ public class ProgrammeMembershipService {
       // Only generate when PM start day is within 12 weeks
       for (ProgrammeMembership programmeMembership : existingProgrammeMemberships) {
         if (programmeMembership.getTisId().equals(programmeMembershipId)) {
-          if (programmeMembership.getStartDate().minusWeeks(PM_CONFIRM_WEEKS)
+          if (programmeMembership.getStartDate().minusWeeks(PM_CONFIRM_WEEKS).minusDays(1)
               .isBefore(LocalDate.now())) {
 
             // Template Variables

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -1631,8 +1631,8 @@ class ProgrammeMembershipServiceTest {
     traineeProfile.setPersonalDetails(createPersonalDetails(""));
     traineeProfile.setProgrammeMemberships(
         List.of(getProgrammeMembershipWithOneCurriculum(PROGRAMME_TIS_ID,
-            PROGRAMME_MEMBERSHIP_TYPE, START_DATE.plusWeeks(PM_CONFIRM_WEEKS), END_DATE,
-            MANAGING_DEANERY, TSS_CURRICULA.get(0),
+            PROGRAMME_MEMBERSHIP_TYPE, START_DATE.plusWeeks(PM_CONFIRM_WEEKS).plusDays(1),
+            END_DATE, MANAGING_DEANERY, TSS_CURRICULA.get(0),
             CURRICULUM_SPECIALTY_CODE, CURRICULUM_SPECIALTY)));
 
     when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);


### PR DESCRIPTION
to include start day just on the day 12 weeks ahead of today.