### PR TITLE
feat(cct): add managing deanery

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.25.0"
+version = "1.26.0"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -328,6 +328,7 @@ class CctResourceIntegrationTest {
             .endDate(LocalDate.parse("2025-01-01"))
             .wte(1.0)
             .designatedBodyCode("testDbc")
+            .managingDeanery("Test Deanery")
             .build())
         .changes(List.of(
             CctChange.builder()
@@ -354,6 +355,7 @@ class CctResourceIntegrationTest {
         .andExpect(jsonPath("$.programmeMembership.endDate").value("2025-01-01"))
         .andExpect(jsonPath("$.programmeMembership.wte").value(1))
         .andExpect(jsonPath("$.programmeMembership.designatedBodyCode").value("testDbc"))
+        .andExpect(jsonPath("$.programmeMembership.managingDeanery").value("Test Deanery"))
         .andExpect(jsonPath("$.changes").isArray())
         .andExpect(jsonPath("$.changes", hasSize(1)))
         .andExpect(jsonPath("$.changes[0].type").value("LTFT"))
@@ -508,7 +510,8 @@ class CctResourceIntegrationTest {
             "startDate": "2024-01-01",
             "endDate": "2025-01-01",
             "wte": 0.5,
-            "designatedBodyCode": "testDbc"
+            "designatedBodyCode": "testDbc",
+            "managingDeanery": "Test Deanery"
           },
           "changes": %s
         }
@@ -535,7 +538,8 @@ class CctResourceIntegrationTest {
             "startDate": "2024-01-01",
             "endDate": "2025-01-01",
             "wte": 0.5,
-            "designatedBodyCode": "testDbc"
+            "designatedBodyCode": "testDbc",
+            "managingDeanery": "Test Deanery"
           },
           "changes": [
             {
@@ -587,7 +591,8 @@ class CctResourceIntegrationTest {
             "startDate": "2024-01-01",
             "endDate": "2025-01-01",
             "wte": 0.5,
-            "designatedBodyCode": "testDbc"
+            "designatedBodyCode": "testDbc",
+            "managingDeanery": "Test Deanery"
           },
           "changes": [
             {
@@ -714,7 +719,8 @@ class CctResourceIntegrationTest {
             "startDate": "2024-01-01",
             "endDate": "2025-01-01",
             "wte": 0.5,
-            "designatedBodyCode": "testDbc"
+            "designatedBodyCode": "testDbc",
+            "managingDeanery": "Test Deanery"
           },
           "changes": [
             {
@@ -748,7 +754,8 @@ class CctResourceIntegrationTest {
             "startDate": "2024-01-01",
             "endDate": "2025-01-01",
             "wte": 0.5,
-            "designatedBodyCode": "testDbc"
+            "designatedBodyCode": "testDbc",
+            "managingDeanery": "Test Deanery"
           },
           "changes": [
             {
@@ -779,6 +786,7 @@ class CctResourceIntegrationTest {
             .endDate(LocalDate.of(2025, 1, 1))
             .wte(0.5)
             .designatedBodyCode("testDbc")
+            .managingDeanery("Test Deanery")
             .build())
         .changes(List.of(
                 CctChange.builder().type(LTFT).startDate(LocalDate.of(2024, 11, 1))
@@ -803,7 +811,8 @@ class CctResourceIntegrationTest {
             "startDate": "2024-01-01",
             "endDate": "2025-01-01",
             "wte": 0.5,
-            "designatedBodyCode": "testDbc"
+            "designatedBodyCode": "testDbc",
+            "managingDeanery": "Test Deanery"
           },
           "changes": [
             {
@@ -851,6 +860,7 @@ class CctResourceIntegrationTest {
             .endDate(LocalDate.of(2025, 1, 1))
             .wte(0.5)
             .designatedBodyCode("testDbc")
+            .managingDeanery("Test Deanery")
             .build())
         .changes(List.of(
             CctChange.builder().type(LTFT).startDate(LocalDate.of(2024, 11, 1))
@@ -876,7 +886,8 @@ class CctResourceIntegrationTest {
             "startDate": "2024-01-01",
             "endDate": "2025-01-01",
             "wte": 0.5,
-            "designatedBodyCode": "testDbc"
+            "designatedBodyCode": "testDbc",
+            "managingDeanery": "Test Deanery"
           },
           "changes": [
             {

--- a/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/dto/CctCalculationDetailDto.java
@@ -96,7 +96,9 @@ public record CctCalculationDetailDto(
       @Range(min = 0, max = 1)
       Double wte,
 
-      String designatedBodyCode) {
+      String designatedBodyCode,
+
+      String managingDeanery) {
 
   }
 

--- a/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
@@ -83,7 +83,8 @@ public record CctCalculation(
       LocalDate startDate,
       LocalDate endDate,
       double wte,
-      String designatedBodyCode) {
+      String designatedBodyCode,
+      String managingDeanery) {
 
   }
 

--- a/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
@@ -203,6 +203,7 @@ class CctServiceTest {
             .endDate(LocalDate.EPOCH.plusYears(1))
             .wte(1.0)
             .designatedBodyCode("testDbc")
+            .managingDeanery("Test Deanery")
             .build())
         .changes(List.of(
             CctChange.builder().type(LTFT).startDate(LocalDate.EPOCH.plusMonths(6))
@@ -234,6 +235,7 @@ class CctServiceTest {
     assertThat("Unexpected PM end date.", pm.endDate(), is(LocalDate.EPOCH.plusYears(1)));
     assertThat("Unexpected PM WTE.", pm.wte(), is(1.0));
     assertThat("Unexpected PM DBC.", pm.designatedBodyCode(), is("testDbc"));
+    assertThat("Unexpected PM deanery.", pm.managingDeanery(), is("Test Deanery"));
 
     List<CctChangeDto> changes = dto.changes();
     assertThat("Unexpected change count.", changes.size(), is(2));
@@ -291,6 +293,7 @@ class CctServiceTest {
               .endDate(pm.endDate())
               .wte(pm.wte())
               .designatedBodyCode("testDbc")
+              .managingDeanery("Test Deanery")
               .build())
           .changes(List.of(
               CctChange.builder()
@@ -319,6 +322,7 @@ class CctServiceTest {
     assertThat("Unexpected PM end date.", pm.endDate(), is(LocalDate.EPOCH.plusYears(1)));
     assertThat("Unexpected PM WTE.", pm.wte(), is(1.0));
     assertThat("Unexpected PM DBC.", pm.designatedBodyCode(), is("testDbc"));
+    assertThat("Unexpected PM deanery.", pm.managingDeanery(), is("Test Deanery"));
 
     List<CctChangeDto> changes = savedDto.changes();
     assertThat("Unexpected change count.", changes.size(), is(2));
@@ -351,6 +355,7 @@ class CctServiceTest {
             .endDate(LocalDate.EPOCH.plusYears(1))
             .wte(1.0)
             .designatedBodyCode("testDbc")
+            .managingDeanery("Test Deanery")
             .build())
         .changes(List.of(
             CctChangeDto.builder().type(LTFT).startDate(LocalDate.EPOCH.plusMonths(6))
@@ -377,6 +382,7 @@ class CctServiceTest {
     assertThat("Unexpected PM end date.", pm.endDate(), is(LocalDate.EPOCH.plusYears(1)));
     assertThat("Unexpected PM WTE.", pm.wte(), is(1.0));
     assertThat("Unexpected PM DBC.", pm.designatedBodyCode(), is("testDbc"));
+    assertThat("Unexpected PM deanery.", pm.managingDeanery(), is("Test Deanery"));
 
     List<CctChangeDto> changes = calculatedDto.changes();
     assertThat("Unexpected change count.", changes.size(), is(2));
@@ -457,6 +463,7 @@ class CctServiceTest {
               .endDate(pm.endDate())
               .wte(pm.wte())
               .designatedBodyCode(pm.designatedBodyCode())
+              .managingDeanery("Test Deanery")
               .build())
           .changes(List.of(
               CctChange.builder()
@@ -493,6 +500,7 @@ class CctServiceTest {
     assertThat("Unexpected PM end date.", pm.endDate(), is(LocalDate.EPOCH.plusYears(1)));
     assertThat("Unexpected PM WTE.", pm.wte(), is(1.0));
     assertThat("Unexpected PM DBC.", pm.designatedBodyCode(), is("testDbc"));
+    assertThat("Unexpected PM deanery.", pm.managingDeanery(), is("Test Deanery"));
 
     List<CctChangeDto> changes = updatedDto.changes();
     assertThat("Unexpected change count.", changes.size(), is(2));


### PR DESCRIPTION
The LTFT notifications require the managing deanery/local office name in order to determine the contacts/links to include in the notification. Update the CCT entity and DTO to include the managing deanery so that it is available to pass to the LTFT.

TIS21-6596
TIS21-6594