### PR TITLE
fix: allow test user update GMC in TSS but not publish to TIS

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "1.28.4"
+version = "1.28.5"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
@@ -88,7 +88,7 @@ public class BasicDetailsResource {
     if (tisId == null) {
       log.warn("No trainee ID provided.");
       return ResponseEntity.badRequest().build();
-    } else if (tisId.startsWith("-")) {
+    } else if (tisId.startsWith("-") && !tisId.equals("-1")) { // Our E2E Tester id is "-1"
       log.warn("Tester trainee ID {} provided. Ignore GMC number update.", tisId);
       return ResponseEntity.badRequest().build();
     }

--- a/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/BasicDetailsResource.java
@@ -88,9 +88,6 @@ public class BasicDetailsResource {
     if (tisId == null) {
       log.warn("No trainee ID provided.");
       return ResponseEntity.badRequest().build();
-    } else if (tisId.startsWith("-") && !tisId.equals("-1")) { // Our E2E Tester id is "-1"
-      log.warn("Tester trainee ID {} provided. Ignore GMC number update.", tisId);
-      return ResponseEntity.badRequest().build();
     }
 
     log.info("Updating GMC number of trainee {}.", tisId);

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
@@ -105,8 +105,14 @@ public class PersonalDetailsService {
     updatedDetails.getPersonalDetails().ifPresent(details -> {
       // if gmcNumber is updated
       if (updatedDetails.isUpdated()) {
-        log.info("Trainee {} updated their GMC number to {}.", tisId, details.getGmcNumber());
-        eventService.publishGmcDetailsProvidedEvent(tisId, gmcDetails);
+        // don't publish to TIS if it is a test user
+        if (tisId.startsWith("-")) {
+          log.warn("Tester trainee ID {} provided. Ignore GMC number update.", tisId);
+        }
+        else {
+          log.info("Trainee {} updated their GMC number to {}.", tisId, details.getGmcNumber());
+          eventService.publishGmcDetailsProvidedEvent(tisId, gmcDetails);
+        }
       }
     });
 

--- a/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
@@ -162,53 +162,6 @@ class BasicDetailsResourceTest {
   }
 
   @Test
-  void getShouldNotUpdateGmcNumberWhenTisIdIsTester() throws Exception {
-    GmcDetailsDto gmcDetails = GmcDetailsDto.builder()
-        .gmcNumber(GMC_NUMBER)
-        .build();
-
-    String token = TestJwtUtil.generateTokenForTisId("-40");
-
-    when(service.updateGmcDetailsByTisId(any(), any())).thenReturn(
-        new PersonalDetailsUpdated(false, Optional.empty()));
-
-    this.mockMvc.perform(put("/api/basic-details/gmc-number")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(mapper.writeValueAsBytes(gmcDetails))
-            .header(HttpHeaders.AUTHORIZATION, token))
-        .andExpect(status().isBadRequest());
-  }
-
-  @Test
-  void shouldUpdateGmcNumberWhenTisIdIsEndTester() throws Exception {
-    GmcDetailsDto gmcDetails = GmcDetailsDto.builder()
-        .gmcNumber(GMC_NUMBER)
-        .build();
-
-    String token = TestJwtUtil.generateTokenForTisId("-1");
-
-    ArgumentCaptor<GmcDetailsDto> gmcDetailsCaptor = ArgumentCaptor.captor();
-    when(service.updateGmcDetailsWithTraineeProvidedDetails(eq("-1"), gmcDetailsCaptor.capture()))
-        .thenAnswer(inv -> {
-          GmcDetailsDto gmcDetailsArg = inv.getArgument(1);
-          PersonalDetails personalDetails = new PersonalDetails();
-          personalDetails.setGmcNumber(gmcDetailsArg.gmcNumber());
-          personalDetails.setGmcStatus(gmcDetailsArg.gmcStatus());
-          return Optional.of(personalDetails);
-        });
-
-    this.mockMvc.perform(put("/api/basic-details/gmc-number")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(mapper.writeValueAsBytes(gmcDetails))
-            .header(HttpHeaders.AUTHORIZATION, token))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.gmcNumber", is("1234567")));
-
-    GmcDetailsDto updatedDetails = gmcDetailsCaptor.getValue();
-    assertThat("Unexpected GMC number.", updatedDetails.gmcNumber(), is("1234567"));
-  }
-
-  @Test
   void shouldUpdateGmcNumberWhenAuthorized() throws Exception {
     GmcDetailsDto gmcDetails = GmcDetailsDto.builder()
         .gmcNumber(GMC_NUMBER)

--- a/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceTest.java
@@ -180,6 +180,35 @@ class BasicDetailsResourceTest {
   }
 
   @Test
+  void shouldUpdateGmcNumberWhenTisIdIsEndTester() throws Exception {
+    GmcDetailsDto gmcDetails = GmcDetailsDto.builder()
+        .gmcNumber(GMC_NUMBER)
+        .build();
+
+    String token = TestJwtUtil.generateTokenForTisId("-1");
+
+    ArgumentCaptor<GmcDetailsDto> gmcDetailsCaptor = ArgumentCaptor.captor();
+    when(service.updateGmcDetailsWithTraineeProvidedDetails(eq("-1"), gmcDetailsCaptor.capture()))
+        .thenAnswer(inv -> {
+          GmcDetailsDto gmcDetailsArg = inv.getArgument(1);
+          PersonalDetails personalDetails = new PersonalDetails();
+          personalDetails.setGmcNumber(gmcDetailsArg.gmcNumber());
+          personalDetails.setGmcStatus(gmcDetailsArg.gmcStatus());
+          return Optional.of(personalDetails);
+        });
+
+    this.mockMvc.perform(put("/api/basic-details/gmc-number")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(mapper.writeValueAsBytes(gmcDetails))
+            .header(HttpHeaders.AUTHORIZATION, token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.gmcNumber", is("1234567")));
+
+    GmcDetailsDto updatedDetails = gmcDetailsCaptor.getValue();
+    assertThat("Unexpected GMC number.", updatedDetails.gmcNumber(), is("1234567"));
+  }
+
+  @Test
   void shouldUpdateGmcNumberWhenAuthorized() throws Exception {
     GmcDetailsDto gmcDetails = GmcDetailsDto.builder()
         .gmcNumber(GMC_NUMBER)

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
@@ -382,6 +382,24 @@ class PersonalDetailsServiceTest {
   }
 
   @Test
+  void shouldNotPublishEventWhenTraineeIsTester() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setPersonalDetails(createPersonalDetails(ORIGINAL_SUFFIX, 0));
+
+    when(repository.findByTraineeTisId("-40")).thenReturn(traineeProfile);
+    when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
+
+    GmcDetailsDto gmcDetails = GmcDetailsDto.builder()
+        .gmcNumber(GMC_NUMBER + MODIFIED_SUFFIX)
+        .gmcStatus(GMC_STATUS + MODIFIED_SUFFIX)
+        .build();
+
+    service.updateGmcDetailsWithTraineeProvidedDetails("-40", gmcDetails);
+
+    verifyNoInteractions(eventService);
+  }
+
+  @Test
   void shouldPublishEventWhenGmcDetailsProvidedByTrainee() {
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setPersonalDetails(createPersonalDetails(ORIGINAL_SUFFIX, 0));


### PR DESCRIPTION
The tester check is blocking the E2E tester (tisId -1) to update GMC number in the E2E test.
This is to allow test user (tisId start with "-") to update GMC number on TSS side, but just not to publish to TIS to avoid exception.