### PR TITLE
fix: CCT get endpoint to provide details not summaries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.20.0"
+version = "1.20.1"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -189,7 +189,7 @@ class CctResourceIntegrationTest {
         .andExpect(jsonPath("$", hasSize(1)))
         .andExpect(jsonPath("$[0].id").value(entity.id().toString()))
         .andExpect(jsonPath("$[0].name").value("Test Calculation"))
-        .andExpect(jsonPath("$[0].programmeMembershipId").value(pmId.toString()))
+        .andExpect(jsonPath("$[0].programmeMembership.id").value(pmId.toString()))
         .andExpect(jsonPath("$[0].created").value(
             entity.created().truncatedTo(ChronoUnit.MILLIS).toString()))
         .andExpect(jsonPath("$[0].lastModified").value(

--- a/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
@@ -37,7 +37,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
-import uk.nhs.hee.trainee.details.dto.CctCalculationSummaryDto;
 import uk.nhs.hee.trainee.details.dto.validation.Create;
 import uk.nhs.hee.trainee.details.service.CctService;
 
@@ -67,9 +66,9 @@ public class CctResource {
    * @return The found CCT calculation summaries.
    */
   @GetMapping("/calculation")
-  public ResponseEntity<List<CctCalculationSummaryDto>> getCalculationSummaries() {
-    log.info("Request to get a summary for all CCT calculations");
-    List<CctCalculationSummaryDto> calculations = service.getCalculations();
+  public ResponseEntity<List<CctCalculationDetailDto>> getCalculationDetails() {
+    log.info("Request to get details for all CCT calculations");
+    List<CctCalculationDetailDto> calculations = service.getCalculations();
     return ResponseEntity.ok(calculations);
   }
 

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/CctMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/CctMapper.java
@@ -64,6 +64,15 @@ public interface CctMapper {
   CctCalculationDetailDto toDetailDto(CctCalculation entity);
 
   /**
+   * Convert a list of {@link CctCalculation} to a list of {@link CctCalculationDetailDto}.
+   *
+   * @param entities The entities to convert to DTOs.
+   * @return The equivalent detail DTOs.
+   */
+  @Mapping(target = "cctDate", ignore = true)
+  List<CctCalculationDetailDto> toDetailDtos(List<CctCalculation> entities);
+
+  /**
    * Convert a {@link CctCalculation} entity to a {@link CctCalculationDetailDto} DTO, injecting
    * the CCT date into this.
    *

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/CctMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/CctMapper.java
@@ -64,15 +64,6 @@ public interface CctMapper {
   CctCalculationDetailDto toDetailDto(CctCalculation entity);
 
   /**
-   * Convert a list of {@link CctCalculation} to a list of {@link CctCalculationDetailDto}.
-   *
-   * @param entities The entities to convert to DTOs.
-   * @return The equivalent detail DTOs.
-   */
-  @Mapping(target = "cctDate", ignore = true)
-  List<CctCalculationDetailDto> toDetailDtos(List<CctCalculation> entities);
-
-  /**
    * Convert a {@link CctCalculation} entity to a {@link CctCalculationDetailDto} DTO, injecting
    * the CCT date into this.
    *
@@ -81,6 +72,15 @@ public interface CctMapper {
    */
   @Mapping(target = "cctDate", source = "cctDate")
   CctCalculationDetailDto toDetailDto(CctCalculation entity, LocalDate cctDate);
+
+  /**
+   * Convert a list of {@link CctCalculation} to a list of {@link CctCalculationDetailDto}.
+   *
+   * @param entities The entities to convert to DTOs.
+   * @return The equivalent detail DTOs.
+   */
+  @Mapping(target = "cctDate", ignore = true)
+  List<CctCalculationDetailDto> toDetailDtos(List<CctCalculation> entities);
 
   /**
    * Convert a {@link CctCalculationDetailDto} DTO to a {@link CctCalculation} entity.

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -31,7 +31,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
-import uk.nhs.hee.trainee.details.dto.CctCalculationSummaryDto;
 import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
 import uk.nhs.hee.trainee.details.exception.NotRecordOwnerException;
 import uk.nhs.hee.trainee.details.mapper.CctMapper;
@@ -67,11 +66,11 @@ public class CctService {
   }
 
   /**
-   * Get a list of CCT calculation summaries for the current user.
+   * Get a list of CCT calculations for the current user.
    *
-   * @return Summaries of the found CCT calculations, or empty when none found.
+   * @return Details of the found CCT calculations, or empty when none found.
    */
-  public List<CctCalculationSummaryDto> getCalculations() {
+  public List<CctCalculationDetailDto> getCalculations() {
     String traineeId = traineeIdentity.getTraineeId();
     log.info("Getting CCT calculations for trainee [{}]", traineeId);
 
@@ -79,7 +78,7 @@ public class CctService {
         traineeId);
     log.info("Found {} CCT calculations for trainee [{}]", entities.size(), traineeId);
 
-    return mapper.toSummaryDtos(entities);
+    return mapper.toDetailDtos(entities);
   }
 
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,8 +31,8 @@ sentry:
 application:
   aws:
     sns:
-      coj-signed: ${TOPIC_ARN_COJ_SIGNED:afdsa}
-      gmc-details-provided: ${TOPIC_ARN_GMC_DETAILS_PROVIDED:afasss}
+      coj-signed: ${TOPIC_ARN_COJ_SIGNED}
+      gmc-details-provided: ${TOPIC_ARN_GMC_DETAILS_PROVIDED}
     sqs:
       event: ${EVENT_QUEUE_URL:}
       basic-details-update: ${BASIC_DETAILS_UPDATE_QUEUE_URL:}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,8 +31,8 @@ sentry:
 application:
   aws:
     sns:
-      coj-signed: ${TOPIC_ARN_COJ_SIGNED}
-      gmc-details-provided: ${TOPIC_ARN_GMC_DETAILS_PROVIDED}
+      coj-signed: ${TOPIC_ARN_COJ_SIGNED:afdsa}
+      gmc-details-provided: ${TOPIC_ARN_GMC_DETAILS_PROVIDED:afasss}
     sqs:
       event: ${EVENT_QUEUE_URL:}
       basic-details-update: ${BASIC_DETAILS_UPDATE_QUEUE_URL:}

--- a/src/test/java/uk/nhs/hee/trainee/details/api/CctResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/CctResourceTest.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
-import uk.nhs.hee.trainee.details.dto.CctCalculationSummaryDto;
 import uk.nhs.hee.trainee.details.service.CctService;
 
 class CctResourceTest {
@@ -60,42 +59,42 @@ class CctResourceTest {
   }
 
   @Test
-  void shouldNotGetCalculationSummariesWhenCalculationsNotExist() {
+  void shouldNotGetCalculationDetailsWhenCalculationsNotExist() {
     ObjectId id = ObjectId.get();
     when(service.getCalculation(id)).thenReturn(Optional.empty());
 
-    ResponseEntity<List<CctCalculationSummaryDto>> response = controller.getCalculationSummaries();
+    ResponseEntity<List<CctCalculationDetailDto>> response = controller.getCalculationDetails();
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
     assertThat("Unexpected response body.", response.getBody(), is(List.of()));
   }
 
   @Test
-  void shouldGetCalculationSummariesWhenCalculationsExist() {
+  void shouldGetCalculationDetailsWhenCalculationsExist() {
     ObjectId id1 = ObjectId.get();
-    CctCalculationSummaryDto dto1 = CctCalculationSummaryDto.builder()
+    CctCalculationDetailDto dto1 = CctCalculationDetailDto.builder()
         .id(id1)
         .name("Test Calculation 1")
         .build();
     ObjectId id2 = ObjectId.get();
-    CctCalculationSummaryDto dto2 = CctCalculationSummaryDto.builder()
+    CctCalculationDetailDto dto2 = CctCalculationDetailDto.builder()
         .id(id2)
         .name("Test Calculation 2")
         .build();
     when(service.getCalculations()).thenReturn(List.of(dto1, dto2));
 
-    ResponseEntity<List<CctCalculationSummaryDto>> response = controller.getCalculationSummaries();
+    ResponseEntity<List<CctCalculationDetailDto>> response = controller.getCalculationDetails();
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
 
-    List<CctCalculationSummaryDto> responseDtos = response.getBody();
+    List<CctCalculationDetailDto> responseDtos = response.getBody();
     assertThat("Unexpected response DTO count.", responseDtos, hasSize(2));
 
-    CctCalculationSummaryDto responseDto1 = responseDtos.get(0);
+    CctCalculationDetailDto responseDto1 = responseDtos.get(0);
     assertThat("Unexpected ID.", responseDto1.id(), is(id1));
     assertThat("Unexpected name.", responseDto1.name(), is("Test Calculation 1"));
 
-    CctCalculationSummaryDto responseDto2 = responseDtos.get(1);
+    CctCalculationDetailDto responseDto2 = responseDtos.get(1);
     assertThat("Unexpected ID.", responseDto2.id(), is(id2));
     assertThat("Unexpected name.", responseDto2.name(), is("Test Calculation 2"));
   }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
@@ -48,7 +48,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto.CctChangeDto;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto.CctProgrammeMembershipDto;
-import uk.nhs.hee.trainee.details.dto.CctCalculationSummaryDto;
 import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
 import uk.nhs.hee.trainee.details.exception.NotRecordOwnerException;
 import uk.nhs.hee.trainee.details.mapper.CctMapperImpl;

--- a/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
@@ -79,9 +79,9 @@ class CctServiceTest {
     when(calculationRepository.findByTraineeIdOrderByLastModified(TRAINEE_ID)).thenReturn(
         List.of());
 
-    List<CctCalculationSummaryDto> result = service.getCalculations();
+    List<CctCalculationDetailDto> result = service.getCalculations();
 
-    assertThat("Unexpected calculation summary count.", result.size(), is(0));
+    assertThat("Unexpected calculation details count.", result.size(), is(0));
   }
 
   @Test
@@ -121,21 +121,21 @@ class CctServiceTest {
     when(calculationRepository.findByTraineeIdOrderByLastModified(TRAINEE_ID)).thenReturn(
         List.of(entity1, entity2));
 
-    List<CctCalculationSummaryDto> result = service.getCalculations();
+    List<CctCalculationDetailDto> result = service.getCalculations();
 
     assertThat("Unexpected calculation summary count.", result.size(), is(2));
 
-    CctCalculationSummaryDto dto1 = result.get(0);
+    CctCalculationDetailDto dto1 = result.get(0);
     assertThat("Unexpected calculation ID.", dto1.id(), is(calculationId1));
     assertThat("Unexpected calculation name.", dto1.name(), is("Test Calculation 1"));
-    assertThat("Unexpected PM ID.", dto1.programmeMembershipId(), is(pmId1));
+    assertThat("Unexpected PM ID.", dto1.programmeMembership().id(), is(pmId1));
     assertThat("Unexpected created timestamp.", dto1.created(), is(created1));
     assertThat("Unexpected last modified timestamp.", dto1.lastModified(), is(lastModified1));
 
-    CctCalculationSummaryDto dto2 = result.get(1);
+    CctCalculationDetailDto dto2 = result.get(1);
     assertThat("Unexpected calculation ID.", dto2.id(), is(calculationId2));
     assertThat("Unexpected calculation name.", dto2.name(), is("Test Calculation 2"));
-    assertThat("Unexpected PM ID.", dto2.programmeMembershipId(), is(pmId2));
+    assertThat("Unexpected PM ID.", dto2.programmeMembership().id(), is(pmId2));
     assertThat("Unexpected created timestamp.", dto2.created(), is(created2));
     assertThat("Unexpected last modified timestamp.", dto2.lastModified(), is(lastModified2));
   }


### PR DESCRIPTION
As per https://github.com/Health-Education-England/tis-trainee-api/blob/3c04e148fa14f831163c2e9d0d69c639ec5f7540/openapi/paths/trainee_cct_calculation.yml#L12

TIS21-6883