### PR TITLE
feat: store personal details role

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.22.0"
+version = "1.23.0"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsDto.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.trainee.details.dto;
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.Data;
 import uk.nhs.hee.trainee.details.dto.deserializer.LowerCaseDeserializer;
 import uk.nhs.hee.trainee.details.dto.signature.Signature;
@@ -40,7 +41,7 @@ public class PersonalDetailsDto implements SignedDto {
   private String knownAs;
   private String maidenName;
   private String title;
-  private String role;
+  private List<String> role;
   @JsonAlias("owner")
   private String personOwner;
   private LocalDate dateOfBirth;

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/PersonalDetailsDto.java
@@ -40,6 +40,7 @@ public class PersonalDetailsDto implements SignedDto {
   private String knownAs;
   private String maidenName;
   private String title;
+  private String role;
   @JsonAlias("owner")
   private String personOwner;
   private LocalDate dateOfBirth;

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/UserDetails.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/UserDetails.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.trainee.details.dto;
 
+import java.util.List;
+
 /**
  * User details for an individual user.
  *
@@ -37,6 +39,6 @@ public record UserDetails(
     String familyName,
     String givenName,
     String gmcNumber,
-    String role) {
+    List<String> role) {
 
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/UserDetails.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/UserDetails.java
@@ -29,12 +29,14 @@ package uk.nhs.hee.trainee.details.dto;
  * @param familyName The profile family name.
  * @param givenName  The profile given name.
  * @param gmcNumber  The profile GMC number.
+ * @param role       The profile TIS role(s).
  */
 public record UserDetails(
     String email,
     String title,
     String familyName,
     String givenName,
-    String gmcNumber) {
+    String gmcNumber,
+    String role) {
 
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
@@ -69,6 +69,7 @@ public abstract class TraineeProfileMapper {
 
   @BeanMapping(ignoreByDefault = true)
   @Mapping(target = "personalDetails.publicHealthNumber", source = "publicHealthNumber")
+  @Mapping(target = "personalDetails.role", source = "role")
   public abstract void updateBasicDetails(@MappingTarget TraineeProfile target,
       PersonalDetails source);
 
@@ -109,6 +110,7 @@ public abstract class TraineeProfileMapper {
   @BeanMapping(ignoreByDefault = true)
   @Mapping(target = "personalDetails.dateOfBirth", source = "dateOfBirth")
   @Mapping(target = "personalDetails.gender", source = "gender")
+  @Mapping(target = "personalDetails.role", source = "role")
   public abstract void updatePersonalInfo(@MappingTarget TraineeProfile target,
       PersonalDetails source);
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
@@ -110,7 +110,6 @@ public abstract class TraineeProfileMapper {
   @BeanMapping(ignoreByDefault = true)
   @Mapping(target = "personalDetails.dateOfBirth", source = "dateOfBirth")
   @Mapping(target = "personalDetails.gender", source = "gender")
-  @Mapping(target = "personalDetails.role", source = "role")
   public abstract void updatePersonalInfo(@MappingTarget TraineeProfile target,
       PersonalDetails source);
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetails.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetails.java
@@ -33,6 +33,7 @@ public class PersonalDetails {
   private String maidenName; // ContactDetails
   private String title; // ContactDetails
   private String personOwner; // PersonOwner
+  private String role; // PersonalDetails
   private LocalDate dateOfBirth; // PersonalDetails
   private String gender; // PersonalDetails
   private String qualification; // TODO: Remove when FE can handle sub-collection.

--- a/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetails.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetails.java
@@ -22,6 +22,7 @@
 package uk.nhs.hee.trainee.details.model;
 
 import java.time.LocalDate;
+import java.util.List;
 import lombok.Data;
 
 /**
@@ -36,7 +37,7 @@ public class PersonalDetails {
   private String maidenName; // ContactDetails
   private String title; // ContactDetails
   private String personOwner; // PersonOwner
-  private String role; // PersonalDetails
+  private List<String> role; // PersonalDetails
   private LocalDate dateOfBirth; // PersonalDetails
   private String gender; // PersonalDetails
   private String qualification; // TODO: Remove when FE can handle sub-collection.

--- a/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetails.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetails.java
@@ -24,6 +24,9 @@ package uk.nhs.hee.trainee.details.model;
 import java.time.LocalDate;
 import lombok.Data;
 
+/**
+ * Trainee doctor personal details.
+ */
 @Data
 public class PersonalDetails {
 

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -140,7 +140,7 @@ public class TraineeProfileService {
       String familyName = traineeProfile.getPersonalDetails().getSurname();
       String givenName = traineeProfile.getPersonalDetails().getForenames();
       String gmcNumber = traineeProfile.getPersonalDetails().getGmcNumber();
-      String role = traineeProfile.getPersonalDetails().getRole();
+      List<String> role = traineeProfile.getPersonalDetails().getRole();
       return Optional.of(new UserDetails(email, title, familyName, givenName, gmcNumber, role));
     }
     return Optional.empty();

--- a/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/TraineeProfileService.java
@@ -140,7 +140,8 @@ public class TraineeProfileService {
       String familyName = traineeProfile.getPersonalDetails().getSurname();
       String givenName = traineeProfile.getPersonalDetails().getForenames();
       String gmcNumber = traineeProfile.getPersonalDetails().getGmcNumber();
-      return Optional.of(new UserDetails(email, title, familyName, givenName, gmcNumber));
+      String role = traineeProfile.getPersonalDetails().getRole();
+      return Optional.of(new UserDetails(email, title, familyName, givenName, gmcNumber, role));
     }
     return Optional.empty();
   }

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -112,6 +112,7 @@ class TraineeProfileResourceTest {
   private static final String PERSON_ADDRESS4 = "UK";
   private static final String PERSON_POSTCODE = "SW1A1AA";
   private static final String PERSON_GMC = "11111111";
+  private static final String PERSON_ROLE = "role";
 
   private static final String PROGRAMME_TISID = "1";
   private static final String PROGRAMME_NAME = "General Practice";
@@ -194,6 +195,7 @@ class TraineeProfileResourceTest {
     personalDetails.setAddress4(PERSON_ADDRESS4);
     personalDetails.setPostCode(PERSON_POSTCODE);
     personalDetails.setGmcNumber(PERSON_GMC);
+    personalDetails.setRole(PERSON_ROLE);
   }
 
   /**
@@ -308,6 +310,7 @@ class TraineeProfileResourceTest {
         .andExpect(jsonPath("$.personalDetails.address4").value(PERSON_ADDRESS4))
         .andExpect(jsonPath("$.personalDetails.postCode").value(PERSON_POSTCODE))
         .andExpect(jsonPath("$.personalDetails.gmcNumber").value(PERSON_GMC))
+        .andExpect(jsonPath("$.personalDetails.role").value(PERSON_ROLE))
         .andExpect(jsonPath("$.personalDetails.signature.hmac").value(signature.getHmac()))
         .andExpect(jsonPath("$.personalDetails.signature.signedAt").value(
             signature.getSignedAt().toString()))
@@ -441,15 +444,16 @@ class TraineeProfileResourceTest {
   void getUserAccountShouldReturnAccountDetailsWhenProfileFoundByTisId() throws Exception {
     when(service.getTraineeDetailsByTisId(DEFAULT_TIS_ID_1))
         .thenReturn(Optional.of(
-            new UserDetails(
-                PERSON_EMAIL, PERSON_TITLE, PERSON_SURNAME, PERSON_FORENAME, PERSON_GMC)));
+            new UserDetails(PERSON_EMAIL, PERSON_TITLE, PERSON_SURNAME, PERSON_FORENAME, PERSON_GMC,
+                PERSON_ROLE)));
 
     mockMvc.perform(get("/api/trainee-profile/account-details/{tisId}", DEFAULT_TIS_ID_1)
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.email").value(PERSON_EMAIL))
-        .andExpect(jsonPath("$.familyName").value(PERSON_SURNAME));
+        .andExpect(jsonPath("$.familyName").value(PERSON_SURNAME))
+        .andExpect(jsonPath("$.role").value(PERSON_ROLE));
   }
 
   @ParameterizedTest

--- a/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/TraineeProfileResourceTest.java
@@ -195,7 +195,7 @@ class TraineeProfileResourceTest {
     personalDetails.setAddress4(PERSON_ADDRESS4);
     personalDetails.setPostCode(PERSON_POSTCODE);
     personalDetails.setGmcNumber(PERSON_GMC);
-    personalDetails.setRole(PERSON_ROLE);
+    personalDetails.setRole(List.of(PERSON_ROLE));
   }
 
   /**
@@ -445,7 +445,7 @@ class TraineeProfileResourceTest {
     when(service.getTraineeDetailsByTisId(DEFAULT_TIS_ID_1))
         .thenReturn(Optional.of(
             new UserDetails(PERSON_EMAIL, PERSON_TITLE, PERSON_SURNAME, PERSON_FORENAME, PERSON_GMC,
-                PERSON_ROLE)));
+                List.of(PERSON_ROLE))));
 
     mockMvc.perform(get("/api/trainee-profile/account-details/{tisId}", DEFAULT_TIS_ID_1)
             .contentType(MediaType.APPLICATION_JSON))
@@ -453,7 +453,7 @@ class TraineeProfileResourceTest {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.email").value(PERSON_EMAIL))
         .andExpect(jsonPath("$.familyName").value(PERSON_SURNAME))
-        .andExpect(jsonPath("$.role").value(PERSON_ROLE));
+        .andExpect(jsonPath("$.role[0]").value(PERSON_ROLE));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
And include it in UserDetails and Profile DTOs for downstream handling.

Example traineeProfile:

```
{
  "_id": {
    "$oid": "5e00c7942749a84794644f83"
  },
  "traineeTisId": "47165",
  "personalDetails": {
    "surname": "Gilliam",
    "forenames": "Anthony Mara",
    "knownAs": "Ivy",
    "maidenName": "N/A",
    "title": "Mr",
    "personOwner": "Thames Valley",
    "role": [
      "DR in Training",
      "Dummy Record",
      "Foundation Clinical Supervisor",
      "x"
    ],
    "dateOfBirth": {
      "$date": "1991-11-11T00:00:00.000Z"
    },
    "gender": "Male",
    "qualification": "MBBS Bachelor of Medicine and Bachelor of Surgery",
    "dateAttained": {
      "$date": "2018-05-29T23:00:00.000Z"
    },
    "medicalSchool": "University of Science and Technology",
    "telephoneNumber": "01632960363",
    "mobileNumber": "08465879348",
    "email": "email@email.com",
    "address1": "585-6360 Interdum Street",
    "address2": "Goulburn",
    "address3": "London",
    "address4": "UK",
    "postCode": "SW1A1AA",
    "gmcNumber": "1234567",
    "gmcStatus": "Registered with Licence",
    "prevRevalBody": "South London",
    "currRevalDate": {
      "$date": "2020-04-08T23:00:00.000Z"
    },
    "prevRevalDate": {
      "$date": "2015-04-08T23:00:00.000Z"
    }
  },
  "qualifications": [
    ...
  ],
  "programmeMemberships": [
    ...
  ],
  "placements": [
   ...
  ],
  "version": {
    "$numberLong": "59"
  },
  "_class": "uk.nhs.hee.trainee.details.model.TraineeProfile"
}
```

TIS21-6950