### PR TITLE
feat: include DBC in programme membership

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.20.2"
+version = "1.21.0"
 
 configurations {
   compileOnly {
@@ -83,6 +83,7 @@ sonarqube {
       "build/reports/checkstyle/main.xml,build/reports/checkstyle/test.xml")
   }
 }
+
 testing {
   suites {
     configureEach {

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/ProgrammeMembershipDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/ProgrammeMembershipDto.java
@@ -43,6 +43,7 @@ public class ProgrammeMembershipDto implements SignedDto {
   private String programmeNumber;
   private String managingDeanery;
   private String designatedBody;
+  private String designatedBodyCode;
   private String programmeMembershipType;
   private LocalDate startDate;
   private LocalDate endDate;

--- a/src/main/java/uk/nhs/hee/trainee/details/model/ProgrammeMembership.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/ProgrammeMembership.java
@@ -39,6 +39,7 @@ public class ProgrammeMembership {
   private String programmeNumber;
   private String managingDeanery;
   private String designatedBody;
+  private String designatedBodyCode;
   private String programmeMembershipType;
   private LocalDate startDate;
   private LocalDate endDate;

--- a/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/ProgrammeMembershipResourceTest.java
@@ -131,6 +131,7 @@ class ProgrammeMembershipResourceTest {
     programmeMembership.setProgrammeNumber("programmeNumberValue");
     programmeMembership.setManagingDeanery("managingDeaneryValue");
     programmeMembership.setDesignatedBody("designatedBodyValue");
+    programmeMembership.setDesignatedBodyCode("designatedBodyCodeValue");
     programmeMembership.setProgrammeMembershipType("programmeMembershipTypeValue");
     programmeMembership.setStartDate(start);
     programmeMembership.setEndDate(end);
@@ -169,6 +170,7 @@ class ProgrammeMembershipResourceTest {
         .andExpect(jsonPath("$.programmeNumber").value(is("programmeNumberValue")))
         .andExpect(jsonPath("$.managingDeanery").value(is("managingDeaneryValue")))
         .andExpect(jsonPath("$.designatedBody").value(is("designatedBodyValue")))
+        .andExpect(jsonPath("$.designatedBodyCode").value(is("designatedBodyCodeValue")))
         .andExpect(jsonPath("$.programmeMembershipType").value(is("programmeMembershipTypeValue")))
         .andExpect(jsonPath("$.startDate").value(is(start.toString())))
         .andExpect(jsonPath("$.endDate").value(is(end.toString())))

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -96,6 +96,7 @@ class ProgrammeMembershipServiceTest {
   private static final String PROGRAMME_NUMBER = "programmeNumber-";
   private static final String MANAGING_DEANERY = "managingDeanery-";
   private static final String DESIGNATED_BODY = "designatedBody-";
+  private static final String DESIGNATED_BODY_CODE = "designatedBodyCode-";
   private static final String PROGRAMME_MEMBERSHIP_TYPE = "programmeMembershipType-";
   private static final String TRAINEE_TIS_ID = "40";
   private static final String MODIFIED_SUFFIX = "post";
@@ -165,6 +166,7 @@ class ProgrammeMembershipServiceTest {
     expectedProgrammeMembership.setProgrammeNumber(PROGRAMME_NUMBER + MODIFIED_SUFFIX);
     expectedProgrammeMembership.setManagingDeanery(MANAGING_DEANERY + MODIFIED_SUFFIX);
     expectedProgrammeMembership.setDesignatedBody(DESIGNATED_BODY + MODIFIED_SUFFIX);
+    expectedProgrammeMembership.setDesignatedBodyCode(DESIGNATED_BODY_CODE + MODIFIED_SUFFIX);
     expectedProgrammeMembership
         .setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE + MODIFIED_SUFFIX);
     expectedProgrammeMembership.setStartDate(START_DATE.plusDays(100));
@@ -200,6 +202,7 @@ class ProgrammeMembershipServiceTest {
     expectedProgrammeMembership.setProgrammeNumber(PROGRAMME_NUMBER + MODIFIED_SUFFIX);
     expectedProgrammeMembership.setManagingDeanery(MANAGING_DEANERY + MODIFIED_SUFFIX);
     expectedProgrammeMembership.setDesignatedBody(DESIGNATED_BODY + MODIFIED_SUFFIX);
+    expectedProgrammeMembership.setDesignatedBodyCode(DESIGNATED_BODY_CODE + MODIFIED_SUFFIX);
     expectedProgrammeMembership
         .setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE + MODIFIED_SUFFIX);
     expectedProgrammeMembership.setStartDate(START_DATE.plusDays(100));
@@ -237,6 +240,7 @@ class ProgrammeMembershipServiceTest {
     expectedProgrammeMembership.setProgrammeNumber(PROGRAMME_NUMBER + MODIFIED_SUFFIX);
     expectedProgrammeMembership.setManagingDeanery(MANAGING_DEANERY + MODIFIED_SUFFIX);
     expectedProgrammeMembership.setDesignatedBody(DESIGNATED_BODY + MODIFIED_SUFFIX);
+    expectedProgrammeMembership.setDesignatedBodyCode(DESIGNATED_BODY_CODE + MODIFIED_SUFFIX);
     expectedProgrammeMembership
         .setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE + MODIFIED_SUFFIX);
     expectedProgrammeMembership.setStartDate(START_DATE.plusDays(100));
@@ -1781,6 +1785,7 @@ class ProgrammeMembershipServiceTest {
     programmeMembership.setProgrammeNumber(PROGRAMME_NUMBER + stringSuffix);
     programmeMembership.setManagingDeanery(MANAGING_DEANERY + stringSuffix);
     programmeMembership.setDesignatedBody(DESIGNATED_BODY + stringSuffix);
+    programmeMembership.setDesignatedBodyCode(DESIGNATED_BODY_CODE + stringSuffix);
     programmeMembership.setProgrammeMembershipType(PROGRAMME_MEMBERSHIP_TYPE + stringSuffix);
     programmeMembership.setStartDate(START_DATE.plusDays(dateAdjustmentDays));
     programmeMembership.setEndDate(END_DATE.plusDays(dateAdjustmentDays));


### PR DESCRIPTION
The admin endpoints for LTFT forms require filtering based on the admin's local office, which can be determined using the `cognito:groups` from the auth token.
The group name is the DBC, rather than a name, so to avoid having to hardcode a mapping the code should be added to the PM so it can be referenced in the LTFT data.

TIS21-6599
TIS21-6938