### PR TITLE
fix: remove DBC NotNull restriction in CCT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.23.1"
+version = "1.23.2"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
@@ -96,7 +96,6 @@ public record CctCalculationDetailDto(
       @Range(min = 0, max = 1)
       Double wte,
 
-      @NotNull
       String designatedBodyCode) {
 
   }


### PR DESCRIPTION
removing the NotNull restriction of the field in BE, in case CCT is being edited without refreshing the PM or the DBC is missing in PM