### PR TITLE
fix: database UUID format

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.19.1"
+version = "1.19.2"
 
 configurations {
   compileOnly {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
     mongodb:
       uri: mongodb://${DB_USER:admin}:${DB_PASSWORD:pwd}@${DB_HOST:localhost}:${DB_PORT:27017}/${DB_NAME:trainee}?authSource=admin
       auto-index-creation: true
+      uuid-representation: standard
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}


### PR DESCRIPTION
UUIDs stored in the database are using the old UUID format (binData sub-type 3) instead of the new UUID format (binData sub-type 4).

Update the application configuration to use the new UUID format when storing UUIDs.

TIS21-6544
TIS21-6623