### PR TITLE
Feat/add change

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.21.0"
+version = "1.22.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -47,7 +47,6 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -151,7 +150,7 @@ class CctResourceIntegrationTest {
 
   @Test
   void shouldNotGetCalculationsWhenNotOwnedByUser() throws Exception {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     CctCalculation entity = CctCalculation.builder()
         .id(id)
         .traineeId(TRAINEE_ID)
@@ -296,7 +295,7 @@ class CctResourceIntegrationTest {
 
   @Test
   void shouldNotGetCalculationWhenNotOwnedByUser() throws Exception {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     CctCalculation entity = CctCalculation.builder()
         .id(id)
         .traineeId(TRAINEE_ID)
@@ -395,7 +394,7 @@ class CctResourceIntegrationTest {
 
   @Test
   void shouldFailCreateCalculationValidationWhenIdPopulated() throws Exception {
-    calculationJson.set("id", TextNode.valueOf(ObjectId.get().toString()));
+    calculationJson.set("id", TextNode.valueOf(UUID.randomUUID().toString()));
 
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
     mockMvc.perform(post("/api/cct/calculation")
@@ -618,7 +617,7 @@ class CctResourceIntegrationTest {
 
   @Test
   void shouldReturnBadRequestWhenUpdatingCalculationWithoutEntityId() throws Exception {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
 
     mockMvc.perform(put("/api/cct/calculation/" + id)
@@ -631,15 +630,15 @@ class CctResourceIntegrationTest {
 
   @Test
   void shouldReturnBadRequestWhenUpdatingCalculationWithConflictingIds() throws Exception {
-    ObjectId id = ObjectId.get();
+    UUID id1 = UUID.randomUUID();
     String body = """
         {
           "id": %s
           "name": "Test Calculation",
         }
-        """.formatted(id);
+        """.formatted(id1);
 
-    ObjectId id2 = ObjectId.get();
+    UUID id2 = UUID.randomUUID();
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
 
     mockMvc.perform(put("/api/cct/calculation/" + id2)
@@ -657,7 +656,7 @@ class CctResourceIntegrationTest {
         .build();
     entity = template.insert(entity);
 
-    ObjectId id = entity.id();
+    UUID id = entity.id();
     Instant created = entity.created();
 
     String body = """
@@ -693,7 +692,7 @@ class CctResourceIntegrationTest {
 
   @Test
   void shouldReturnNotFoundWhenUpdatingNewCalculation() throws Exception {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     String body = """
         {
           "id": "%s",
@@ -741,7 +740,7 @@ class CctResourceIntegrationTest {
         .build();
     entity = template.insert(entity);
 
-    ObjectId id = entity.id();
+    UUID id = entity.id();
     Instant created = entity.created();
     Instant lastModified = entity.lastModified();
     assertThat("Unexpected initial last modified date.", created, is(lastModified));

--- a/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -93,7 +94,8 @@ public class CctResource {
    */
   @PutMapping("/calculation/{id}")
   public ResponseEntity<CctCalculationDetailDto> updateCalculationDetails(@PathVariable UUID id,
-      @Validated @RequestBody CctCalculationDetailDto calculation) {
+      @Validated @RequestBody CctCalculationDetailDto calculation)
+      throws MethodArgumentNotValidException {
     log.info("Request to update CCT calculation[{}]", id);
     Optional<CctCalculationDetailDto> savedCalculation;
 

--- a/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
@@ -25,8 +25,8 @@ import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.bson.types.ObjectId;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -79,7 +79,7 @@ public class CctResource {
    * @return The found CCT calculation details.
    */
   @GetMapping("/calculation/{id}")
-  public ResponseEntity<CctCalculationDetailDto> getCalculationDetails(@PathVariable ObjectId id) {
+  public ResponseEntity<CctCalculationDetailDto> getCalculationDetails(@PathVariable UUID id) {
     log.info("Request to get details for CCT calculation[{}]", id);
     Optional<CctCalculationDetailDto> calculation = service.getCalculation(id);
     return ResponseEntity.of(calculation);
@@ -92,7 +92,7 @@ public class CctResource {
    * @return The updated CCT calculation details, or bad request if inconsistent ids.
    */
   @PutMapping("/calculation/{id}")
-  public ResponseEntity<CctCalculationDetailDto> updateCalculationDetails(@PathVariable ObjectId id,
+  public ResponseEntity<CctCalculationDetailDto> updateCalculationDetails(@PathVariable UUID id,
       @Validated @RequestBody CctCalculationDetailDto calculation) {
     log.info("Request to update CCT calculation[{}]", id);
     Optional<CctCalculationDetailDto> savedCalculation;

--- a/src/main/java/uk/nhs/hee/trainee/details/config/MongoIndexConfiguration.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/MongoIndexConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexInfo;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import uk.nhs.hee.trainee.details.model.TraineeProfile;
+
+/**
+ * Configuration for the Mongo database indexes.
+ */
+@Configuration
+public class MongoIndexConfiguration {
+
+  private final MongoTemplate template;
+
+  MongoIndexConfiguration(MongoTemplate template) {
+    this.template = template;
+  }
+
+  /**
+   * Add custom indexes to the Mongo collections.
+   */
+  @PostConstruct
+  public void initIndexes() {
+    IndexOperations traineeProfileIndexOps = template.indexOps(TraineeProfile.class);
+    traineeProfileIndexOps.ensureIndex(new Index().on("personalDetails.email", Direction.ASC));
+
+    //ensure unique index on traineeTisId
+    for (IndexInfo idx : traineeProfileIndexOps.getIndexInfo()) {
+      if (idx.getIndexFields().stream().anyMatch(i -> i.getKey().equals("traineeTisId"))
+          && !idx.isUnique()) {
+        traineeProfileIndexOps.dropIndex(idx.getName());
+      }
+    }
+    traineeProfileIndexOps.ensureIndex(new Index().on("traineeTisId", Direction.ASC).unique());
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
@@ -21,8 +21,6 @@
 
 package uk.nhs.hee.trainee.details.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -33,7 +31,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
-import org.bson.types.ObjectId;
 import org.hibernate.validator.constraints.Range;
 import uk.nhs.hee.trainee.details.dto.enumeration.CctChangeType;
 import uk.nhs.hee.trainee.details.dto.validation.Create;
@@ -52,9 +49,8 @@ import uk.nhs.hee.trainee.details.dto.validation.Create;
 @Builder
 public record CctCalculationDetailDto(
 
-    @JsonSerialize(using = ToStringSerializer.class)
     @Null(groups = Create.class)
-    ObjectId id,
+    UUID id,
 
     @NotBlank
     String name,

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
@@ -101,12 +101,16 @@ public record CctCalculationDetailDto(
   /**
    * A CCT changes associated with a calculation.
    *
+   * @param id        The identifier of the CCT change.
    * @param type      The type of CCT change.
    * @param startDate The start date of the CCT change.
    * @param wte       The new desired whole time equivalent.
    */
   @Builder
   public record CctChangeDto(
+
+      @Null(groups = Create.class)
+      UUID id,
 
       @NotNull
       CctChangeType type,

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationSummaryDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationSummaryDto.java
@@ -21,12 +21,9 @@
 
 package uk.nhs.hee.trainee.details.dto;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
-import org.bson.types.ObjectId;
 
 /**
  * A summary of a CCT calculation.
@@ -38,8 +35,7 @@ import org.bson.types.ObjectId;
 @Builder
 public record CctCalculationSummaryDto(
 
-    @JsonSerialize(using = ToStringSerializer.class)
-    ObjectId id,
+    UUID id,
     String name,
     UUID programmeMembershipId,
     Instant created,

--- a/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
@@ -56,6 +56,7 @@ public record CctCalculation(
     String traineeId,
     String name,
     CctProgrammeMembership programmeMembership,
+    @With
     List<CctChange> changes,
 
     @CreatedDate
@@ -88,12 +89,16 @@ public record CctCalculation(
   /**
    * A CCT changes associated with a calculation.
    *
+   * @param id        The identifier of the CCT change.
    * @param type      The type of CCT change.
    * @param startDate The start date of the CCT change.
    * @param wte       The new desired whole time equivalent.
    */
   @Builder
   public record CctChange(
+      @Field("id")
+      @With
+      UUID id,
       CctChangeType type,
       LocalDate startDate,
       Double wte) {

--- a/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
@@ -26,7 +26,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 import lombok.Builder;
-import org.bson.types.ObjectId;
+import lombok.With;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -50,7 +50,8 @@ import uk.nhs.hee.trainee.details.dto.enumeration.CctChangeType;
 @Builder
 public record CctCalculation(
     @Id
-    ObjectId id,
+    @With
+    UUID id,
     @Indexed
     String traineeId,
     String name,
@@ -61,8 +62,7 @@ public record CctCalculation(
     Instant created,
 
     @LastModifiedDate
-    Instant lastModified
-) {
+    Instant lastModified) implements UuidIdentifiedRecord<CctCalculation> {
 
   /**
    * Programme membership data for a calculation.

--- a/src/main/java/uk/nhs/hee/trainee/details/model/UuidIdentifiedRecord.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/UuidIdentifiedRecord.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2020 Crown Copyright (Health Education England)
+ * Copyright 2025 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -19,29 +19,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package uk.nhs.hee.trainee.details.config;
+package uk.nhs.hee.trainee.details.model;
 
 import java.util.UUID;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.config.EnableMongoAuditing;
-import org.springframework.data.mongodb.core.mapping.event.BeforeConvertCallback;
-import uk.nhs.hee.trainee.details.model.UuidIdentifiedRecord;
 
 /**
- * Configuration for the Mongo database.
+ * An interface for record-based entities with UUID identifiers.
  */
-@Configuration
-@EnableMongoAuditing
-public class MongoConfiguration {
+public interface UuidIdentifiedRecord<T> {
 
-  @Bean
-  public <T extends UuidIdentifiedRecord<T>> BeforeConvertCallback<T> beforeConvertCallback() {
-    return (entity, collection) -> {
-      if (entity.id() == null) {
-        entity = entity.withId(UUID.randomUUID());
-      }
-      return entity;
-    };
-  }
+  /**
+   * Get the entity's current ID.
+   *
+   * @return The entity's ID.
+   */
+  UUID id();
+
+  /**
+   * Create a new instance of the entity with the given ID.
+   *
+   * @param id The ID to add to the entity.
+   * @return The new instance of the entity.
+   */
+  T withId(UUID id);
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/repository/CctCalculationRepository.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/repository/CctCalculationRepository.java
@@ -22,7 +22,7 @@
 package uk.nhs.hee.trainee.details.repository;
 
 import java.util.List;
-import org.bson.types.ObjectId;
+import java.util.UUID;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 import uk.nhs.hee.trainee.details.model.CctCalculation;
@@ -31,7 +31,7 @@ import uk.nhs.hee.trainee.details.model.CctCalculation;
  * A repository for CCT calculations.
  */
 @Repository
-public interface CctCalculationRepository extends MongoRepository<CctCalculation, ObjectId> {
+public interface CctCalculationRepository extends MongoRepository<CctCalculation, UUID> {
 
   /**
    * Find all calculations belonging to the given trainee, ordered by last modified.

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -28,8 +28,8 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.bson.types.ObjectId;
 import org.springframework.stereotype.Service;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
 import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
@@ -45,6 +45,7 @@ import uk.nhs.hee.trainee.details.repository.CctCalculationRepository;
 @Service
 @XRayEnabled
 public class CctService {
+
   protected static final double WTE_EPSILON = 0.01; //minimum WTE value
 
   private final TraineeIdentity traineeIdentity;
@@ -93,7 +94,7 @@ public class CctService {
    * @throws NotRecordOwnerException If the found CCT calculation does not belong to the current
    *                                 user.
    */
-  public Optional<CctCalculationDetailDto> getCalculation(ObjectId id) {
+  public Optional<CctCalculationDetailDto> getCalculation(UUID id) {
     log.info("Getting CCT calculation [{}]", id);
     String traineeId = traineeIdentity.getTraineeId();
     Optional<CctCalculation> entity = calculationRepository.findById(id);
@@ -132,7 +133,7 @@ public class CctService {
    * @param dto The detail of the CCT calculation.
    * @return The updated CCT calculation, or optional empty if error.
    */
-  public Optional<CctCalculationDetailDto> updateCalculation(ObjectId id,
+  public Optional<CctCalculationDetailDto> updateCalculation(UUID id,
       CctCalculationDetailDto dto) {
     log.info("Updating CCT calculation [{}] with id [{}]", dto.name(), id);
 

--- a/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipService.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.hee.trainee.details.service;
 
-import static java.time.temporal.ChronoUnit.YEARS;
 import static uk.nhs.hee.trainee.details.model.HrefType.ABSOLUTE_URL;
 import static uk.nhs.hee.trainee.details.model.HrefType.NON_HREF;
 import static uk.nhs.hee.trainee.details.model.HrefType.PROTOCOL_EMAIL;
@@ -538,8 +537,7 @@ public class ProgrammeMembershipService {
                 templatePath, Set.of(), TemplateMode.HTML, null);
 
             return pdfService.generatePdf(templateSpec, templateVariables);
-          }
-          else {
+          } else {
             throw new IllegalArgumentException("Programme membership " + programmeMembershipId
                 + " not starting in " + PM_CONFIRM_WEEKS + " weeks.");
           }
@@ -763,9 +761,8 @@ public class ProgrammeMembershipService {
    * @return The specific contact of the owner, or the default message if not found.
    */
   protected String getOwnerContact(List<Map<String, String>> ownerContactList,
-                                   LocalOfficeContactType contactType,
-                                   LocalOfficeContactType fallbackContactType,
-                                   String defaultMessage) {
+      LocalOfficeContactType contactType, LocalOfficeContactType fallbackContactType,
+      String defaultMessage) {
 
     Optional<Map<String, String>> ownerContact = ownerContactList.stream()
         .filter(c ->
@@ -795,8 +792,7 @@ public class ProgrammeMembershipService {
    * @return The specific contact of the local office, or the default message if not found.
    */
   public String getOwnerContact(String localOfficeName, LocalOfficeContactType contactType,
-                                LocalOfficeContactType fallbackContactType,
-                                String defaultMessage) {
+      LocalOfficeContactType fallbackContactType, String defaultMessage) {
     return getOwnerContact(
         getOwnerContactList(localOfficeName), contactType, fallbackContactType, defaultMessage);
   }

--- a/src/test/java/uk/nhs/hee/trainee/details/api/CctResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/CctResourceTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
 import uk.nhs.hee.trainee.details.service.CctService;
 
@@ -175,7 +177,7 @@ class CctResourceTest {
   }
 
   @Test
-  void shouldReturnUpdatedCalculation() {
+  void shouldReturnUpdatedCalculation() throws MethodArgumentNotValidException {
     UUID id = UUID.randomUUID();
     Instant created = Instant.now();
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
@@ -209,7 +211,7 @@ class CctResourceTest {
   }
 
   @Test
-  void shouldReturnBadRequestWhenUpdateIsInconsistent() {
+  void shouldReturnBadRequestWhenUpdateIsInconsistent() throws MethodArgumentNotValidException {
     UUID id1 = UUID.randomUUID();
     UUID id2 = UUID.randomUUID();
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
@@ -227,7 +229,7 @@ class CctResourceTest {
   }
 
   @Test
-  void shouldReturnBadRequestWhenUpdateHasNoEntityId() {
+  void shouldReturnBadRequestWhenUpdateHasNoEntityId() throws MethodArgumentNotValidException {
     UUID id = UUID.randomUUID();
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
         .name("Test Calculation")
@@ -242,7 +244,7 @@ class CctResourceTest {
   }
 
   @Test
-  void shouldReturnNotFoundWhenCalculationCannotBeUpdated() {
+  void shouldReturnNotFoundWhenCalculationCannotBeUpdated() throws MethodArgumentNotValidException {
     UUID id = UUID.randomUUID();
     Instant created = Instant.now();
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
@@ -261,5 +263,23 @@ class CctResourceTest {
 
     CctCalculationDetailDto responseBody = response.getBody();
     assertThat("Unexpected response body.", responseBody, nullValue());
+  }
+
+  @Test
+  void shouldNotCatchValidationErrorWhenUpdateCalculationValidationFails()
+      throws MethodArgumentNotValidException {
+    UUID id = UUID.randomUUID();
+    Instant created = Instant.now();
+    CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
+        .id(id)
+        .name("Test Calculation")
+        .created(created)
+        .lastModified(created)
+        .build();
+
+    when(service.updateCalculation(any(), any())).thenThrow(MethodArgumentNotValidException.class);
+
+    assertThrows(MethodArgumentNotValidException.class,
+        () -> controller.updateCalculationDetails(id, dto));
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/api/CctResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/CctResourceTest.java
@@ -39,7 +39,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
-import org.bson.types.ObjectId;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -60,7 +60,7 @@ class CctResourceTest {
 
   @Test
   void shouldNotGetCalculationDetailsWhenCalculationsNotExist() {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     when(service.getCalculation(id)).thenReturn(Optional.empty());
 
     ResponseEntity<List<CctCalculationDetailDto>> response = controller.getCalculationDetails();
@@ -71,12 +71,12 @@ class CctResourceTest {
 
   @Test
   void shouldGetCalculationDetailsWhenCalculationsExist() {
-    ObjectId id1 = ObjectId.get();
+    UUID id1 = UUID.randomUUID();
     CctCalculationDetailDto dto1 = CctCalculationDetailDto.builder()
         .id(id1)
         .name("Test Calculation 1")
         .build();
-    ObjectId id2 = ObjectId.get();
+    UUID id2 = UUID.randomUUID();
     CctCalculationDetailDto dto2 = CctCalculationDetailDto.builder()
         .id(id2)
         .name("Test Calculation 2")
@@ -101,7 +101,7 @@ class CctResourceTest {
 
   @Test
   void shouldNotGetCalculationDetailWhenCalculationNotExists() {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     when(service.getCalculation(id)).thenReturn(Optional.empty());
 
     ResponseEntity<CctCalculationDetailDto> response = controller.getCalculationDetails(id);
@@ -112,7 +112,7 @@ class CctResourceTest {
 
   @Test
   void shouldGetCalculationDetailWhenCalculationExists() {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
         .id(id)
         .name("Test Calculation")
@@ -131,7 +131,7 @@ class CctResourceTest {
         .name("Test Calculation")
         .build();
 
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     when(service.createCalculation(any())).thenAnswer(inv -> {
       CctCalculationDetailDto arg = inv.getArgument(0);
       return CctCalculationDetailDto.builder()
@@ -158,7 +158,7 @@ class CctResourceTest {
         .name("Test Calculation")
         .build();
 
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     when(service.createCalculation(any())).thenAnswer(inv -> {
       CctCalculationDetailDto arg = inv.getArgument(0);
       return CctCalculationDetailDto.builder()
@@ -176,7 +176,7 @@ class CctResourceTest {
 
   @Test
   void shouldReturnUpdatedCalculation() {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     Instant created = Instant.now();
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
         .id(id)
@@ -210,14 +210,15 @@ class CctResourceTest {
 
   @Test
   void shouldReturnBadRequestWhenUpdateIsInconsistent() {
-    ObjectId id = ObjectId.get();
-    ObjectId id2 = ObjectId.get();
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
         .id(id2)
         .name("Test Calculation")
         .build();
 
-    ResponseEntity<CctCalculationDetailDto> response = controller.updateCalculationDetails(id, dto);
+    ResponseEntity<CctCalculationDetailDto> response = controller.updateCalculationDetails(id1,
+        dto);
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(BAD_REQUEST));
 
@@ -227,7 +228,7 @@ class CctResourceTest {
 
   @Test
   void shouldReturnBadRequestWhenUpdateHasNoEntityId() {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
         .name("Test Calculation")
         .build();
@@ -242,7 +243,7 @@ class CctResourceTest {
 
   @Test
   void shouldReturnNotFoundWhenCalculationCannotBeUpdated() {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     Instant created = Instant.now();
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
         .id(id)

--- a/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
@@ -121,7 +121,7 @@ class MongoConfigurationTest {
   }
 
   /**
-   * A stub UUID identified entity
+   * A stub UUID identified entity.
    *
    * @param id The id of the entity, may be null.
    */

--- a/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/MongoConfigurationTest.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright 2021 Crown Copyright (Health Education England)
+ * Copyright 2025 Crown Copyright (Health Education England)
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
  * associated documentation files (the "Software"), to deal in the Software without restriction,
@@ -21,90 +21,68 @@
 
 package uk.nhs.hee.trainee.details.config;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatchers;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.index.IndexDefinition;
-import org.springframework.data.mongodb.core.index.IndexField;
-import org.springframework.data.mongodb.core.index.IndexInfo;
-import org.springframework.data.mongodb.core.index.IndexOperations;
-import uk.nhs.hee.trainee.details.model.TraineeProfile;
+import org.springframework.data.mongodb.core.mapping.event.BeforeConvertCallback;
+import uk.nhs.hee.trainee.details.model.UuidIdentifiedRecord;
 
 class MongoConfigurationTest {
-  private static final String NON_UNIQUE_INDEX_NAME = "traineeTisId_notUnique";
 
   private MongoConfiguration configuration;
 
-  private MongoTemplate template;
-
   @BeforeEach
   void setUp() {
-    template = mock(MongoTemplate.class);
-    configuration = new MongoConfiguration(template);
-
-    IndexOperations indexOperations = mock(IndexOperations.class);
-    when(template.indexOps(ArgumentMatchers.<Class<TraineeProfile>>any()))
-        .thenReturn(indexOperations);
+    configuration = new MongoConfiguration();
   }
 
   @Test
-  void shouldInitIndexesForTraineeProfileCollection() {
-    IndexOperations indexOperations = mock(IndexOperations.class);
-    when(template.indexOps(TraineeProfile.class)).thenReturn(indexOperations);
+  void shouldSetUuidIdentifierBeforeConvertWhenEmpty() {
+    UuidIdentifiedStub before = new UuidIdentifiedStub(null);
 
-    configuration.initIndexes();
+    BeforeConvertCallback<UuidIdentifiedStub> callback = configuration.beforeConvertCallback();
+    UuidIdentifiedStub after = callback.onBeforeConvert(new UuidIdentifiedStub(null), "");
 
-    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.forClass(IndexDefinition.class);
-    verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
-
-    List<IndexDefinition> indexes = indexCaptor.getAllValues();
-    assertThat("Unexpected number of indexes.", indexes.size(), is(2));
-
-    List<String> indexKeys = indexes.stream()
-        .flatMap(i -> i.getIndexKeys().keySet().stream())
-        .collect(Collectors.toList());
-    assertThat("Unexpected index.", indexKeys, hasItems("traineeTisId", "personalDetails.email"));
+    assertThat("Unexpected entity ID.", before.id(), nullValue());
+    assertThat("Unexpected entity ID.", after.id(), notNullValue());
+    assertThat("Unexpected entity.", after, not(sameInstance(before)));
   }
 
   @Test
-  void shouldReplaceNonUniqueIndexForTraineeTisIdWithUniqueIndex() {
-    IndexField indexField = IndexField.create("traineeTisId", Sort.Direction.ASC);
-    IndexInfo indexInfo = new IndexInfo(List.of(indexField),
-        NON_UNIQUE_INDEX_NAME, false, false, "");
+  void shouldNotSetUuidIdentifierBeforeConvertWhenPopulated() {
+    UUID id = UUID.randomUUID();
+    UuidIdentifiedStub before = new UuidIdentifiedStub(id);
 
-    IndexOperations indexOperations = mock(IndexOperations.class);
-    when(template.indexOps(TraineeProfile.class)).thenReturn(indexOperations);
-    when(indexOperations.getIndexInfo()).thenReturn(List.of(indexInfo));
+    BeforeConvertCallback<UuidIdentifiedStub> callback = configuration.beforeConvertCallback();
+    UuidIdentifiedStub after = callback.onBeforeConvert(before, "");
 
-    configuration.initIndexes();
+    assertThat("Unexpected entity ID.", before.id(), is(id));
+    assertThat("Unexpected entity ID.", after.id(), is(id));
+    assertThat("Unexpected entity.", after, sameInstance(before));
+  }
 
-    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.forClass(IndexDefinition.class);
-    verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
-    ArgumentCaptor<String> indexCaptorDel = ArgumentCaptor.forClass(String.class);
-    verify(indexOperations, atLeastOnce()).dropIndex(indexCaptorDel.capture());
+  /**
+   * A stub UUID identified entity
+   *
+   * @param id The id of the entity, may be null.
+   */
+  private record UuidIdentifiedStub(UUID id) implements UuidIdentifiedRecord<UuidIdentifiedStub> {
 
-    List<IndexDefinition> indexes = indexCaptor.getAllValues();
-    String indexDeleted = indexCaptorDel.getValue();
+    @Override
+    public UUID id() {
+      return id;
+    }
 
-    Optional<IndexDefinition> idxTraineeTisId = indexes.stream()
-        .filter(i -> i.getIndexKeys().containsKey("traineeTisId")).findFirst();
-    assertTrue(idxTraineeTisId.isPresent());
-    assertTrue(idxTraineeTisId.get().getIndexOptions().getBoolean("unique"));
-    assertThat("Unexpected index deleted", indexDeleted, is(NON_UNIQUE_INDEX_NAME));
+    @Override
+    public UuidIdentifiedStub withId(UUID id) {
+      return new UuidIdentifiedStub(id);
+    }
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/config/MongoIndexConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/MongoIndexConfigurationTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -46,6 +45,7 @@ import org.springframework.data.mongodb.core.index.IndexOperations;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
 class MongoIndexConfigurationTest {
+
   private static final String NON_UNIQUE_INDEX_NAME = "traineeTisId_notUnique";
 
   private MongoIndexConfiguration configuration;
@@ -77,7 +77,7 @@ class MongoIndexConfigurationTest {
 
     List<String> indexKeys = indexes.stream()
         .flatMap(i -> i.getIndexKeys().keySet().stream())
-        .collect(Collectors.toList());
+        .toList();
     assertThat("Unexpected index.", indexKeys, hasItems("traineeTisId", "personalDetails.email"));
   }
 

--- a/src/test/java/uk/nhs/hee/trainee/details/config/MongoIndexConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/MongoIndexConfigurationTest.java
@@ -1,0 +1,110 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2021 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.IndexDefinition;
+import org.springframework.data.mongodb.core.index.IndexField;
+import org.springframework.data.mongodb.core.index.IndexInfo;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import uk.nhs.hee.trainee.details.model.TraineeProfile;
+
+class MongoIndexConfigurationTest {
+  private static final String NON_UNIQUE_INDEX_NAME = "traineeTisId_notUnique";
+
+  private MongoIndexConfiguration configuration;
+
+  private MongoTemplate template;
+
+  @BeforeEach
+  void setUp() {
+    template = mock(MongoTemplate.class);
+    configuration = new MongoIndexConfiguration(template);
+
+    IndexOperations indexOperations = mock(IndexOperations.class);
+    when(template.indexOps(ArgumentMatchers.<Class<TraineeProfile>>any()))
+        .thenReturn(indexOperations);
+  }
+
+  @Test
+  void shouldInitIndexesForTraineeProfileCollection() {
+    IndexOperations indexOperations = mock(IndexOperations.class);
+    when(template.indexOps(TraineeProfile.class)).thenReturn(indexOperations);
+
+    configuration.initIndexes();
+
+    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.forClass(IndexDefinition.class);
+    verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
+
+    List<IndexDefinition> indexes = indexCaptor.getAllValues();
+    assertThat("Unexpected number of indexes.", indexes.size(), is(2));
+
+    List<String> indexKeys = indexes.stream()
+        .flatMap(i -> i.getIndexKeys().keySet().stream())
+        .collect(Collectors.toList());
+    assertThat("Unexpected index.", indexKeys, hasItems("traineeTisId", "personalDetails.email"));
+  }
+
+  @Test
+  void shouldReplaceNonUniqueIndexForTraineeTisIdWithUniqueIndex() {
+    IndexField indexField = IndexField.create("traineeTisId", Sort.Direction.ASC);
+    IndexInfo indexInfo = new IndexInfo(List.of(indexField),
+        NON_UNIQUE_INDEX_NAME, false, false, "");
+
+    IndexOperations indexOperations = mock(IndexOperations.class);
+    when(template.indexOps(TraineeProfile.class)).thenReturn(indexOperations);
+    when(indexOperations.getIndexInfo()).thenReturn(List.of(indexInfo));
+
+    configuration.initIndexes();
+
+    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.forClass(IndexDefinition.class);
+    verify(indexOperations, atLeastOnce()).ensureIndex(indexCaptor.capture());
+    ArgumentCaptor<String> indexCaptorDel = ArgumentCaptor.forClass(String.class);
+    verify(indexOperations, atLeastOnce()).dropIndex(indexCaptorDel.capture());
+
+    List<IndexDefinition> indexes = indexCaptor.getAllValues();
+    String indexDeleted = indexCaptorDel.getValue();
+
+    Optional<IndexDefinition> idxTraineeTisId = indexes.stream()
+        .filter(i -> i.getIndexKeys().containsKey("traineeTisId")).findFirst();
+    assertTrue(idxTraineeTisId.isPresent());
+    assertTrue(idxTraineeTisId.get().getIndexOptions().getBoolean("unique"));
+    assertThat("Unexpected index deleted", indexDeleted, is(NON_UNIQUE_INDEX_NAME));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
@@ -40,7 +40,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -85,7 +84,7 @@ class CctServiceTest {
 
   @Test
   void shouldGetCalculationsWhenFound() {
-    ObjectId calculationId1 = ObjectId.get();
+    UUID calculationId1 = UUID.randomUUID();
     UUID pmId1 = UUID.randomUUID();
     Instant created1 = Instant.now().minus(Duration.ofDays(1));
     Instant lastModified1 = Instant.now().plus(Duration.ofDays(1));
@@ -108,7 +107,7 @@ class CctServiceTest {
             .build()))
         .build();
 
-    ObjectId calculationId2 = ObjectId.get();
+    UUID calculationId2 = UUID.randomUUID();
     UUID pmId2 = UUID.randomUUID();
     Instant created2 = Instant.now().minus(Duration.ofDays(2));
     Instant lastModified2 = Instant.now().plus(Duration.ofDays(2));
@@ -157,7 +156,7 @@ class CctServiceTest {
 
   @Test
   void shouldReturnEmptyGettingCalculationWhenNotFound() {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
 
     when(calculationRepository.findById(id)).thenReturn(Optional.empty());
 
@@ -168,7 +167,7 @@ class CctServiceTest {
 
   @Test
   void shouldThrowExceptionGettingCalculationWhenNotBelongsToUser() {
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     CctCalculation entity = CctCalculation.builder()
         .id(id)
         .traineeId(UUID.randomUUID().toString())
@@ -181,7 +180,7 @@ class CctServiceTest {
 
   @Test
   void shouldGetCalculationWhenBelongsToUser() {
-    ObjectId calculationId = ObjectId.get();
+    UUID calculationId = UUID.randomUUID();
     UUID pmId = UUID.randomUUID();
 
     Instant created = Instant.now().minus(Duration.ofDays(1));
@@ -265,7 +264,7 @@ class CctServiceTest {
         ))
         .build();
 
-    ObjectId calculationId = ObjectId.get();
+    UUID calculationId = UUID.randomUUID();
     when(calculationRepository.insert(any(CctCalculation.class))).thenAnswer(inv -> {
       CctCalculation entity = inv.getArgument(0);
       CctProgrammeMembership pm = entity.programmeMembership();
@@ -330,7 +329,7 @@ class CctServiceTest {
   void shouldInsertCctDateAndIncludeOtherDetailsInReturnedDto() {
     UUID pmId = UUID.randomUUID();
 
-    ObjectId calculationId = ObjectId.get();
+    UUID calculationId = UUID.randomUUID();
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
         .id(calculationId)
         .name("Test Calculation")
@@ -385,7 +384,7 @@ class CctServiceTest {
   @Test
   void shouldUpdateExistingCalculationIfExistsAndOwnedByUser() {
     UUID pmId = UUID.randomUUID();
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     Instant created = Instant.now();
 
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()
@@ -492,7 +491,7 @@ class CctServiceTest {
   @Test
   void shouldNotUpdateExistingCalculationIfNotExists() {
     UUID pmId = UUID.randomUUID();
-    ObjectId id = ObjectId.get();
+    UUID id = UUID.randomUUID();
     Instant created = Instant.now();
 
     CctCalculationDetailDto dto = CctCalculationDetailDto.builder()


### PR DESCRIPTION
# refactor(cct): use UUID for calculation ID

The CctCalculation should use UUID so that it matches the agreed API
documentation. UUIDs are more portable and gives consistency with other
new trainee data types (e.g. LTFT forms) which are UUID based.

Refactor the CctCalculation to use a UUID identifier instead of
ObjectID.

NO-TICKET

---

# feat(cct): add ID field to CctChange

The CctChanges should have an identifier so they can be referenced by
associated forms.
Validation should ensure that the ID is empty when a calculation is
created. When updating a calculation, the ID must be unique within the
calculation's change list and must null or match an existing change in
the database. This will ensure that users can not generated their own
IDs, while allowing previously saved changes to maintain a consistent
ID.

NO-TICKET