### PR TITLE
feat(ltft): always enable for beta participants

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.24.0"
+version = "1.25.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/FeatureResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/FeatureResourceIntegrationTest.java
@@ -52,7 +52,7 @@ import uk.nhs.hee.trainee.details.TestJwtUtil;
 import uk.nhs.hee.trainee.details.model.ProgrammeMembership;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
-@SpringBootTest
+@SpringBootTest(properties = "application.features.ltft.pilot.start-date=1970-01-01")
 @ActiveProfiles("test")
 @Testcontainers(disabledWithoutDocker = true)
 @AutoConfigureMockMvc
@@ -79,23 +79,24 @@ class FeatureResourceIntegrationTest {
   }
 
   @Test
-  void shouldBeForbiddenGettingFeaturesWhenNoToken() throws Exception {
+  void shouldDisableLtftWhenNoToken() throws Exception {
     mockMvc.perform(get("/api/features"))
-        .andExpect(status().isForbidden())
-        .andExpect(jsonPath("$").doesNotExist());
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.ltft", is(false)));
   }
 
   @Test
-  void shouldBeForbiddenGettingFeaturesWhenNoTraineeId() throws Exception {
+  void shouldDisableLtftWhenNoTraineeId() throws Exception {
     String token = TestJwtUtil.generateToken("{}");
     mockMvc.perform(get("/api/features")
             .header(HttpHeaders.AUTHORIZATION, token))
-        .andExpect(status().isForbidden())
-        .andExpect(jsonPath("$").doesNotExist());
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.ltft", is(false)));
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"North West London", "North Central and East London", "South London", "South West"})
+  @ValueSource(strings = {"North West London", "North Central and East London", "South London",
+      "South West"})
   void shouldEnableLtftWhenQualifyingProgrammeExists(String deanery) throws Exception {
     TraineeProfile profile = new TraineeProfile();
     profile.setTraineeTisId(TRAINEE_ID);

--- a/src/main/java/uk/nhs/hee/trainee/details/config/FeaturesProperties.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/FeaturesProperties.java
@@ -21,6 +21,8 @@
 
 package uk.nhs.hee.trainee.details.config;
 
+import java.time.LocalDate;
+import java.util.Map;
 import java.util.Set;
 import lombok.Builder;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -30,16 +32,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @Builder
 @ConfigurationProperties(prefix = "application.features")
-public record FeaturesProperties(Ltft ltft) {
+public record FeaturesProperties(Map<String, Tranche> ltft) {
 
   /**
-   * LTFT feature flag application properties.
+   * A tranche of deaneries for feature rollout.
    *
-   * @param deaneries The managing deaneries to enable LTFT for.
+   * @param startDate The start date of the tranche.
+   * @param deaneries The managing deaneries in the tranche.
    */
   @Builder
-  public record Ltft(Set<String> deaneries) {
+  public record Tranche(LocalDate startDate, Set<String> deaneries) {
 
   }
-
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/TraineeIdentity.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/TraineeIdentity.java
@@ -21,6 +21,7 @@
 
 package uk.nhs.hee.trainee.details.dto;
 
+import java.util.Set;
 import lombok.Data;
 
 /**
@@ -30,4 +31,5 @@ import lombok.Data;
 public class TraineeIdentity {
 
   String traineeId;
+  Set<String> groups;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,11 +44,13 @@ application:
   environment: ${ENVIRONMENT:local}
   features:
     ltft:
-      deaneries:
-        - North West London
-        - North Central and East London
-        - South London
-        - South West
+      pilot:
+        start-date: 2025-04-28
+        deaneries:
+          - North West London
+          - North Central and East London
+          - South London
+          - South West
   signature:
     secret-key: ${SIGNATURE_SECRET_KEY}
     expire-after:  # Minutes

--- a/src/test/java/uk/nhs/hee/trainee/details/api/util/AuthTokenUtilTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/util/AuthTokenUtilTest.java
@@ -24,55 +24,131 @@ package uk.nhs.hee.trainee.details.api.util;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class AuthTokenUtilTest {
 
-  private static final String TIS_ID_ATTRIBUTE = "custom:tisId";
+  private static final String STRING_ATTRIBUTE = "custom:my-string";
+  private static final String ARRAY_ATTRIBUTE = "my-array";
 
   @Test
-  void getTraineeTisIdShouldThrowExceptionWhenTokenPayloadNotMap() {
+  void getAttributesShouldHandleUrlCharactersInToken() {
+    // The payload is specifically crafted to include an underscore, the group is 123.
+    String token = "aGVhZGVy.eyJteS1hcnJheSI6WyIxMjMiXSwibmFtZSI6IkpvaG4gRG_DqyJ9.c2ln";
+
+    Set<String> groups = assertDoesNotThrow(
+        () -> AuthTokenUtil.getAttributes(token, ARRAY_ATTRIBUTE));
+
+    assertThat("Unexpected attribute count.", groups, hasSize(1));
+    assertThat("Unexpected attributes.", groups, hasItem("123"));
+  }
+
+  @Test
+  void getAttributesShouldThrowExceptionWhenTokenPayloadNotMap() {
     String encodedPayload = Base64.getEncoder()
         .encodeToString("[]".getBytes(StandardCharsets.UTF_8));
     String token = String.format("aa.%s.cc", encodedPayload);
 
-    assertThrows(IOException.class, () -> AuthTokenUtil.getTraineeTisId(token));
+    assertThrows(IOException.class, () -> AuthTokenUtil.getAttributes(token, ARRAY_ATTRIBUTE));
   }
 
   @Test
-  void getTraineeTisIdShouldReturnNullWhenTisIdNotInToken() throws IOException {
+  void getAttributesShouldReturnNullWhenArrayNotInToken() throws IOException {
     String encodedPayload = Base64.getEncoder()
         .encodeToString("{}".getBytes(StandardCharsets.UTF_8));
     String token = String.format("aa.%s.cc", encodedPayload);
 
-    String tisId = AuthTokenUtil.getTraineeTisId(token);
+    Set<String> attributes = AuthTokenUtil.getAttributes(token, ARRAY_ATTRIBUTE);
 
-    assertThat("Unexpected trainee TIS ID", tisId, nullValue());
+    assertThat("Unexpected attribute values.", attributes, nullValue());
   }
 
   @Test
-  void getTraineeTisIdShouldReturnIdWhenTisIdInToken() throws IOException {
-    String payload = String.format("{\"%s\":\"%s\"}", TIS_ID_ATTRIBUTE, "40");
+  void getAttributesShouldReturnEmptyWhenArrayEmptyInToken() throws IOException {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("""
+             {
+                "my-array": []
+             }
+            """
+            .getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    Set<String> attributes = AuthTokenUtil.getAttributes(token, ARRAY_ATTRIBUTE);
+
+    assertThat("Unexpected attribute count.", attributes, hasSize(0));
+  }
+
+  @Test
+  void getAttributesShouldReturnSetWhenArrayInToken() throws IOException {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("""
+             {
+                "my-array": [
+                  "123456",
+                  "ABCDEF"
+                ]
+             }
+            """
+            .getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    Set<String> attributes = AuthTokenUtil.getAttributes(token, ARRAY_ATTRIBUTE);
+
+    assertThat("Unexpected attribute count.", attributes, hasSize(2));
+    assertThat("Unexpected attributes.", attributes, hasItems("123456", "ABCDEF"));
+  }
+
+  @Test
+  void getAttributeShouldHandleUrlCharactersInToken() {
+    // The payload is specifically crafted to include an underscore, the ID is 123.
+    String token = "aGVhZGVy.eyJjdXN0b206bXktc3RyaW5nIjoiMTIzIiwibmFtZSI6IkpvaG4gRG_DqyJ9.c2ln";
+
+    String attribute = assertDoesNotThrow(
+        () -> AuthTokenUtil.getAttribute(token, STRING_ATTRIBUTE));
+
+    assertThat("Unexpected attribute.", attribute, is("123"));
+  }
+
+  @Test
+  void getAttributeShouldThrowExceptionWhenTokenPayloadNotMap() {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("[]".getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    assertThrows(IOException.class, () -> AuthTokenUtil.getAttribute(token, STRING_ATTRIBUTE));
+  }
+
+  @Test
+  void getAttributeShouldReturnNullWhenAttributeNotInToken() throws IOException {
+    String encodedPayload = Base64.getEncoder()
+        .encodeToString("{}".getBytes(StandardCharsets.UTF_8));
+    String token = String.format("aa.%s.cc", encodedPayload);
+
+    String attribute = AuthTokenUtil.getAttribute(token, STRING_ATTRIBUTE);
+
+    assertThat("Unexpected attribute.", attribute, nullValue());
+  }
+
+  @Test
+  void getAttributeShouldReturnIdWhenTisIdInToken() throws IOException {
+    String payload = String.format("{\"%s\":\"%s\"}", STRING_ATTRIBUTE, "40");
     String encodedPayload = Base64.getEncoder()
         .encodeToString(payload.getBytes(StandardCharsets.UTF_8));
     String token = String.format("aa.%s.cc", encodedPayload);
 
-    String tisId = AuthTokenUtil.getTraineeTisId(token);
+    String attribute = AuthTokenUtil.getAttribute(token, STRING_ATTRIBUTE);
 
-    assertThat("Unexpected trainee TIS ID", tisId, is("40"));
-  }
-
-  @Test
-  void getTraineeTisIdShouldHandleUrlCharactersInToken() {
-    // The payload is specifically crafted to include an underscore, the ID is 12.
-    String token = "aGVhZGVy.eyJjdXN0b206dGlzSWQiOiAiMTIiLCJuYW1lIjogIkpvaG4gRG_DqyJ9.c2lnbmF0dXJl";
-    String tisId = assertDoesNotThrow(() -> AuthTokenUtil.getTraineeTisId(token));
-    assertThat("Unexpected trainee TIS ID.", tisId, is("12"));
+    assertThat("Unexpected attribute.", attribute, is("40"));
   }
 }


### PR DESCRIPTION
Members of the `beta-participant` group should always have the LTFT feature enabled, regardless of having a qualifying programme membership. Update the trainee identity to include the Cognito groups, use the groups to determine beta group membership when checking valid feature flags.

Refactor the FeaturesProperties to allow multiple tranches to be configured with individual start dates and deanery lists. The feature service should combine all started tranches when determining whether there is a valid PM or not.

Update the TraineeIdentityInterceptor to relax the trainee ID requirement on the feature flag endpoint.
Features will still be disabled via the FeatureService if there is no trainee ID, but the hard requirement in the interceptor causes authentication failures with ambiguous error messages.

TIS21-6703
TIS21-6908