### PR TITLE
build: upgrade version catalog

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,6 +11,7 @@ jobs:
     uses: health-education-england/.github/.github/workflows/ci-cd-gradle.yml@main
     with:
       cluster-prefix: trainee
+      publish-build-scan: true
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}
       reject-pat: ${{ secrets.PAT_REJECT_APPROVALS }}

--- a/.github/workflows/pr-analysis.yml
+++ b/.github/workflows/pr-analysis.yml
@@ -9,5 +9,7 @@ jobs:
   analysis:
     name: Analyse PR
     uses: health-education-england/.github/.github/workflows/pr-analysis-gradle.yml@main
+    with:
+      publish-build-scan: true
     secrets:
       sonar-token: ${{ secrets.SONAR_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.26.0"
+version = "1.26.1"
 
 configurations {
   compileOnly {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,7 @@ dependencyResolutionManagement {
 
   versionCatalogs {
     create("libs") {
-      from("uk.nhs.tis.trainee:version-catalog:0.0.2")
+      from("uk.nhs.tis.trainee:version-catalog:0.0.6")
     }
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/config/ApplicationConfiguration.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/config/ApplicationConfiguration.java
@@ -21,12 +21,9 @@
 
 package uk.nhs.hee.trainee.details.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.converter.MappingJackson2MessageConverter;
-import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -38,18 +35,5 @@ public class ApplicationConfiguration {
   @Bean
   RestTemplate restTemplate(RestTemplateBuilder builder) {
     return builder.build();
-  }
-
-  /**
-   * Create a message converter bean with an object mapper.
-   *
-   * @param objectMapper The object mapper to set.
-   * @return The created message converter.
-   */
-  @Bean
-  public MessageConverter messageConverter(ObjectMapper objectMapper) {
-    var converter = new MappingJackson2MessageConverter();
-    converter.setObjectMapper(objectMapper);
-    return converter;
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/config/ApplicationConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/ApplicationConfigurationTest.java
@@ -21,17 +21,12 @@
 
 package uk.nhs.hee.trainee.details.config;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.messaging.converter.MappingJackson2MessageConverter;
-import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.web.client.RestTemplate;
 
 class ApplicationConfigurationTest {
@@ -50,18 +45,5 @@ class ApplicationConfigurationTest {
     RestTemplate restTemplate = configuration.restTemplate(restTemplateBuilder);
 
     assertThat("Unexpected rest template.", restTemplate, notNullValue());
-  }
-
-  @Test
-  void shouldIncludeExistingObjectMapperInMessageConverter() {
-    ObjectMapper objectMapper = new ObjectMapper();
-
-    MessageConverter messageConverter = configuration.messageConverter(objectMapper);
-
-    assertThat("Unexpected message converter.", messageConverter,
-        instanceOf(MappingJackson2MessageConverter.class));
-    assertThat("Unexpected object mapper.",
-        ((MappingJackson2MessageConverter) messageConverter).getObjectMapper(),
-        sameInstance(objectMapper));
   }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PdfGeneratingServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PdfGeneratingServiceTest.java
@@ -33,6 +33,8 @@ import java.io.IOException;
 import java.time.ZoneId;
 import java.util.Map;
 import java.util.Set;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,7 +65,7 @@ class PdfGeneratingServiceTest {
 
     byte[] resultByte =  service.generatePdf(templateSpec, Map.of());
     ByteArrayInputStream resultStream = new ByteArrayInputStream(resultByte);
-    PDDocument pdf = PDDocument.load(resultStream);
+    PDDocument pdf = Loader.loadPDF(new RandomAccessReadBuffer(resultStream));
     String pdfText = new PDFTextStripper().getText(pdf);
 
     assertThat("Unexpected content.", pdfText, is("test content" + System.lineSeparator()));


### PR DESCRIPTION
Upgrade tis-trainee-version-catalog to 0.0.6.
Refactor PDDocument creation in tests to handle deprecation of `PDDocument.load()`.

Since version 3.2.0 the Spring Cloud AWS starter for SQS autoconfigured a message converter, as a result the bean configured in ApplicationConfiguration is no longer needed.

Upgrade the Gradle wrapper to 8.9.

Enable build scan publishing after PR analysis and CI/CD workflows.

NO-TICKET