### PR TITLE
feat: feature flags for LTFT

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.23.3"
+version = "1.24.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/FeatureResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/FeatureResourceIntegrationTest.java
@@ -1,0 +1,116 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.api;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.nhs.hee.trainee.details.DockerImageNames.MONGO;
+
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.nhs.hee.trainee.details.TestJwtUtil;
+import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
+import uk.nhs.hee.trainee.details.model.TraineeProfile;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers(disabledWithoutDocker = true)
+@AutoConfigureMockMvc
+class FeatureResourceIntegrationTest {
+
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+
+  @Container
+  @ServiceConnection
+  private static final MongoDBContainer mongoContainer = new MongoDBContainer(MONGO);
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private MongoTemplate template;
+
+  @MockBean
+  private SqsTemplate sqsTemplate;
+
+  @AfterEach
+  void tearDown() {
+    template.findAllAndRemove(new Query(), TraineeProfile.class);
+  }
+
+  @Test
+  void shouldBeForbiddenGettingFeaturesWhenNoToken() throws Exception {
+    mockMvc.perform(get("/api/features"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$").doesNotExist());
+  }
+
+  @Test
+  void shouldBeForbiddenGettingFeaturesWhenNoTraineeId() throws Exception {
+    String token = TestJwtUtil.generateToken("{}");
+    mockMvc.perform(get("/api/features")
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$").doesNotExist());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"North West London", "North Central and East London", "South London", "South West"})
+  void shouldEnableLtftWhenQualifyingProgrammeExists(String deanery) throws Exception {
+    TraineeProfile profile = new TraineeProfile();
+    profile.setTraineeTisId(TRAINEE_ID);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(deanery);
+    pm.setEndDate(LocalDate.now().plusDays(1));
+    profile.setProgrammeMemberships(List.of(pm));
+
+    template.save(profile);
+
+    String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
+    mockMvc.perform(get("/api/features")
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.ltft", is(true)));
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/api/FeatureResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/FeatureResource.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.trainee.details.dto.FeaturesDto;
+import uk.nhs.hee.trainee.details.service.FeatureService;
+
+/**
+ * A rest controller for feature flag endpoints.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/features")
+public class FeatureResource {
+
+  private final FeatureService service;
+
+  public FeatureResource(FeatureService service) {
+    this.service = service;
+  }
+
+  /**
+   * Get the enabled features for the requesting trainee.
+   *
+   * @return The features that are enabled.
+   */
+  @GetMapping
+  ResponseEntity<FeaturesDto> getFeatures() {
+    log.info("Requested feature flags for signed in trainee.");
+    FeaturesDto features = service.getFeatures();
+    return ResponseEntity.ok(features);
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/config/FeaturesProperties.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/FeaturesProperties.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.config;
+
+import java.util.Set;
+import lombok.Builder;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Feature flag application properties.
+ */
+@Builder
+@ConfigurationProperties(prefix = "application.features")
+public record FeaturesProperties(Ltft ltft) {
+
+  /**
+   * LTFT feature flag application properties.
+   *
+   * @param deaneries The managing deaneries to enable LTFT for.
+   */
+  @Builder
+  public record Ltft(Set<String> deaneries) {
+
+  }
+
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/FeaturesDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/FeaturesDto.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.dto;
+
+import lombok.Builder;
+
+/**
+ * A DTO for trainee details feature flags.
+ */
+@Builder
+public record FeaturesDto(boolean ltft) {
+
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptor.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptor.java
@@ -59,8 +59,11 @@ public class TraineeIdentityInterceptor implements HandlerInterceptor {
 
     // Non-CCT endpoints are a mix of authenticated (public) and unauthenticated (internal), limit
     // trainee ID verification to CCT endpoints for now.
-    if (traineeIdentity.getTraineeId() == null
-        && request.getRequestURI().matches("^/api/cct(/.+)?$")) {
+    String requestUri = request.getRequestURI();
+    boolean identityRequired = requestUri.matches("^/api/cct(/.+)?$")
+        || requestUri.equals("/api/features");
+
+    if (identityRequired && traineeIdentity.getTraineeId() == null) {
       response.setStatus(HttpStatus.FORBIDDEN.value());
       return false;
     }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/FeatureService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/FeatureService.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.trainee.details.config.FeaturesProperties;
+import uk.nhs.hee.trainee.details.dto.FeaturesDto;
+import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
+import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
+import uk.nhs.hee.trainee.details.model.TraineeProfile;
+
+/**
+ * A service providing access to feature flag logic.
+ */
+@Slf4j
+@Service
+public class FeatureService {
+
+  private final TraineeIdentity identity;
+  private final TraineeProfileService profileService;
+  private final FeaturesProperties featuresProperties;
+  private final ZoneId timezone;
+
+  /**
+   * Construct a feature service instance.
+   *
+   * @param identity           The identity of the caller.
+   * @param profileService     The profile service to lookup trainee data.
+   * @param featuresProperties The feature properties.
+   * @param timezone           The timezone to use.
+   */
+  public FeatureService(TraineeIdentity identity, TraineeProfileService profileService,
+      FeaturesProperties featuresProperties, @Value("${application.timezone}") ZoneId timezone) {
+    this.identity = identity;
+    this.profileService = profileService;
+    this.featuresProperties = featuresProperties;
+    this.timezone = timezone;
+  }
+
+  /**
+   * Get the enabled features for the requesting trainee.
+   *
+   * @return The features that are enabled.
+   */
+  public FeaturesDto getFeatures() {
+    String traineeId = identity.getTraineeId();
+    log.info("Getting enabled features for trainee {}.", traineeId);
+
+    TraineeProfile profile = profileService.getTraineeProfileByTraineeTisId(traineeId);
+
+    return FeaturesDto.builder()
+        .ltft(isLtftEnabled(profile))
+        .build();
+  }
+
+  /**
+   * Whether the given profile is allowed access to Less Than Full Time functionality.
+   *
+   * @param profile The trainee profile to check.
+   * @return Whether the trainee should have access to LTFT.
+   */
+  private boolean isLtftEnabled(TraineeProfile profile) {
+    if (profile == null) {
+      log.info("LTFT disabled due to missing profile.");
+      return false;
+    }
+
+    LocalDate now = LocalDate.now(timezone);
+
+    boolean enabled = profile.getProgrammeMemberships().stream()
+        .filter(pm -> pm.getEndDate().isAfter(now)) // Past programmes are not valid for LTFT.
+        .map(ProgrammeMembership::getManagingDeanery)
+        .anyMatch(md -> featuresProperties.ltft().deaneries().contains(md));
+
+    log.info("LTFT enabled for trainee {}: {}", profile.getTraineeTisId(), enabled);
+
+    return enabled;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,13 @@ application:
       personal-info-update: ${PERSONAL_INFO_UPDATE_QUEUE_URL:}
       person-owner-update: ${PERSON_OWNER_UPDATE_QUEUE_URL:}
   environment: ${ENVIRONMENT:local}
+  features:
+    ltft:
+      deaneries:
+        - North West London
+        - North Central and East London
+        - South London
+        - South West
   signature:
     secret-key: ${SIGNATURE_SECRET_KEY}
     expire-after:  # Minutes

--- a/src/test/java/uk/nhs/hee/trainee/details/api/FeatureResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/FeatureResourceTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.OK;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+import uk.nhs.hee.trainee.details.dto.FeaturesDto;
+import uk.nhs.hee.trainee.details.service.FeatureService;
+
+class FeatureResourceTest {
+
+  private FeatureResource controller;
+  private FeatureService service;
+
+  @BeforeEach
+  void setUp() {
+    service = mock(FeatureService.class);
+    controller = new FeatureResource(service);
+  }
+
+  @Test
+  void shouldReturnFeatures() {
+    FeaturesDto features = FeaturesDto.builder()
+        .ltft(true)
+        .build();
+
+    when(service.getFeatures()).thenReturn(features);
+
+    ResponseEntity<FeaturesDto> response = controller.getFeatures();
+
+    assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
+    assertThat("Unexpected response body.", response.getBody(), sameInstance(features));
+  }
+}

--- a/src/test/java/uk/nhs/hee/trainee/details/api/RestResponseEntityExceptionHandlerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/RestResponseEntityExceptionHandlerTest.java
@@ -35,7 +35,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -187,7 +186,7 @@ class RestResponseEntityExceptionHandlerTest {
       Map<String, List<String>> parametersToMessages) implements MethodValidationResult {
 
     @Override
-    public @NotNull Object getTarget() {
+    public Object getTarget() {
       return "testTarget";
     }
 
@@ -202,7 +201,7 @@ class RestResponseEntityExceptionHandlerTest {
     }
 
     @Override
-    public @NotNull List<ParameterValidationResult> getAllValidationResults() {
+    public List<ParameterValidationResult> getAllValidationResults() {
       return parametersToMessages.entrySet().stream()
           .map(entry -> {
             String parameterName = entry.getKey();

--- a/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorTest.java
@@ -47,7 +47,7 @@ class TraineeIdentityInterceptorTest {
   }
 
   @Test
-  void shouldReturnTrueAndNotSetTraineeIdWhenNoAuthTokenAndNonCctEndpoint() {
+  void shouldReturnTrueAndNotSetTraineeIdWhenNoAuthTokenAndNonIdRequiredEndpoint() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setRequestURI("/api/test");
 
@@ -59,8 +59,8 @@ class TraineeIdentityInterceptorTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"/api/cct", "/api/cct/calculator", "/api/cct/calculator/1",
-      "/api/cct/test/1"})
-  void shouldReturnFalseAndNotSetTraineeIdWhenNoAuthTokenAndCctEndpoint(String uri) {
+      "/api/cct/test/1", "/api/features"})
+  void shouldReturnFalseAndNotSetTraineeIdWhenNoAuthTokenAndIdRequiredEndpoint(String uri) {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setRequestURI(uri);
 
@@ -71,7 +71,7 @@ class TraineeIdentityInterceptorTest {
   }
 
   @Test
-  void shouldReturnTrueAndNotSetTraineeIdWhenTokenNotMapAndNonCctEndpoint() {
+  void shouldReturnTrueAndNotSetTraineeIdWhenTokenNotMapAndNonIdRequiredEndpoint() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("[]"));
     request.setRequestURI("/api/test");
@@ -84,8 +84,8 @@ class TraineeIdentityInterceptorTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"/api/cct", "/api/cct/calculator", "/api/cct/calculator/1",
-      "/api/cct/test/1"})
-  void shouldReturnFalseAndNotSetTraineeIdWhenTokenNotMapAndCctEndpoint(String uri) {
+      "/api/cct/test/1", "/api/features"})
+  void shouldReturnFalseAndNotSetTraineeIdWhenTokenNotMapAndIdRequiredEndpoint(String uri) {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("[]"));
     request.setRequestURI(uri);
@@ -97,7 +97,7 @@ class TraineeIdentityInterceptorTest {
   }
 
   @Test
-  void shouldReturnTrueAndNotSetTraineeIdWhenNoTisIdInAuthTokenAndNonCctEndpoint() {
+  void shouldReturnTrueAndNotSetTraineeIdWhenNoTisIdInAuthTokenAndNonIdRequiredEndpoint() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("{}"));
     request.setRequestURI("/api/test");
@@ -110,8 +110,8 @@ class TraineeIdentityInterceptorTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"/api/cct", "/api/cct/calculator", "/api/cct/calculator/1",
-      "/api/cct/test/1"})
-  void shouldReturnFalseAndNotSetTraineeIdWhenNoTisIdInAuthTokenAndCctEndpoint(String uri) {
+      "/api/cct/test/1", "/api/features"})
+  void shouldReturnFalseAndNotSetTraineeIdWhenNoTisIdInAuthTokenAndIdRequiredEndpoint(String uri) {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateToken("{}"));
     request.setRequestURI(uri);
@@ -124,8 +124,8 @@ class TraineeIdentityInterceptorTest {
 
   @ParameterizedTest
   @ValueSource(strings = {"/api/cct", "/api/cct/calculator", "/api/cct/calculator/1",
-      "/api/cct/test/1", "/api/test"})
-  void shouldReturnTrueAndSetTraineeIdWhenTisIdInAuthTokenAndCctEndpoint() {
+      "/api/cct/test/1", "/api/test", "/api/features"})
+  void shouldReturnTrueAndSetTraineeIdWhenTisIdInAuthToken() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId("40"));
 

--- a/src/test/java/uk/nhs/hee/trainee/details/service/FeatureServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/FeatureServiceTest.java
@@ -1,0 +1,138 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2025 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.nhs.hee.trainee.details.config.FeaturesProperties;
+import uk.nhs.hee.trainee.details.config.FeaturesProperties.Ltft;
+import uk.nhs.hee.trainee.details.dto.FeaturesDto;
+import uk.nhs.hee.trainee.details.dto.TraineeIdentity;
+import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
+import uk.nhs.hee.trainee.details.model.TraineeProfile;
+
+class FeatureServiceTest {
+
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+
+  private FeatureService service;
+  private TraineeProfileService profileService;
+
+  @BeforeEach
+  void setUp() {
+    TraineeIdentity traineeIdentity = new TraineeIdentity();
+    traineeIdentity.setTraineeId(TRAINEE_ID);
+
+    profileService = mock(TraineeProfileService.class);
+    FeaturesProperties featuresProperties = FeaturesProperties.builder()
+        .ltft(Ltft.builder()
+            .deaneries(Set.of("test 1", "test 2", "test 3"))
+            .build())
+        .build();
+
+    service = new FeatureService(traineeIdentity, profileService, featuresProperties,
+        ZoneId.of("UTC"));
+  }
+
+  @Test
+  void shouldDisableLtftWhenNoProfileFound() {
+    when(profileService.getTraineeProfileByTraineeTisId(TRAINEE_ID)).thenReturn(null);
+
+    FeaturesDto features = service.getFeatures();
+
+    assertThat("Unexpected LTFT flag.", features.ltft(), is(false));
+  }
+
+  @Test
+  void shouldDisableLtftWhenNoProgrammes() {
+    TraineeProfile profile = new TraineeProfile();
+    profile.setTraineeTisId(TRAINEE_ID);
+    profile.setProgrammeMemberships(List.of());
+    when(profileService.getTraineeProfileByTraineeTisId(TRAINEE_ID)).thenReturn(profile);
+
+    FeaturesDto features = service.getFeatures();
+
+    assertThat("Unexpected LTFT flag.", features.ltft(), is(false));
+  }
+
+  @Test
+  void shouldDisableLtftWhenNoProgrammesInQualifyingDeanery() {
+    TraineeProfile profile = new TraineeProfile();
+    profile.setTraineeTisId(TRAINEE_ID);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery("None Qualifying");
+    pm.setEndDate(LocalDate.now().plusDays(1));
+    profile.setProgrammeMemberships(List.of(pm));
+    when(profileService.getTraineeProfileByTraineeTisId(TRAINEE_ID)).thenReturn(profile);
+
+    FeaturesDto features = service.getFeatures();
+
+    assertThat("Unexpected LTFT flag.", features.ltft(), is(false));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"test 1", "test 2", "test 3"})
+  void shouldDisableLtftWhenProgrammeInQualifyingDeaneryEnded(String deanery) {
+    TraineeProfile profile = new TraineeProfile();
+    profile.setTraineeTisId(TRAINEE_ID);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(deanery);
+    pm.setEndDate(LocalDate.now());
+    profile.setProgrammeMemberships(List.of(pm));
+    when(profileService.getTraineeProfileByTraineeTisId(TRAINEE_ID)).thenReturn(profile);
+
+    FeaturesDto features = service.getFeatures();
+
+    assertThat("Unexpected LTFT flag.", features.ltft(), is(false));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"test 1", "test 2", "test 3"})
+  void shouldEnableLtftWhenProgrammeInQualifyingDeaneryNotEnded(String deanery) {
+    TraineeProfile profile = new TraineeProfile();
+    profile.setTraineeTisId(TRAINEE_ID);
+
+    ProgrammeMembership pm = new ProgrammeMembership();
+    pm.setManagingDeanery(deanery);
+    pm.setEndDate(LocalDate.now().plusDays(1));
+    profile.setProgrammeMemberships(List.of(pm));
+    when(profileService.getTraineeProfileByTraineeTisId(TRAINEE_ID)).thenReturn(profile);
+
+    FeaturesDto features = service.getFeatures();
+
+    assertThat("Unexpected LTFT flag.", features.ltft(), is(true));
+  }
+}


### PR DESCRIPTION
Create a feature flag for LTFT at `GET: /api/features` to return whether the trainee has a valid programme for LTFT.

Current rules are that the programme must not have ended and must be a a London or South West programme.

TIS21-6703
TIS21-6908