### PR TITLE
fix: return bad request when GMC details update entity is empty

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.28.2"
+version = "1.28.3"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
@@ -89,7 +89,7 @@ public class BasicDetailsResource {
       log.warn("No trainee ID provided.");
       return ResponseEntity.badRequest().build();
     } else if (tisId.startsWith("-")) {
-      log.warn("Tester trainee ID provided. Ignore GMC number update.");
+      log.warn("Tester trainee ID {} provided. Ignore GMC number update.", tisId);
       return ResponseEntity.badRequest().build();
     }
 
@@ -101,7 +101,13 @@ public class BasicDetailsResource {
 
     Optional<PersonalDetails> entity = service.updateGmcDetailsWithTraineeProvidedDetails(tisId,
         updatedGmcDetails);
-    Optional<PersonalDetailsDto> dto = entity.map(mapper::toDto);
-    return ResponseEntity.of(dto);
+    if (entity.isPresent()) {
+      Optional<PersonalDetailsDto> dto = entity.map(mapper::toDto);
+      return ResponseEntity.of(dto);
+    }
+    else {
+      log.warn("GMC details not updated.");
+      return ResponseEntity.badRequest().build();
+    }
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
@@ -101,13 +101,7 @@ public class BasicDetailsResource {
 
     Optional<PersonalDetails> entity = service.updateGmcDetailsWithTraineeProvidedDetails(tisId,
         updatedGmcDetails);
-    if (entity.isPresent()) {
-      Optional<PersonalDetailsDto> dto = entity.map(mapper::toDto);
-      return ResponseEntity.of(dto);
-    }
-    else {
-      log.warn("GMC details not updated.");
-      return ResponseEntity.badRequest().build();
-    }
+    Optional<PersonalDetailsDto> dto = entity.map(mapper::toDto);
+    return ResponseEntity.of(dto);
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/event/ContactDetailsListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/ContactDetailsListener.java
@@ -29,6 +29,7 @@ import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.PersonalDetailsUpdated;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
 /**
@@ -58,9 +59,9 @@ public class ContactDetailsListener {
 
     PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
-    Optional<PersonalDetails> optionalEntity = service.updateContactDetailsByTisId(tisId, entity);
+    PersonalDetailsUpdated updatedDetails = service.updateContactDetailsByTisId(tisId, entity);
 
-    if (optionalEntity.isEmpty()) {
+    if (updatedDetails.getPersonalDetails().isEmpty()) {
       throw new IllegalArgumentException("Trainee not found.");
     }
   }

--- a/src/main/java/uk/nhs/hee/trainee/details/event/GdcDetailsListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/GdcDetailsListener.java
@@ -29,6 +29,7 @@ import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.PersonalDetailsUpdated;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
 /**
@@ -58,9 +59,9 @@ public class GdcDetailsListener {
 
     PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
-    Optional<PersonalDetails> optionalEntity = service.updateGdcDetailsByTisId(tisId, entity);
+    PersonalDetailsUpdated updatedDetails = service.updateGdcDetailsByTisId(tisId, entity);
 
-    if (optionalEntity.isEmpty()) {
+    if (updatedDetails.getPersonalDetails().isEmpty()) {
       throw new IllegalArgumentException("Trainee not found.");
     }
   }

--- a/src/main/java/uk/nhs/hee/trainee/details/event/GmcDetailsListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/GmcDetailsListener.java
@@ -57,7 +57,7 @@ public class GmcDetailsListener {
 
     PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
-    service.updateGmcDetailsByTisId(tisId, entity)
+    service.updateGmcDetailsByTisId(tisId, entity).getPersonalDetails()
         .orElseThrow(() -> new IllegalArgumentException("Trainee not found."));
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/event/PersonOwnerListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/PersonOwnerListener.java
@@ -29,6 +29,7 @@ import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.PersonalDetailsUpdated;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
 /**
@@ -58,9 +59,9 @@ public class PersonOwnerListener {
 
     PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
-    Optional<PersonalDetails> optionalEntity = service.updatePersonOwnerByTisId(tisId, entity);
+    PersonalDetailsUpdated updatedDetails = service.updatePersonOwnerByTisId(tisId, entity);
 
-    if (optionalEntity.isEmpty()) {
+    if (updatedDetails.getPersonalDetails().isEmpty()) {
       throw new IllegalArgumentException("Trainee not found.");
     }
   }

--- a/src/main/java/uk/nhs/hee/trainee/details/event/PersonalInfoListener.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/event/PersonalInfoListener.java
@@ -29,6 +29,7 @@ import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapper;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.PersonalDetailsUpdated;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
 /**
@@ -58,9 +59,9 @@ public class PersonalInfoListener {
 
     PersonalDetailsDto dto = event.update().personalDetails();
     PersonalDetails entity = mapper.toEntity(dto);
-    Optional<PersonalDetails> optionalEntity = service.updatePersonalInfoByTisId(tisId, entity);
+    PersonalDetailsUpdated updatedDetails = service.updatePersonalInfoByTisId(tisId, entity);
 
-    if (optionalEntity.isEmpty()) {
+    if (updatedDetails.getPersonalDetails().isEmpty()) {
       throw new IllegalArgumentException("Trainee not found.");
     }
   }

--- a/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetailsUpdated.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetailsUpdated.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.trainee.details.model;
+
+import lombok.Getter;
+
+import java.util.Optional;
+
+public class PersonalDetailsUpdated {
+
+  @Getter
+  private final boolean updated;
+  private final Optional<PersonalDetails> personalDetails;
+
+  public PersonalDetailsUpdated(boolean updated, Optional<PersonalDetails> personalDetails) {
+    this.updated = updated;
+    this.personalDetails = personalDetails;
+  }
+
+  public Optional<PersonalDetails> getPersonalDetails() {
+    return personalDetails;
+  }
+}

--- a/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetailsUpdated.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/PersonalDetailsUpdated.java
@@ -21,10 +21,12 @@
 
 package uk.nhs.hee.trainee.details.model;
 
+import java.util.Optional;
 import lombok.Getter;
 
-import java.util.Optional;
-
+/**
+ * Return personal details updated result.
+ */
 public class PersonalDetailsUpdated {
 
   @Getter

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
@@ -70,9 +70,9 @@ public class PersonalDetailsService {
 
       eventService.publishProfileCreateEvent(savedProfile);
       return savedProfile.getPersonalDetails();
+    } else {
+      return updatedDetails.getPersonalDetails().get();
     }
-
-    return updatedDetails.getPersonalDetails().get();
   }
 
   /**

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
@@ -61,8 +61,9 @@ public class PersonalDetailsService {
       PersonalDetails personalDetails) {
     PersonalDetailsUpdated updatedDetails = updatePersonalDetailsByTisId(tisId, personalDetails,
         mapper::updateBasicDetails);
+    Optional<PersonalDetails> updatedPersonalDetails =  updatedDetails.getPersonalDetails();
 
-    if (updatedDetails.getPersonalDetails().isEmpty()) {
+    if (updatedPersonalDetails.isEmpty()) {
       TraineeProfile traineeProfile = new TraineeProfile();
       traineeProfile.setTraineeTisId(tisId);
       mapper.updateBasicDetails(traineeProfile, personalDetails);
@@ -71,7 +72,7 @@ public class PersonalDetailsService {
       eventService.publishProfileCreateEvent(savedProfile);
       return savedProfile.getPersonalDetails();
     } else {
-      return updatedDetails.getPersonalDetails().get();
+      return updatedPersonalDetails.get();
     }
   }
 

--- a/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
@@ -58,6 +58,7 @@ import uk.nhs.hee.trainee.details.dto.PersonalDetailsDto;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.mapper.SignatureMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.PersonalDetailsUpdated;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 import uk.nhs.hee.trainee.details.service.SignatureService;
 
@@ -143,20 +144,21 @@ class BasicDetailsResourceTest {
   }
 
   @Test
-  void getReturnBadRequestThenUpdatedGmcDetailsEntityIsEmpty() throws Exception {
+  void getShouldNotUpdateGmcNumberWhenTisIdNotExists() throws Exception {
     GmcDetailsDto gmcDetails = GmcDetailsDto.builder()
         .gmcNumber(GMC_NUMBER)
         .build();
 
     String token = TestJwtUtil.generateTokenForTisId("40");
 
-    when(service.updateGmcDetailsByTisId(any(), any())).thenReturn(Optional.empty());
+    when(service.updateGmcDetailsByTisId(any(), any())).thenReturn(
+        new PersonalDetailsUpdated(false, Optional.empty()));
 
     this.mockMvc.perform(put("/api/basic-details/gmc-number")
             .contentType(MediaType.APPLICATION_JSON)
             .content(mapper.writeValueAsBytes(gmcDetails))
             .header(HttpHeaders.AUTHORIZATION, token))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().isNotFound());
   }
 
   @Test
@@ -167,7 +169,8 @@ class BasicDetailsResourceTest {
 
     String token = TestJwtUtil.generateTokenForTisId("-40");
 
-    when(service.updateGmcDetailsByTisId(any(), any())).thenReturn(Optional.empty());
+    when(service.updateGmcDetailsByTisId(any(), any())).thenReturn(
+        new PersonalDetailsUpdated(false, Optional.empty()));
 
     this.mockMvc.perform(put("/api/basic-details/gmc-number")
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
@@ -143,7 +143,7 @@ class BasicDetailsResourceTest {
   }
 
   @Test
-  void getShouldNotUpdateGmcNumberWhenTisIdNotExists() throws Exception {
+  void getReturnBadRequestThenUpdatedGmcDetailsEntityIsEmpty() throws Exception {
     GmcDetailsDto gmcDetails = GmcDetailsDto.builder()
         .gmcNumber(GMC_NUMBER)
         .build();
@@ -156,7 +156,7 @@ class BasicDetailsResourceTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content(mapper.writeValueAsBytes(gmcDetails))
             .header(HttpHeaders.AUTHORIZATION, token))
-        .andExpect(status().isNotFound());
+        .andExpect(status().isBadRequest());
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/trainee/details/event/ContactDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/ContactDetailsListenerTest.java
@@ -38,6 +38,7 @@ import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent.Update;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.PersonalDetailsUpdated;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
 class ContactDetailsListenerTest {
@@ -63,7 +64,8 @@ class ContactDetailsListenerTest {
     Update update = new Update(dto);
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
-    when(service.updateContactDetailsByTisId(eq(TIS_ID), any())).thenReturn(Optional.empty());
+    when(service.updateContactDetailsByTisId(eq(TIS_ID), any())).thenReturn(
+        new PersonalDetailsUpdated(false, Optional.empty()));
 
     assertThrows(IllegalArgumentException.class, () -> listener.updateContactDetails(event));
   }
@@ -80,7 +82,7 @@ class ContactDetailsListenerTest {
 
     ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
     when(service.updateContactDetailsByTisId(eq(TIS_ID), entityCaptor.capture())).then(
-        inv -> Optional.of(inv.getArgument(1)));
+        inv -> new PersonalDetailsUpdated(true, Optional.of(inv.getArgument(1))));
 
     listener.updateContactDetails(event);
 

--- a/src/test/java/uk/nhs/hee/trainee/details/event/GdcDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/GdcDetailsListenerTest.java
@@ -38,6 +38,7 @@ import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent.Update;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.PersonalDetailsUpdated;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
 class GdcDetailsListenerTest {
@@ -62,7 +63,8 @@ class GdcDetailsListenerTest {
     Update update = new Update(dto);
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
-    when(service.updateGdcDetailsByTisId(eq(TIS_ID), any())).thenReturn(Optional.empty());
+    when(service.updateGdcDetailsByTisId(eq(TIS_ID), any())).thenReturn(
+        new PersonalDetailsUpdated(false, Optional.empty()));
 
     assertThrows(IllegalArgumentException.class, () -> listener.updateGdcDetails(event));
   }
@@ -78,7 +80,8 @@ class GdcDetailsListenerTest {
 
     ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
     when(service.updateGdcDetailsByTisId(eq(TIS_ID), entityCaptor.capture())).then(
-        inv -> Optional.of(inv.getArgument(1)));
+        inv ->
+            new PersonalDetailsUpdated(true, Optional.of(inv.getArgument(1))));
 
     listener.updateGdcDetails(event);
 

--- a/src/test/java/uk/nhs/hee/trainee/details/event/GmcDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/GmcDetailsListenerTest.java
@@ -38,6 +38,7 @@ import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent.Update;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.PersonalDetailsUpdated;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
 class GmcDetailsListenerTest {
@@ -62,7 +63,8 @@ class GmcDetailsListenerTest {
     Update update = new Update(dto);
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
-    when(service.updateGmcDetailsByTisId(eq(TIS_ID), any())).thenReturn(Optional.empty());
+    when(service.updateGmcDetailsByTisId(eq(TIS_ID), any())).thenReturn(
+        new PersonalDetailsUpdated(false, Optional.empty()));
 
     assertThrows(IllegalArgumentException.class, () -> listener.updateGmcDetails(event));
   }
@@ -78,7 +80,7 @@ class GmcDetailsListenerTest {
 
     ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
     when(service.updateGmcDetailsByTisId(eq(TIS_ID), entityCaptor.capture())).thenAnswer(
-        inv -> Optional.of(inv.getArgument(1)));
+        inv -> new PersonalDetailsUpdated(true, Optional.of(inv.getArgument(1))));
 
     listener.updateGmcDetails(event);
 

--- a/src/test/java/uk/nhs/hee/trainee/details/event/PersonOwnerListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/PersonOwnerListenerTest.java
@@ -38,6 +38,7 @@ import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent.Update;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.PersonalDetailsUpdated;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
 class PersonOwnerListenerTest {
@@ -61,7 +62,8 @@ class PersonOwnerListenerTest {
     Update update = new Update(dto);
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
-    when(service.updatePersonOwnerByTisId(eq(TIS_ID), any())).thenReturn(Optional.empty());
+    when(service.updatePersonOwnerByTisId(eq(TIS_ID), any())).thenReturn(
+        new PersonalDetailsUpdated(false, Optional.empty()));
 
     assertThrows(IllegalArgumentException.class, () -> listener.updatePersonOwner(event));
   }
@@ -76,7 +78,7 @@ class PersonOwnerListenerTest {
 
     ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
     when(service.updatePersonOwnerByTisId(eq(TIS_ID), entityCaptor.capture())).then(
-        inv -> Optional.of(inv.getArgument(1)));
+        inv -> new PersonalDetailsUpdated(true, Optional.of(inv.getArgument(1))));
 
     listener.updatePersonOwner(event);
 

--- a/src/test/java/uk/nhs/hee/trainee/details/event/PersonalInfoListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/PersonalInfoListenerTest.java
@@ -39,6 +39,7 @@ import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent;
 import uk.nhs.hee.trainee.details.dto.PersonalDetailsUpdateEvent.Update;
 import uk.nhs.hee.trainee.details.mapper.PersonalDetailsMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.PersonalDetailsUpdated;
 import uk.nhs.hee.trainee.details.service.PersonalDetailsService;
 
 class PersonalInfoListenerTest {
@@ -63,7 +64,8 @@ class PersonalInfoListenerTest {
     Update update = new Update(dto);
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
-    when(service.updatePersonalInfoByTisId(eq(TIS_ID), any())).thenReturn(Optional.empty());
+    when(service.updatePersonalInfoByTisId(eq(TIS_ID), any())).thenReturn(
+        new PersonalDetailsUpdated(false, Optional.empty()));
 
     assertThrows(IllegalArgumentException.class, () -> listener.updatePersonalInfo(event));
   }
@@ -79,7 +81,7 @@ class PersonalInfoListenerTest {
 
     ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
     when(service.updatePersonalInfoByTisId(eq(TIS_ID), entityCaptor.capture())).then(
-        inv -> Optional.of(inv.getArgument(1)));
+        inv -> new PersonalDetailsUpdated(true, Optional.of(inv.getArgument(1))));
 
     listener.updatePersonalInfo(event);
 

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
@@ -43,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 import uk.nhs.hee.trainee.details.dto.GmcDetailsDto;
 import uk.nhs.hee.trainee.details.mapper.TraineeProfileMapperImpl;
 import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.PersonalDetailsUpdated;
 import uk.nhs.hee.trainee.details.model.TraineeProfile;
 import uk.nhs.hee.trainee.details.repository.TraineeProfileRepository;
 
@@ -177,10 +178,12 @@ class PersonalDetailsServiceTest {
 
   @Test
   void shouldNotUpdateGdcDetailsWhenTraineeIdNotFound() {
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updateGdcDetailsByTisId("notFound", new PersonalDetails());
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(true));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(false));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(true));
     verify(repository).findByTraineeTisId("notFound");
     verifyNoMoreInteractions(repository);
   }
@@ -194,10 +197,12 @@ class PersonalDetailsServiceTest {
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
     // update with the same value
-    Optional<PersonalDetails> personalDetails = service.updateGdcDetailsByTisId("40",
+    PersonalDetailsUpdated personalDetails = service.updateGdcDetailsByTisId("40",
         createPersonalDetails(ORIGINAL_SUFFIX, 0));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(true));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(false));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
     verify(repository, never()).save(any());
     verifyNoInteractions(eventService);
   }
@@ -210,16 +215,19 @@ class PersonalDetailsServiceTest {
     when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updateGdcDetailsByTisId("40", createPersonalDetails(MODIFIED_SUFFIX, 100));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(false));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
 
     PersonalDetails expectedPersonalDetails = createPersonalDetails(ORIGINAL_SUFFIX, 0);
     expectedPersonalDetails.setGdcNumber(GDC_NUMBER + MODIFIED_SUFFIX);
     expectedPersonalDetails.setGdcStatus(GDC_STATUS + MODIFIED_SUFFIX);
 
-    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+    assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
+        is(expectedPersonalDetails));
   }
 
   @Test
@@ -229,24 +237,28 @@ class PersonalDetailsServiceTest {
     when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updateGdcDetailsByTisId("40", createPersonalDetails(MODIFIED_SUFFIX, 100));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(false));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
 
     PersonalDetails expectedPersonalDetails = new PersonalDetails();
     expectedPersonalDetails.setGdcNumber(GDC_NUMBER + MODIFIED_SUFFIX);
     expectedPersonalDetails.setGdcStatus(GDC_STATUS + MODIFIED_SUFFIX);
 
-    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+    assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
+        is(expectedPersonalDetails));
   }
 
   @Test
   void shouldNotUpdateGmcDetailsWhenTraineeIdNotFound() {
-    Optional<PersonalDetails> personalDetails = service.updateGmcDetailsByTisId("notFound",
+    PersonalDetailsUpdated personalDetails = service.updateGmcDetailsByTisId("notFound",
         new PersonalDetails());
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(true));
     verify(repository).findByTraineeTisId("notFound");
     verifyNoMoreInteractions(repository);
   }
@@ -260,10 +272,12 @@ class PersonalDetailsServiceTest {
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
     // update with the same value
-    Optional<PersonalDetails> personalDetails = service.updateGmcDetailsByTisId("40",
+    PersonalDetailsUpdated personalDetails = service.updateGmcDetailsByTisId("40",
         createPersonalDetails(ORIGINAL_SUFFIX, 0));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(true));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(false));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
     verify(repository, never()).save(any());
     verifyNoInteractions(eventService);
   }
@@ -276,17 +290,20 @@ class PersonalDetailsServiceTest {
     when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
-    Optional<PersonalDetails> personalDetails = service.updateGmcDetailsByTisId("40",
+    PersonalDetailsUpdated personalDetails = service.updateGmcDetailsByTisId("40",
         createPersonalDetails(MODIFIED_SUFFIX, 100));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(false));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
 
     PersonalDetails expectedPersonalDetails = createPersonalDetails(ORIGINAL_SUFFIX, 0);
     expectedPersonalDetails.setGmcNumber(GMC_NUMBER + MODIFIED_SUFFIX);
     // GMC number updated, so GMC status changes to DEFAULT_GMC_STATUS
     expectedPersonalDetails.setGmcStatus(DEFAULT_GMC_STATUS);
 
-    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+    assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
+        is(expectedPersonalDetails));
   }
 
   @Test
@@ -296,17 +313,20 @@ class PersonalDetailsServiceTest {
     when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
-    Optional<PersonalDetails> personalDetails = service.updateGmcDetailsByTisId("40",
+    PersonalDetailsUpdated personalDetails = service.updateGmcDetailsByTisId("40",
         createPersonalDetails(MODIFIED_SUFFIX, 100));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(false));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
 
     PersonalDetails expectedPersonalDetails = new PersonalDetails();
     expectedPersonalDetails.setGmcNumber(GMC_NUMBER + MODIFIED_SUFFIX);
     // GMC number updated, so GMC status changes to DEFAULT_GMC_STATUS
     expectedPersonalDetails.setGmcStatus(DEFAULT_GMC_STATUS);
 
-    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+    assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
+        is(expectedPersonalDetails));
   }
 
   @Test
@@ -316,17 +336,20 @@ class PersonalDetailsServiceTest {
     when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
-    Optional<PersonalDetails> personalDetails = service.updateGmcDetailsByTisId("40",
+    PersonalDetailsUpdated personalDetails = service.updateGmcDetailsByTisId("40",
         new PersonalDetails());
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(false));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
 
     PersonalDetails expectedPersonalDetails = new PersonalDetails();
     expectedPersonalDetails.setGmcNumber(null);
     // GMC number updated, so GMC status changes to DEFAULT_GMC_STATUS
     expectedPersonalDetails.setGmcStatus(null);
 
-    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+    assertThat("Unexpected personal details.",
+        personalDetails.getPersonalDetails().get(), is(expectedPersonalDetails));
   }
 
   @Test
@@ -369,10 +392,11 @@ class PersonalDetailsServiceTest {
 
   @Test
   void shouldNotUpdateContactDetailsWhenTraineeIdNotFound() {
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updateContactDetailsByTisId("notFound", new PersonalDetails());
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(true));
     verify(repository).findByTraineeTisId("notFound");
     verifyNoMoreInteractions(repository);
   }
@@ -386,10 +410,12 @@ class PersonalDetailsServiceTest {
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
     // update with the same value
-    Optional<PersonalDetails> personalDetails = service.updateContactDetailsByTisId("40",
+    PersonalDetailsUpdated personalDetails = service.updateContactDetailsByTisId("40",
         createPersonalDetails(ORIGINAL_SUFFIX, 0));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(true));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(false));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
     verify(repository, never()).save(any());
     verifyNoInteractions(eventService);
   }
@@ -402,10 +428,12 @@ class PersonalDetailsServiceTest {
     when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updateContactDetailsByTisId("40", createPersonalDetails(MODIFIED_SUFFIX, 100));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(false));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
 
     PersonalDetails expectedPersonalDetails = createPersonalDetails(ORIGINAL_SUFFIX, 0);
     expectedPersonalDetails.setTitle(TITLE + MODIFIED_SUFFIX);
@@ -422,7 +450,8 @@ class PersonalDetailsServiceTest {
     expectedPersonalDetails.setAddress4(ADDRESS_4 + MODIFIED_SUFFIX);
     expectedPersonalDetails.setPostCode(POST_CODE + MODIFIED_SUFFIX);
 
-    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+    assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
+        is(expectedPersonalDetails));
   }
 
   @Test
@@ -432,10 +461,12 @@ class PersonalDetailsServiceTest {
     when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updateContactDetailsByTisId("40", createPersonalDetails(MODIFIED_SUFFIX, 100));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(false));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
 
     PersonalDetails expectedPersonalDetails = new PersonalDetails();
     expectedPersonalDetails.setTitle(TITLE + MODIFIED_SUFFIX);
@@ -452,15 +483,18 @@ class PersonalDetailsServiceTest {
     expectedPersonalDetails.setAddress4(ADDRESS_4 + MODIFIED_SUFFIX);
     expectedPersonalDetails.setPostCode(POST_CODE + MODIFIED_SUFFIX);
 
-    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+    assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
+        is(expectedPersonalDetails));
   }
 
   @Test
   void shouldNotUpdatePersonOwnerDetailsWhenTraineeIdNotFound() {
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updatePersonOwnerByTisId("notFound", new PersonalDetails());
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(true));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(false));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(true));
     verify(repository).findByTraineeTisId("notFound");
     verifyNoMoreInteractions(repository);
   }
@@ -474,10 +508,12 @@ class PersonalDetailsServiceTest {
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
     // update with the same value
-    Optional<PersonalDetails> personalDetails = service.updatePersonOwnerByTisId("40",
+    PersonalDetailsUpdated personalDetails = service.updatePersonOwnerByTisId("40",
         createPersonalDetails(ORIGINAL_SUFFIX, 0));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(true));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(false));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
     verify(repository, never()).save(any());
     verifyNoInteractions(eventService);
   }
@@ -493,10 +529,12 @@ class PersonalDetailsServiceTest {
     PersonalDetails newPersonalDetails = createPersonalDetails(MODIFIED_SUFFIX, 100);
     newPersonalDetails.setPersonOwner(null);
 
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updatePersonOwnerByTisId("40", newPersonalDetails);
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(true));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(false));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
     verify(repository, never()).save(any());
   }
 
@@ -508,15 +546,18 @@ class PersonalDetailsServiceTest {
     when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updatePersonOwnerByTisId("40", createPersonalDetails(MODIFIED_SUFFIX, 100));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(false));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
 
     PersonalDetails expectedPersonalDetails = createPersonalDetails(ORIGINAL_SUFFIX, 0);
     expectedPersonalDetails.setPersonOwner(PERSON_OWNER + MODIFIED_SUFFIX);
 
-    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+    assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
+        is(expectedPersonalDetails));
   }
 
   @Test
@@ -526,24 +567,29 @@ class PersonalDetailsServiceTest {
     when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updatePersonOwnerByTisId("40", createPersonalDetails(MODIFIED_SUFFIX, 100));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(false));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
 
     PersonalDetails expectedPersonalDetails = new PersonalDetails();
     expectedPersonalDetails.setPersonOwner(PERSON_OWNER + MODIFIED_SUFFIX);
 
-    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+    assertThat("Unexpected personal details.",
+        personalDetails.getPersonalDetails().get(), is(expectedPersonalDetails));
   }
 
   @Test
   void shouldNotUpdatePersonalInfoWhenTraineeIdNotFound() {
     PersonalDetails personalDetailsMock = mock(PersonalDetails.class);
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updatePersonalInfoByTisId("notFound", personalDetailsMock);
 
-    assertTrue(personalDetails.isEmpty(), "Expected personal details to have been empty");
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(false));
+    assertTrue(personalDetails.getPersonalDetails().isEmpty(),
+        "Expected personal details to have been empty");
     verify(repository).findByTraineeTisId("notFound");
     verifyNoInteractions(personalDetailsMock);
   }
@@ -557,11 +603,13 @@ class PersonalDetailsServiceTest {
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
     // update with the same value
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updatePersonalInfoByTisId(
             TRAINEE_TIS_ID, createPersonalDetails(ORIGINAL_SUFFIX, 0));
 
-    assertThat("Unexpected optional isEmpty flag.", personalDetails.isEmpty(), is(true));
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(false));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
     verify(repository, never()).save(any());
     verifyNoInteractions(eventService);
   }
@@ -574,17 +622,20 @@ class PersonalDetailsServiceTest {
     when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updatePersonalInfoByTisId(
             TRAINEE_TIS_ID, createPersonalDetails(MODIFIED_SUFFIX, ONE_HUNDRED));
 
-    assertTrue(personalDetails.isPresent(), "Expected a PersonalDetails to be returned");
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertTrue(personalDetails.getPersonalDetails().isPresent(),
+        "Expected a PersonalDetails to be returned");
 
     PersonalDetails expectedPersonalDetails = createPersonalDetails(ORIGINAL_SUFFIX, 0);
     expectedPersonalDetails.setDateOfBirth(DATE.plusDays(ONE_HUNDRED));
     expectedPersonalDetails.setGender(GENDER + MODIFIED_SUFFIX);
 
-    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+    assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
+        is(expectedPersonalDetails));
   }
 
   @Test
@@ -594,17 +645,20 @@ class PersonalDetailsServiceTest {
     when(repository.findByTraineeTisId(TRAINEE_TIS_ID)).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
-    Optional<PersonalDetails> personalDetails = service
+    PersonalDetailsUpdated personalDetails = service
         .updatePersonalInfoByTisId(
             TRAINEE_TIS_ID, createPersonalDetails(MODIFIED_SUFFIX, ONE_HUNDRED));
 
-    assertTrue(personalDetails.isPresent(), "Expected a PersonalDetails to be returned");
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertTrue(personalDetails.getPersonalDetails().isPresent(),
+        "Expected a PersonalDetails to be returned");
 
     PersonalDetails expectedPersonalDetails = new PersonalDetails();
     expectedPersonalDetails.setDateOfBirth(DATE.plusDays(ONE_HUNDRED));
     expectedPersonalDetails.setGender(GENDER + MODIFIED_SUFFIX);
 
-    assertThat("Unexpected personal details.", personalDetails.get(), is(expectedPersonalDetails));
+    assertThat("Unexpected personal details.",
+        personalDetails.getPersonalDetails().get(), is(expectedPersonalDetails));
   }
 
   /**

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
@@ -36,7 +36,6 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
@@ -365,6 +365,23 @@ class PersonalDetailsServiceTest {
   }
 
   @Test
+  void shouldNotPublishEventWhenGmcDetailsNotUpdated() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setPersonalDetails(createPersonalDetails(ORIGINAL_SUFFIX, 0));
+
+    when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
+    when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
+
+    GmcDetailsDto gmcDetails = GmcDetailsDto.builder()
+        .gmcNumber(GMC_NUMBER + ORIGINAL_SUFFIX)
+        .build();
+
+    service.updateGmcDetailsWithTraineeProvidedDetails("40", gmcDetails);
+
+    verifyNoInteractions(eventService);
+  }
+
+  @Test
   void shouldPublishEventWhenGmcDetailsProvidedByTrainee() {
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setPersonalDetails(createPersonalDetails(ORIGINAL_SUFFIX, 0));


### PR DESCRIPTION
On stage, when GMC details update return empty entity (due to TisId not found or no-change update), It shows "GMC number updated" with a blank profile page enough the trainee profile is not really updated.
<img width="1377" height="916" alt="image" src="https://github.com/user-attachments/assets/87860444-7061-4eb8-9016-a7b67044524e" />
Raising this PR to make sure the endpoint return bad request if details not updated.
