### PR TITLE
feat: move CCT calcs to different trainee

### DIFF
--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -135,6 +135,7 @@ class CctResourceIntegrationTest {
   @AfterEach
   void tearDown() {
     template.findAllAndRemove(new Query(), CctCalculation.class);
+    template.findAllAndRemove(new Query(), TraineeProfile.class);
   }
 
   @Test

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -29,6 +29,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.IsNot.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -77,6 +78,8 @@ import uk.nhs.hee.trainee.details.dto.enumeration.CctChangeType;
 import uk.nhs.hee.trainee.details.model.CctCalculation;
 import uk.nhs.hee.trainee.details.model.CctCalculation.CctChange;
 import uk.nhs.hee.trainee.details.model.CctCalculation.CctProgrammeMembership;
+import uk.nhs.hee.trainee.details.model.PersonalDetails;
+import uk.nhs.hee.trainee.details.model.TraineeProfile;
 
 @SpringBootTest
 @Testcontainers(disabledWithoutDocker = true)
@@ -1007,5 +1010,96 @@ class CctResourceIntegrationTest {
             .header(HttpHeaders.AUTHORIZATION, token))
         .andExpect(status().isOk())
         .andExpect(content().string("true"));
+  }
+
+  @Test
+  void shouldMoveCctCalculationsWhenToTraineeExists() throws Exception {
+    String toTraineeId = "new Trainee Id";
+
+    UUID id = UUID.randomUUID();
+    CctCalculation entity = CctCalculation.builder()
+        .id(id)
+        .traineeId(TRAINEE_ID)
+        .programmeMembership(CctProgrammeMembership.builder()
+            .startDate(LocalDate.of(2024, 1, 1))
+            .endDate(LocalDate.of(2025, 1, 1))
+            .wte(0.5)
+            .designatedBodyCode("testDbc")
+            .managingDeanery("Test Deanery")
+            .build())
+        .changes(List.of(
+            CctChange.builder().type(LTFT).startDate(LocalDate.of(2024, 11, 1))
+                .wte(1.0)
+                .build()))
+        .build();
+    template.insert(entity);
+
+    UUID id2 = UUID.randomUUID();
+    CctCalculation entity2 = CctCalculation.builder()
+        .id(id2)
+        .traineeId(TRAINEE_ID)
+        .programmeMembership(CctProgrammeMembership.builder()
+            .startDate(LocalDate.of(2024, 2, 2))
+            .endDate(LocalDate.of(2025, 2, 2))
+            .wte(0.8)
+            .designatedBodyCode("testDbc")
+            .managingDeanery("Test Deanery")
+            .build())
+        .changes(List.of(
+            CctChange.builder().type(LTFT).startDate(LocalDate.of(2024, 12, 2))
+                .wte(0.9)
+                .build()))
+        .build();
+    template.insert(entity2);
+
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setTraineeTisId(toTraineeId);
+    traineeProfile.setPersonalDetails(new PersonalDetails());
+    template.insert(traineeProfile);
+
+    mockMvc.perform(patch("/api/cct/move/{fromTraineeId}/{toTraineeId}", TRAINEE_ID, toTraineeId))
+        .andExpect(status().isOk())
+        .andExpect(content().string("true"));
+
+    CctCalculation movedEntity = template.findById(id, CctCalculation.class);
+    assertThat("Unexpected missing moved entity.", movedEntity, notNullValue());
+    assertThat("Unexpected trainee id on moved entity.", movedEntity.traineeId(),
+        is(toTraineeId));
+
+    CctCalculation movedEntity2 = template.findById(id2, CctCalculation.class);
+    assertThat("Unexpected missing moved entity.", movedEntity2, notNullValue());
+    assertThat("Unexpected trainee id on moved entity.", movedEntity2.traineeId(),
+        is(toTraineeId));
+  }
+
+  @Test
+  void shouldNotMoveCctCalculationsWhenToTraineeDoesNotExist() throws Exception {
+    String toTraineeId = "new Trainee Id";
+
+    UUID id = UUID.randomUUID();
+    CctCalculation entity = CctCalculation.builder()
+        .id(id)
+        .traineeId(TRAINEE_ID)
+        .programmeMembership(CctProgrammeMembership.builder()
+            .startDate(LocalDate.of(2024, 1, 1))
+            .endDate(LocalDate.of(2025, 1, 1))
+            .wte(0.5)
+            .designatedBodyCode("testDbc")
+            .managingDeanery("Test Deanery")
+            .build())
+        .changes(List.of(
+            CctChange.builder().type(LTFT).startDate(LocalDate.of(2024, 11, 1))
+                .wte(1.0)
+                .build()))
+        .build();
+    template.insert(entity);
+
+    mockMvc.perform(patch("/api/cct/move/{fromTraineeId}/{toTraineeId}", TRAINEE_ID, toTraineeId))
+        .andExpect(status().isBadRequest());
+
+    CctCalculation cct = template.findById(id, CctCalculation.class);
+    assertThat("Unexpected missing CCT.", cct, notNullValue());
+    assertThat("Unexpected changed trainee id on CCT.", cct.traineeId(),
+        is(TRAINEE_ID));
   }
 }

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -1058,7 +1058,8 @@ class CctResourceIntegrationTest {
     traineeProfile.setPersonalDetails(new PersonalDetails());
     template.insert(traineeProfile);
 
-    mockMvc.perform(patch("/api/cct/move/{fromTraineeId}/{toTraineeId}", TRAINEE_ID, toTraineeId))
+    mockMvc.perform(patch("/api/cct/move/{fromTraineeId}/to/{toTraineeId}",
+            TRAINEE_ID, toTraineeId))
         .andExpect(status().isOk())
         .andExpect(content().string("true"));
 
@@ -1095,7 +1096,8 @@ class CctResourceIntegrationTest {
         .build();
     template.insert(entity);
 
-    mockMvc.perform(patch("/api/cct/move/{fromTraineeId}/{toTraineeId}", TRAINEE_ID, toTraineeId))
+    mockMvc.perform(patch("/api/cct/move/{fromTraineeId}/to/{toTraineeId}",
+            TRAINEE_ID, toTraineeId))
         .andExpect(status().isBadRequest());
 
     CctCalculation cct = template.findById(id, CctCalculation.class);

--- a/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
@@ -165,10 +165,10 @@ public class CctResource {
    * Move all CCT calculations from one trainee to another.
    *
    * @param fromTraineeId The TIS ID of the trainee to move calculations from.
-   * @param toTraineeId The TIS ID of the trainee to move calculations to.
+   * @param toTraineeId   The TIS ID of the trainee to move calculations to.
    * @return True if the calculations were moved, bad request if the target trainee does not exist.
    */
-  @PatchMapping("/move/{fromTraineeId}/{toTraineeId}")
+  @PatchMapping("/move/{fromTraineeId}/to/{toTraineeId}")
   public ResponseEntity<Boolean> moveCalculations(@PathVariable String fromTraineeId,
       @PathVariable String toTraineeId) {
     log.info("Request to move CCT calculations from trainee {} to trainee {}",

--- a/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
@@ -34,6 +34,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -42,8 +43,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
+import uk.nhs.hee.trainee.details.dto.UserDetails;
 import uk.nhs.hee.trainee.details.dto.validation.Create;
 import uk.nhs.hee.trainee.details.service.CctService;
+import uk.nhs.hee.trainee.details.service.TraineeProfileService;
 
 /**
  * A REST controller for CCT related endpoints.
@@ -55,13 +58,16 @@ import uk.nhs.hee.trainee.details.service.CctService;
 public class CctResource {
 
   private final CctService service;
+  private final TraineeProfileService traineeProfileService;
 
   /**
    * Construct a REST controller for CCT related endpoints.
    *
-   * @param service A service providing CCT functionality.
+   * @param service               A service providing CCT functionality.
+   * @param traineeProfileService A service providing trainee profile functionality.
    */
-  public CctResource(CctService service) {
+  public CctResource(CctService service, TraineeProfileService traineeProfileService) {
+    this.traineeProfileService = traineeProfileService;
     this.service = service;
   }
 
@@ -153,5 +159,29 @@ public class CctResource {
         savedCalculation.id());
     return ResponseEntity.created(URI.create("/api/cct/calculation/" + savedCalculation.id()))
         .body(savedCalculation);
+  }
+
+  /**
+   * Move all CCT calculations from one trainee to another.
+   *
+   * @param fromTraineeId The TIS ID of the trainee to move calculations from.
+   * @param toTraineeId The TIS ID of the trainee to move calculations to.
+   * @return True if the calculations were moved, bad request if the target trainee does not exist.
+   */
+  @PatchMapping("/move/{fromTraineeId}/{toTraineeId}")
+  public ResponseEntity<Boolean> moveCalculations(@PathVariable String fromTraineeId,
+      @PathVariable String toTraineeId) {
+    log.info("Request to move CCT calculations from trainee {} to trainee {}",
+        fromTraineeId, toTraineeId);
+
+    Optional<UserDetails> toUserDetails
+        = traineeProfileService.getTraineeDetailsByTisId(toTraineeId);
+    if (toUserDetails.isEmpty()) {
+      log.warn("Not moving CCT calculations because toTraineeId not found [{}]", toTraineeId);
+      return ResponseEntity.badRequest().build();
+    }
+
+    service.moveCalculations(fromTraineeId, toTraineeId);
+    return ResponseEntity.ok(true);
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/api/CctResource.java
@@ -24,6 +24,7 @@ package uk.nhs.hee.trainee.details.api;
 import com.amazonaws.xray.spring.aop.XRayEnabled;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -166,10 +167,10 @@ public class CctResource {
    *
    * @param fromTraineeId The TIS ID of the trainee to move calculations from.
    * @param toTraineeId   The TIS ID of the trainee to move calculations to.
-   * @return True if the calculations were moved, bad request if the target trainee does not exist.
+   * @return Map of calculation counts moved, bad request if the target trainee does not exist.
    */
   @PatchMapping("/move/{fromTraineeId}/to/{toTraineeId}")
-  public ResponseEntity<Boolean> moveCalculations(@PathVariable String fromTraineeId,
+  public ResponseEntity<Map<String, Integer>> moveCalculations(@PathVariable String fromTraineeId,
       @PathVariable String toTraineeId) {
     log.info("Request to move CCT calculations from trainee {} to trainee {}",
         fromTraineeId, toTraineeId);
@@ -181,7 +182,7 @@ public class CctResource {
       return ResponseEntity.badRequest().build();
     }
 
-    service.moveCalculations(fromTraineeId, toTraineeId);
-    return ResponseEntity.ok(true);
+    Map<String, Integer> movedStats = service.moveCalculations(fromTraineeId, toTraineeId);
+    return ResponseEntity.ok(movedStats);
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptor.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptor.java
@@ -65,7 +65,7 @@ public class TraineeIdentityInterceptor implements HandlerInterceptor {
     }
 
     // Skip authentication check for the CCT move endpoint
-    if (request.getRequestURI().matches("^/api/cct/move/[^/]+/[^/]+$")) {
+    if (request.getRequestURI().matches("^/api/cct/move/[^/]+/to/[^/]+$")) {
       return true;
     }
 

--- a/src/main/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptor.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptor.java
@@ -64,6 +64,11 @@ public class TraineeIdentityInterceptor implements HandlerInterceptor {
       }
     }
 
+    // Skip authentication check for the CCT move endpoint
+    if (request.getRequestURI().matches("^/api/cct/move/[^/]+/[^/]+$")) {
+      return true;
+    }
+
     // Non-CCT endpoints are a mix of authenticated (public) and unauthenticated (internal), limit
     // trainee ID verification to CCT endpoints for now.
     if (request.getRequestURI().matches("^/api/cct(/.+)?$")

--- a/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/model/CctCalculation.java
@@ -53,6 +53,7 @@ public record CctCalculation(
     @With
     UUID id,
     @Indexed
+    @With
     String traineeId,
     String name,
     CctProgrammeMembership programmeMembership,

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -28,10 +28,12 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -301,16 +303,19 @@ public class CctService {
    * @param fromTraineeId The trainee ID to move calculations from.
    * @param toTraineeId   The trainee ID to move calculations to.
    */
-  public void moveCalculations(String fromTraineeId, String toTraineeId) {
+  public Map<String, Integer> moveCalculations(String fromTraineeId, String toTraineeId) {
     List<CctCalculation> calculations = calculationRepository
         .findByTraineeIdOrderByLastModified(fromTraineeId);
 
+    AtomicReference<Integer> movedCount = new AtomicReference<>(0);
     calculations.forEach(c -> {
-      log.info("Moving CCT calculation [{}] from trainee [{}] to trainee [{}]",
+      log.debug("Moving CCT calculation [{}] from trainee [{}] to trainee [{}].",
           c.id(), fromTraineeId, toTraineeId);
       calculationRepository.save(c.withTraineeId(toTraineeId));
+      movedCount.getAndSet(movedCount.get() + 1);
     });
-    log.info("Moved {} CCT calculations from trainee [{}] to trainee [{}]",
-        calculations.size(), fromTraineeId, toTraineeId);
+    log.info("Moved {} of expected {} CCT calculations from trainee [{}] to trainee [{}].",
+        movedCount.get(), calculations.size(), fromTraineeId, toTraineeId);
+    return Map.of("cct", movedCount.get());
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -302,6 +302,7 @@ public class CctService {
    *
    * @param fromTraineeId The trainee ID to move calculations from.
    * @param toTraineeId   The trainee ID to move calculations to.
+   * @return A map of the types of records moved and their counts.
    */
   public Map<String, Integer> moveCalculations(String fromTraineeId, String toTraineeId) {
     List<CctCalculation> calculations = calculationRepository

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -294,4 +294,23 @@ public class CctService {
   public LocalDate calculateCctDate(CctCalculationDetailDto dto) {
     return calculateCctDate(mapper.toEntity(dto, null));
   }
+
+  /**
+   * Move all CCT calculations from one trainee to another. Assumes that toTraineeId is valid.
+   *
+   * @param fromTraineeId The trainee ID to move calculations from.
+   * @param toTraineeId   The trainee ID to move calculations to.
+   */
+  public void moveCalculations(String fromTraineeId, String toTraineeId) {
+    List<CctCalculation> calculations = calculationRepository
+        .findByTraineeIdOrderByLastModified(fromTraineeId);
+
+    calculations.forEach(c -> {
+      log.info("Moving CCT calculation [{}] from trainee [{}] to trainee [{}]",
+          c.id(), fromTraineeId, toTraineeId);
+      calculationRepository.save(c.withTraineeId(toTraineeId));
+    });
+    log.info("Moved {} CCT calculations from trainee [{}] to trainee [{}]",
+        calculations.size(), fromTraineeId, toTraineeId);
+  }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/api/CctResourceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/api/CctResourceTest.java
@@ -39,8 +39,10 @@ import static org.springframework.http.HttpStatus.OK;
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
@@ -345,11 +347,15 @@ class CctResourceTest {
 
     when(traineeProfileService.getTraineeDetailsByTisId(toTraineeId))
         .thenReturn(Optional.of(toUserDetails));
+    Map<String, Integer> serviceResponse = Map.of("dummy", 1);
+    when(service.moveCalculations(fromTraineeId, toTraineeId)).thenReturn(serviceResponse);
 
-    ResponseEntity<Boolean> response = controller.moveCalculations(fromTraineeId, toTraineeId);
+    ResponseEntity<Map<String, Integer>> response
+        = controller.moveCalculations(fromTraineeId, toTraineeId);
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(OK));
-    assertThat("Unexpected response body.", response.getBody(), is(true));
+    Assertions.assertNotNull(response.getBody());
+    assertThat("Unexpected response body.", response.getBody().get("dummy"), is(1));
   }
 
   @Test
@@ -360,7 +366,8 @@ class CctResourceTest {
     when(traineeProfileService.getTraineeDetailsByTisId(toTraineeId))
         .thenReturn(Optional.empty());
 
-    ResponseEntity<Boolean> response = controller.moveCalculations(fromTraineeId, toTraineeId);
+    ResponseEntity<Map<String, Integer>> response
+        = controller.moveCalculations(fromTraineeId, toTraineeId);
 
     assertThat("Unexpected response code.", response.getStatusCode(), is(BAD_REQUEST));
     assertThat("Unexpected response body.", response.getBody(), nullValue());

--- a/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorTest.java
@@ -139,6 +139,41 @@ class TraineeIdentityInterceptorTest {
   }
 
   @Test
+  void shouldReturnTrueAndNotRequireAuthForCctMoveEndpoint() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/api/cct/move/40/41");
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(true));
+    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
+  }
+
+  @Test
+  void shouldReturnTrueAndStillProcessAuthTokenForCctMoveEndpoint() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/api/cct/move/40/41");
+    request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId("40"));
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(true));
+    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), is("40"));
+  }
+
+  @Test
+  void shouldNotMatchPartialCctMoveEndpoint() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setRequestURI("/api/cct/move/40");  // Missing second ID
+
+    boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+
+    assertThat("Unexpected result.", result, is(false));
+    assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), nullValue());
+  }
+
+
+  @Test
   void shouldNotSetGroupsWhenCognitoGroupsNotInAuthToken() {
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId("40"));

--- a/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/interceptor/TraineeIdentityInterceptorTest.java
@@ -141,7 +141,7 @@ class TraineeIdentityInterceptorTest {
   @Test
   void shouldReturnTrueAndNotRequireAuthForCctMoveEndpoint() {
     MockHttpServletRequest request = new MockHttpServletRequest();
-    request.setRequestURI("/api/cct/move/40/41");
+    request.setRequestURI("/api/cct/move/40/to/41");
 
     boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
 
@@ -152,7 +152,7 @@ class TraineeIdentityInterceptorTest {
   @Test
   void shouldReturnTrueAndStillProcessAuthTokenForCctMoveEndpoint() {
     MockHttpServletRequest request = new MockHttpServletRequest();
-    request.setRequestURI("/api/cct/move/40/41");
+    request.setRequestURI("/api/cct/move/40/to/41");
     request.addHeader(HttpHeaders.AUTHORIZATION, TestJwtUtil.generateTokenForTisId("40"));
 
     boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
@@ -161,10 +161,11 @@ class TraineeIdentityInterceptorTest {
     assertThat("Unexpected trainee ID.", traineeIdentity.getTraineeId(), is("40"));
   }
 
-  @Test
-  void shouldNotMatchPartialCctMoveEndpoint() {
+  @ParameterizedTest
+  @ValueSource(strings = {"/40", "/40/to", "/40/to/41/more"})
+  void shouldNotMatchPartialCctMoveEndpoint(String uriFragment) {
     MockHttpServletRequest request = new MockHttpServletRequest();
-    request.setRequestURI("/api/cct/move/40");  // Missing second ID
+    request.setRequestURI("/api/cct/move" + uriFragment);
 
     boolean result = interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
 

--- a/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
@@ -844,4 +844,45 @@ class CctServiceTest {
     verify(calculationRepository).deleteById(id);
     verifyNoMoreInteractions(calculationRepository);
   }
+
+  @Test
+  void shouldMoveCctCalculationsWhenFound() {
+    String fromTraineeId = "40";
+    String toTraineeId = "50";
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+
+    CctCalculation calc1 = CctCalculation.builder()
+        .id(id1)
+        .traineeId(fromTraineeId)
+        .name("Test Calculation 1")
+        .build();
+
+    CctCalculation calc2 = CctCalculation.builder()
+        .id(id2)
+        .traineeId(fromTraineeId)
+        .name("Test Calculation 2")
+        .build();
+
+    when(calculationRepository.findByTraineeIdOrderByLastModified(fromTraineeId))
+        .thenReturn(List.of(calc1, calc2));
+
+    service.moveCalculations(fromTraineeId, toTraineeId);
+
+    verify(calculationRepository).save(calc1.withTraineeId(toTraineeId));
+    verify(calculationRepository).save(calc2.withTraineeId(toTraineeId));
+  }
+
+  @Test
+  void shouldNotSaveCalculationsWhenNoneMoved() {
+    String fromTraineeId = "40";
+    String toTraineeId = "50";
+
+    when(calculationRepository.findByTraineeIdOrderByLastModified(fromTraineeId))
+        .thenReturn(List.of());
+
+    service.moveCalculations(fromTraineeId, toTraineeId);
+
+    verify(calculationRepository, never()).save(any());
+  }
 }

--- a/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
@@ -40,6 +40,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -867,7 +868,10 @@ class CctServiceTest {
     when(calculationRepository.findByTraineeIdOrderByLastModified(fromTraineeId))
         .thenReturn(List.of(calc1, calc2));
 
-    service.moveCalculations(fromTraineeId, toTraineeId);
+    Map<String, Integer> movedStats = service.moveCalculations(fromTraineeId, toTraineeId);
+
+    Map<String, Integer> expectedMap = Map.of("cct", 2);
+    assertThat("Unexpected moved CCT count.", movedStats, is(expectedMap));
 
     verify(calculationRepository).save(calc1.withTraineeId(toTraineeId));
     verify(calculationRepository).save(calc2.withTraineeId(toTraineeId));
@@ -881,7 +885,10 @@ class CctServiceTest {
     when(calculationRepository.findByTraineeIdOrderByLastModified(fromTraineeId))
         .thenReturn(List.of());
 
-    service.moveCalculations(fromTraineeId, toTraineeId);
+    Map<String, Integer> movedStats = service.moveCalculations(fromTraineeId, toTraineeId);
+
+    Map<String, Integer> expectedMap = Map.of("cct", 0);
+    assertThat("Unexpected moved CCT count.", movedStats, is(expectedMap));
 
     verify(calculationRepository, never()).save(any());
   }


### PR DESCRIPTION
Note: ignores programme membership, which will be a broken link on the new trainee. Possibly we should limit the move to CCT calcs where the programme membership has ended?

Regardless, it doesn't break the FE; if you edit the new CCT calc the old PM name is simply not listed in the dropdown, as you would expect.

Downstream service effects: None.

TIS21-7634