### PR TITLE
feat: CCT list calculations endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.15.1"
+version = "1.16.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.trainee.details.api;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
@@ -35,6 +36,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
+import uk.nhs.hee.trainee.details.dto.CctCalculationSummaryDto;
 import uk.nhs.hee.trainee.details.dto.validation.Create;
 import uk.nhs.hee.trainee.details.service.CctService;
 
@@ -56,6 +58,18 @@ public class CctResource {
    */
   public CctResource(CctService service) {
     this.service = service;
+  }
+
+  /**
+   * Get a list of CCT calculation summaries for the current user.
+   *
+   * @return The found CCT calculation summaries.
+   */
+  @GetMapping("/calculation")
+  public ResponseEntity<List<CctCalculationSummaryDto>> getCalculationSummaries() {
+    log.info("Request to get a summary for all CCT calculations");
+    List<CctCalculationSummaryDto> calculations = service.getCalculations();
+    return ResponseEntity.ok(calculations);
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/trainee/details/config/MongoConfiguration.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/MongoConfiguration.java
@@ -24,13 +24,18 @@ package uk.nhs.hee.trainee.details.config;
 import jakarta.annotation.PostConstruct;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.index.Index;
 import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.data.mongodb.core.index.IndexOperations;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
+/**
+ * Configuration for the Mongo database.
+ */
 @Configuration
+@EnableMongoAuditing
 public class MongoConfiguration {
 
   private final MongoTemplate template;

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
@@ -28,6 +28,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Null;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -61,7 +62,9 @@ public record CctCalculationDetailDto(
 
     @NotEmpty
     @Valid
-    List<CctChangeDto> changes) {
+    List<CctChangeDto> changes,
+    Instant created,
+    Instant lastModified) {
 
   /**
    * Programme membership data for a calculation.

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationSummaryDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationSummaryDto.java
@@ -23,6 +23,7 @@ package uk.nhs.hee.trainee.details.dto;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 import org.bson.types.ObjectId;
@@ -40,6 +41,8 @@ public record CctCalculationSummaryDto(
     @JsonSerialize(using = ToStringSerializer.class)
     ObjectId id,
     String name,
-    UUID programmeMembershipId) {
+    UUID programmeMembershipId,
+    Instant created,
+    Instant lastModified) {
 
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationSummaryDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationSummaryDto.java
@@ -19,25 +19,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.repository;
+package uk.nhs.hee.trainee.details.dto;
 
-import java.util.List;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import java.util.UUID;
+import lombok.Builder;
 import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.repository.MongoRepository;
-import org.springframework.stereotype.Repository;
-import uk.nhs.hee.trainee.details.model.CctCalculation;
 
 /**
- * A repository for CCT calculations.
+ * A summary of a CCT calculation.
+ *
+ * @param id                    The ID of the calculation.
+ * @param name                  The name of the calculation.
+ * @param programmeMembershipId The ID of the associated programme membership.
  */
-@Repository
-public interface CctCalculationRepository extends MongoRepository<CctCalculation, ObjectId> {
+@Builder
+public record CctCalculationSummaryDto(
 
-  /**
-   * Find all calculations belonging to the given trainee.
-   *
-   * @param traineeId The ID of the trainee.
-   * @return A list of found calculations.
-   */
-  List<CctCalculation> findByTraineeIdOrderByName(String traineeId);
+    @JsonSerialize(using = ToStringSerializer.class)
+    ObjectId id,
+    String name,
+    UUID programmeMembershipId) {
+
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/CctMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/CctMapper.java
@@ -23,9 +23,11 @@ package uk.nhs.hee.trainee.details.mapper;
 
 import static org.mapstruct.MappingConstants.ComponentModel.SPRING;
 
+import java.util.List;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
+import uk.nhs.hee.trainee.details.dto.CctCalculationSummaryDto;
 import uk.nhs.hee.trainee.details.model.CctCalculation;
 
 /**
@@ -33,6 +35,23 @@ import uk.nhs.hee.trainee.details.model.CctCalculation;
  */
 @Mapper(componentModel = SPRING)
 public interface CctMapper {
+
+  /**
+   * Convert a {@link CctCalculation} entity to a {@link CctCalculationSummaryDto} DTO.
+   *
+   * @param entity The entity to convert to a DTO.
+   * @return The equivalent summary DTO.
+   */
+  @Mapping(target = "programmeMembershipId", source = "programmeMembership.id")
+  CctCalculationSummaryDto toSummaryDto(CctCalculation entity);
+
+  /**
+   * Convert a list of {@link CctCalculation} to a list of {@link CctCalculationDetailDto}.
+   *
+   * @param entities The entities to convert to DTOs.
+   * @return The equivalent summary DTOs.
+   */
+  List<CctCalculationSummaryDto> toSummaryDtos(List<CctCalculation> entities);
 
   /**
    * Convert a {@link CctCalculation} entity to a {@link CctCalculationDetailDto} DTO.

--- a/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
@@ -21,12 +21,15 @@
 
 package uk.nhs.hee.trainee.details.model;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
 import org.bson.types.ObjectId;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
@@ -50,7 +53,13 @@ public record CctCalculation(
     String traineeId,
     String name,
     CctProgrammeMembership programmeMembership,
-    List<CctChange> changes
+    List<CctChange> changes,
+
+    @CreatedDate
+    Instant created,
+
+    @LastModifiedDate
+    Instant lastModified
 ) {
 
   /**

--- a/src/main/java/uk/nhs/hee/trainee/details/model/TraineeProfile.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/TraineeProfile.java
@@ -26,7 +26,6 @@ import java.util.List;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
-import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 

--- a/src/main/java/uk/nhs/hee/trainee/details/repository/CctCalculationRepository.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/repository/CctCalculationRepository.java
@@ -34,10 +34,10 @@ import uk.nhs.hee.trainee.details.model.CctCalculation;
 public interface CctCalculationRepository extends MongoRepository<CctCalculation, ObjectId> {
 
   /**
-   * Find all calculations belonging to the given trainee.
+   * Find all calculations belonging to the given trainee, ordered by last modified.
    *
    * @param traineeId The ID of the trainee.
    * @return A list of found calculations.
    */
-  List<CctCalculation> findByTraineeIdOrderByName(String traineeId);
+  List<CctCalculation> findByTraineeIdOrderByLastModified(String traineeId);
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -22,11 +22,13 @@
 package uk.nhs.hee.trainee.details.service;
 
 import com.amazonaws.xray.spring.aop.XRayEnabled;
+import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
+import uk.nhs.hee.trainee.details.dto.CctCalculationSummaryDto;
 import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
 import uk.nhs.hee.trainee.details.exception.NotRecordOwnerException;
 import uk.nhs.hee.trainee.details.mapper.CctMapper;
@@ -58,6 +60,21 @@ public class CctService {
     this.traineeIdentity = traineeIdentity;
     this.calculationRepository = calculationRepository;
     this.mapper = mapper;
+  }
+
+  /**
+   * Get a list of CCT calculation summaries for the current user.
+   *
+   * @return Summaries of the found CCT calculations, or empty when none found.
+   */
+  public List<CctCalculationSummaryDto> getCalculations() {
+    String traineeId = traineeIdentity.getTraineeId();
+    log.info("Getting CCT calculations for trainee [{}]", traineeId);
+
+    List<CctCalculation> entities = calculationRepository.findByTraineeIdOrderByName(traineeId);
+    log.info("Found {} CCT calculations for trainee [{}]", entities.size(), traineeId);
+
+    return mapper.toSummaryDtos(entities);
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -71,7 +71,8 @@ public class CctService {
     String traineeId = traineeIdentity.getTraineeId();
     log.info("Getting CCT calculations for trainee [{}]", traineeId);
 
-    List<CctCalculation> entities = calculationRepository.findByTraineeIdOrderByName(traineeId);
+    List<CctCalculation> entities = calculationRepository.findByTraineeIdOrderByLastModified(
+        traineeId);
     log.info("Found {} CCT calculations for trainee [{}]", entities.size(), traineeId);
 
     return mapper.toSummaryDtos(entities);

--- a/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.nhs.hee.trainee.details.dto.enumeration.CctChangeType.LTFT;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -68,7 +70,8 @@ class CctServiceTest {
 
   @Test
   void shouldReturnEmptyGettingCalculationsWhenNotFound() {
-    when(calculationRepository.findByTraineeIdOrderByName(TRAINEE_ID)).thenReturn(List.of());
+    when(calculationRepository.findByTraineeIdOrderByLastModified(TRAINEE_ID)).thenReturn(
+        List.of());
 
     List<CctCalculationSummaryDto> result = service.getCalculations();
 
@@ -79,6 +82,9 @@ class CctServiceTest {
   void shouldGetCalculationsWhenFound() {
     ObjectId calculationId1 = ObjectId.get();
     UUID pmId1 = UUID.randomUUID();
+    Instant created1 = Instant.now().minus(Duration.ofDays(1));
+    Instant lastModified1 = Instant.now().plus(Duration.ofDays(1));
+
     CctCalculation entity1 = CctCalculation.builder()
         .id(calculationId1)
         .traineeId(TRAINEE_ID)
@@ -86,10 +92,15 @@ class CctServiceTest {
         .programmeMembership(CctProgrammeMembership.builder()
             .id(pmId1)
             .build())
+        .created(created1)
+        .lastModified(lastModified1)
         .build();
 
     ObjectId calculationId2 = ObjectId.get();
     UUID pmId2 = UUID.randomUUID();
+    Instant created2 = Instant.now().minus(Duration.ofDays(2));
+    Instant lastModified2 = Instant.now().plus(Duration.ofDays(2));
+
     CctCalculation entity2 = CctCalculation.builder()
         .id(calculationId2)
         .traineeId(TRAINEE_ID)
@@ -97,9 +108,12 @@ class CctServiceTest {
         .programmeMembership(CctProgrammeMembership.builder()
             .id(pmId2)
             .build())
+        .created(created2)
+        .lastModified(lastModified2)
         .build();
 
-    when(calculationRepository.findByTraineeIdOrderByName(TRAINEE_ID)).thenReturn(List.of(entity1, entity2));
+    when(calculationRepository.findByTraineeIdOrderByLastModified(TRAINEE_ID)).thenReturn(
+        List.of(entity1, entity2));
 
     List<CctCalculationSummaryDto> result = service.getCalculations();
 
@@ -109,11 +123,15 @@ class CctServiceTest {
     assertThat("Unexpected calculation ID.", dto1.id(), is(calculationId1));
     assertThat("Unexpected calculation name.", dto1.name(), is("Test Calculation 1"));
     assertThat("Unexpected PM ID.", dto1.programmeMembershipId(), is(pmId1));
+    assertThat("Unexpected created timestamp.", dto1.created(), is(created1));
+    assertThat("Unexpected last modified timestamp.", dto1.lastModified(), is(lastModified1));
 
     CctCalculationSummaryDto dto2 = result.get(1);
     assertThat("Unexpected calculation ID.", dto2.id(), is(calculationId2));
     assertThat("Unexpected calculation name.", dto2.name(), is("Test Calculation 2"));
     assertThat("Unexpected PM ID.", dto2.programmeMembershipId(), is(pmId2));
+    assertThat("Unexpected created timestamp.", dto2.created(), is(created2));
+    assertThat("Unexpected last modified timestamp.", dto2.lastModified(), is(lastModified2));
   }
 
   @Test
@@ -145,6 +163,9 @@ class CctServiceTest {
     ObjectId calculationId = ObjectId.get();
     UUID pmId = UUID.randomUUID();
 
+    Instant created = Instant.now().minus(Duration.ofDays(1));
+    Instant lastModified = Instant.now().plus(Duration.ofDays(1));
+
     CctCalculation entity = CctCalculation.builder()
         .id(calculationId)
         .traineeId(TRAINEE_ID)
@@ -160,6 +181,8 @@ class CctServiceTest {
             CctChange.builder().type(LTFT).startDate(LocalDate.MIN).wte(0.5).build(),
             CctChange.builder().type(LTFT).startDate(LocalDate.MAX).wte(0.75).build()
         ))
+        .created(created)
+        .lastModified(lastModified)
         .build();
 
     when(calculationRepository.findById(calculationId)).thenReturn(Optional.of(entity));
@@ -171,6 +194,8 @@ class CctServiceTest {
     CctCalculationDetailDto dto = result.get();
     assertThat("Unexpected calculation ID.", dto.id(), is(calculationId));
     assertThat("Unexpected calculation name.", dto.name(), is("Test Calculation"));
+    assertThat("Unexpected created timestamp.", dto.created(), is(created));
+    assertThat("Unexpected last modified timestamp.", dto.lastModified(), is(lastModified));
 
     CctProgrammeMembershipDto pm = dto.programmeMembership();
     assertThat("Unexpected PM ID.", pm.id(), is(pmId));


### PR DESCRIPTION
# feat: CCT list calculations endpoint
Add a `GET: /api/cct/calculation` endpoint to retrieve all calculations
associated with the current user.

# feat: CCT list calculations endpoint
Add a `GET: /api/cct/calculation` endpoint to retrieve all calculations
associated with the current user.

TIS21-6544
TIS21-6623