### PR TITLE
fix: create validation relaxed

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.19.2"
+version = "1.19.3"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -113,6 +113,7 @@ class CctResourceIntegrationTest {
             "endDate": "2025-01-01",
             "wte": 0.5
           },
+          "cctDate": "2024-01-01",
           "changes": [
             {
               "type": "LTFT",

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
@@ -67,7 +67,6 @@ public record CctCalculationDetailDto(
     @Valid
     List<CctChangeDto> changes,
 
-    @Null(groups = Create.class)
     LocalDate cctDate,
 
     Instant created,


### PR DESCRIPTION
Note: validation is not applied in the unit tests, so the only 'test' for this is by implication in the integration tests.

TIS21-6761