### PR TITLE
fix: include cctDate in cct list api response

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.20.1"
+version = "1.20.2"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -176,9 +176,20 @@ class CctResourceIntegrationTest {
         .name("Test Calculation")
         .programmeMembership(CctProgrammeMembership.builder()
             .id(pmId)
+            .startDate(LocalDate.parse("2024-01-01"))
+            .endDate(LocalDate.parse("2025-01-01"))
+            .wte(1.0)
             .build())
+        .changes(List.of(
+            CctChange.builder()
+                .type(CctChangeType.LTFT)
+                .startDate(LocalDate.parse("2024-07-01"))
+                .wte(0.5)
+                .build()))
         .build();
     entity = template.insert(entity);
+
+    LocalDate cctDate = LocalDate.of(2025, 7, 4); //based on details above
 
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
     mockMvc.perform(get("/api/cct/calculation")
@@ -192,6 +203,7 @@ class CctResourceIntegrationTest {
         .andExpect(jsonPath("$[0].programmeMembership.id").value(pmId.toString()))
         .andExpect(jsonPath("$[0].created").value(
             entity.created().truncatedTo(ChronoUnit.MILLIS).toString()))
+        .andExpect(jsonPath("$[0].cctDate").value(cctDate.toString()))
         .andExpect(jsonPath("$[0].lastModified").value(
             entity.lastModified().truncatedTo(ChronoUnit.MILLIS).toString()));
   }
@@ -201,18 +213,54 @@ class CctResourceIntegrationTest {
     CctCalculation future = CctCalculation.builder()
         .traineeId(TRAINEE_ID)
         .name("Future")
+        .programmeMembership(CctProgrammeMembership.builder()
+            .id(UUID.randomUUID())
+            .startDate(LocalDate.parse("2024-01-01"))
+            .endDate(LocalDate.parse("2025-01-01"))
+            .wte(1.0)
+            .build())
+        .changes(List.of(
+            CctChange.builder()
+                .type(CctChangeType.LTFT)
+                .startDate(LocalDate.parse("2024-07-01"))
+                .wte(0.5)
+                .build()))
         .build();
     future = template.insert(future);
 
     CctCalculation past = CctCalculation.builder()
         .traineeId(TRAINEE_ID)
         .name("Past")
+        .programmeMembership(CctProgrammeMembership.builder()
+            .id(UUID.randomUUID())
+            .startDate(LocalDate.parse("2024-01-01"))
+            .endDate(LocalDate.parse("2025-01-01"))
+            .wte(1.0)
+            .build())
+        .changes(List.of(
+            CctChange.builder()
+                .type(CctChangeType.LTFT)
+                .startDate(LocalDate.parse("2024-07-01"))
+                .wte(0.5)
+                .build()))
         .build();
     template.insert(past);
 
     CctCalculation present = CctCalculation.builder()
         .traineeId(TRAINEE_ID)
         .name("Present")
+        .programmeMembership(CctProgrammeMembership.builder()
+            .id(UUID.randomUUID())
+            .startDate(LocalDate.parse("2024-01-01"))
+            .endDate(LocalDate.parse("2025-01-01"))
+            .wte(1.0)
+            .build())
+        .changes(List.of(
+            CctChange.builder()
+                .type(CctChangeType.LTFT)
+                .startDate(LocalDate.parse("2024-07-01"))
+                .wte(0.5)
+                .build()))
         .build();
     template.insert(present);
 

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.trainee.details.service;
 import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -78,7 +79,10 @@ public class CctService {
         traineeId);
     log.info("Found {} CCT calculations for trainee [{}]", entities.size(), traineeId);
 
-    return mapper.toDetailDtos(entities);
+    List<CctCalculationDetailDto> entityDtos = new ArrayList<>();
+    entities.forEach(entity ->
+        entityDtos.add(mapper.toDetailDto(entity, calculateCctDate(entity))));
+    return entityDtos;
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
@@ -96,9 +96,16 @@ class CctServiceTest {
         .name("Test Calculation 1")
         .programmeMembership(CctProgrammeMembership.builder()
             .id(pmId1)
+            .startDate(LocalDate.EPOCH)
+            .endDate(LocalDate.EPOCH.plusYears(1))
+            .wte(1.0)
             .build())
         .created(created1)
         .lastModified(lastModified1)
+        .changes(List.of(CctChange.builder()
+            .startDate(LocalDate.EPOCH.plusMonths(1))
+            .wte(0.5)
+            .build()))
         .build();
 
     ObjectId calculationId2 = ObjectId.get();
@@ -112,7 +119,14 @@ class CctServiceTest {
         .name("Test Calculation 2")
         .programmeMembership(CctProgrammeMembership.builder()
             .id(pmId2)
+            .startDate(LocalDate.EPOCH)
+            .endDate(LocalDate.EPOCH.plusYears(1))
+            .wte(1.0)
             .build())
+        .changes(List.of(CctChange.builder()
+            .startDate(LocalDate.EPOCH)
+            .wte(0.75)
+            .build()))
         .created(created2)
         .lastModified(lastModified2)
         .build();
@@ -128,6 +142,7 @@ class CctServiceTest {
     assertThat("Unexpected calculation ID.", dto1.id(), is(calculationId1));
     assertThat("Unexpected calculation name.", dto1.name(), is("Test Calculation 1"));
     assertThat("Unexpected PM ID.", dto1.programmeMembership().id(), is(pmId1));
+    assertThat("Unexpected CCT date.", dto1.cctDate(), is(service.calculateCctDate(entity1)));
     assertThat("Unexpected created timestamp.", dto1.created(), is(created1));
     assertThat("Unexpected last modified timestamp.", dto1.lastModified(), is(lastModified1));
 
@@ -135,6 +150,7 @@ class CctServiceTest {
     assertThat("Unexpected calculation ID.", dto2.id(), is(calculationId2));
     assertThat("Unexpected calculation name.", dto2.name(), is("Test Calculation 2"));
     assertThat("Unexpected PM ID.", dto2.programmeMembership().id(), is(pmId2));
+    assertThat("Unexpected CCT date.", dto2.cctDate(), is(service.calculateCctDate(entity2)));
     assertThat("Unexpected created timestamp.", dto2.created(), is(created2));
     assertThat("Unexpected last modified timestamp.", dto2.lastModified(), is(lastModified2));
   }


### PR DESCRIPTION
Omitted from https://github.com/Health-Education-England/tis-trainee-details/pull/508 . 

(The other issues were data-related with some legacy entries in the db with programme membership id in binary form, which have now been removed).

TIS21-6883