### PR TITLE
fix(cct): update calculateCctDate logic

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,6 +132,12 @@ testing {
   }
 }
 
+tasks.named<org.gradle.language.jvm.tasks.ProcessResources>("processIntegrationTestResources") {
+  from("src/test/resources") {
+    include("cct-calc-test-cases.json")
+  }
+}
+
 tasks.named("check") {
   dependsOn(testing.suites.named("integrationTest"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "2.8.3"
+version = "2.8.4"
 
 configurations {
   compileOnly {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,12 +132,6 @@ testing {
   }
 }
 
-tasks.named<org.gradle.language.jvm.tasks.ProcessResources>("processIntegrationTestResources") {
-  from("src/test/resources") {
-    include("cct-calc-test-cases.json")
-  }
-}
-
 tasks.named("check") {
   dependsOn(testing.suites.named("integrationTest"))
 }

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -44,7 +44,6 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.jayway.jsonpath.JsonPath;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.io.IOException;
-import java.io.InputStream;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -89,16 +88,12 @@ class CctResourceIntegrationTest {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
 
   private static final String TRAINEE_ID = UUID.randomUUID().toString();
-  private static final String CCT_CALC_TEST_CASES_RESOURCE = "cct-calc-test-cases.json";
-  private static final String CCT_CASE_DESCRIPTION = "already part-time going more part-time";
-
-  private static final CalculateCctDateCase CCT_CASE = loadCctCase(CCT_CASE_DESCRIPTION);
-  private static final LocalDate CCT_PM_END_DATE = CCT_CASE.input().currentProgEndDate();
+  private static final LocalDate CCT_PM_END_DATE = LocalDate.of(2025, 9, 30);
   private static final LocalDate CCT_PM_START_DATE = CCT_PM_END_DATE.minusYears(1);
-  private static final LocalDate CCT_CHANGE_START_DATE = CCT_CASE.input().changeStartDate();
-  private static final double CCT_PM_WTE = CCT_CASE.input().currentWte();
-  private static final double CCT_CHANGE_WTE = CCT_CASE.input().newWte();
-  private static final LocalDate CCT_EXPECTED_DATE = CCT_CASE.expected();
+  private static final LocalDate CCT_CHANGE_START_DATE = LocalDate.of(2025, 4, 1);
+  private static final double CCT_PM_WTE = 0.8;
+  private static final double CCT_CHANGE_WTE = 0.6;
+  private static final LocalDate CCT_EXPECTED_DATE = LocalDate.of(2025, 11, 15);
 
   @Container
   @ServiceConnection
@@ -1026,34 +1021,4 @@ class CctResourceIntegrationTest {
         .andExpect(content().string("true"));
   }
 
-  private static CalculateCctDateCase loadCctCase(String description) {
-    try (InputStream jsonInputStream = CctResourceIntegrationTest.class.getClassLoader()
-        .getResourceAsStream(CCT_CALC_TEST_CASES_RESOURCE)) {
-      if (jsonInputStream == null) {
-        throw new IllegalStateException("Unable to load test resource: "
-            + CCT_CALC_TEST_CASES_RESOURCE);
-      }
-
-      CalculateCctDateSourceOfTruth sourceOfTruth = OBJECT_MAPPER.readValue(jsonInputStream,
-          CalculateCctDateSourceOfTruth.class);
-      return sourceOfTruth.calculateCctDate().stream()
-          .filter(c -> description.equals(c.description()))
-          .findFirst()
-          .orElseThrow(() -> new IllegalStateException("Unable to find CCT test case: "
-              + description));
-    } catch (IOException e) {
-      throw new IllegalStateException("Unable to parse CCT test case resource.", e);
-    }
-  }
-
-  private record CalculateCctDateSourceOfTruth(List<CalculateCctDateCase> calculateCctDate) {
-  }
-
-  private record CalculateCctDateCase(String description, CalculateCctDateInput input,
-                                      LocalDate expected) {
-  }
-
-  private record CalculateCctDateInput(LocalDate currentProgEndDate, double currentWte,
-                                       double newWte, LocalDate changeStartDate) {
-  }
 }

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/CctResourceIntegrationTest.java
@@ -44,6 +44,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.jayway.jsonpath.JsonPath;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.io.IOException;
+import java.io.InputStream;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
@@ -85,10 +86,19 @@ import uk.nhs.hee.trainee.details.model.TraineeProfile;
 @AutoConfigureMockMvc
 class CctResourceIntegrationTest {
 
-  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
 
-  private static final LocalDate CCT_DATE_75 = LocalDate.of(2024, 11, 1);
-  //based on calculationJson change below.
+  private static final String TRAINEE_ID = UUID.randomUUID().toString();
+  private static final String CCT_CALC_TEST_CASES_RESOURCE = "cct-calc-test-cases.json";
+  private static final String CCT_CASE_DESCRIPTION = "already part-time going more part-time";
+
+  private static final CalculateCctDateCase CCT_CASE = loadCctCase(CCT_CASE_DESCRIPTION);
+  private static final LocalDate CCT_PM_END_DATE = CCT_CASE.input().currentProgEndDate();
+  private static final LocalDate CCT_PM_START_DATE = CCT_PM_END_DATE.minusYears(1);
+  private static final LocalDate CCT_CHANGE_START_DATE = CCT_CASE.input().changeStartDate();
+  private static final double CCT_PM_WTE = CCT_CASE.input().currentWte();
+  private static final double CCT_CHANGE_WTE = CCT_CASE.input().newWte();
+  private static final LocalDate CCT_EXPECTED_DATE = CCT_CASE.expected();
 
   @Container
   @ServiceConnection
@@ -108,27 +118,33 @@ class CctResourceIntegrationTest {
 
   @BeforeEach
   void setUp() throws IOException {
-    calculationJson = (ObjectNode) new ObjectMapper().readTree("""
+    calculationJson = (ObjectNode) OBJECT_MAPPER.readTree("""
         {
           "name": "Test Calculation",
           "programmeMembership": {
             "id": "12345678-aaaa-bbbb-cccc-012345678910",
             "name": "Test Programme",
-            "startDate": "2024-01-01",
-            "endDate": "2025-01-01",
-            "wte": 0.5,
+            "startDate": "%s",
+            "endDate": "%s",
+            "wte": %s,
             "designatedBodyCode": "testDbc"
           },
-          "cctDate": "2024-01-01",
+          "cctDate": "%s",
           "changes": [
             {
               "type": "LTFT",
-              "startDate": "2024-07-01",
-              "wte": 0.75
+              "startDate": "%s",
+              "wte": %s
             }
           ]
         }
-        """);
+        """.formatted(
+        CCT_PM_START_DATE,
+        CCT_PM_END_DATE,
+        CCT_PM_WTE,
+        CCT_EXPECTED_DATE,
+        CCT_CHANGE_START_DATE,
+        CCT_CHANGE_WTE));
   }
 
   @AfterEach
@@ -180,21 +196,19 @@ class CctResourceIntegrationTest {
         .name("Test Calculation")
         .programmeMembership(CctProgrammeMembership.builder()
             .id(pmId)
-            .startDate(LocalDate.parse("2024-01-01"))
-            .endDate(LocalDate.parse("2025-01-01"))
-            .wte(1.0)
+        .startDate(CCT_PM_START_DATE)
+        .endDate(CCT_PM_END_DATE)
+        .wte(CCT_PM_WTE)
             .designatedBodyCode("testDbc")
             .build())
         .changes(List.of(
             CctChange.builder()
                 .type(CctChangeType.LTFT)
-                .startDate(LocalDate.parse("2024-07-01"))
-                .wte(0.5)
+          .startDate(CCT_CHANGE_START_DATE)
+          .wte(CCT_CHANGE_WTE)
                 .build()))
         .build();
     entity = template.insert(entity);
-
-    LocalDate cctDate = LocalDate.of(2025, 7, 4); //based on details above
 
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
     mockMvc.perform(get("/api/cct/calculation")
@@ -208,7 +222,7 @@ class CctResourceIntegrationTest {
         .andExpect(jsonPath("$[0].programmeMembership.id").value(pmId.toString()))
         .andExpect(jsonPath("$[0].created").value(
             entity.created().truncatedTo(ChronoUnit.MILLIS).toString()))
-        .andExpect(jsonPath("$[0].cctDate").value(cctDate.toString()))
+        .andExpect(jsonPath("$[0].cctDate").value(CCT_EXPECTED_DATE.toString()))
         .andExpect(jsonPath("$[0].lastModified").value(
             entity.lastModified().truncatedTo(ChronoUnit.MILLIS).toString()));
   }
@@ -330,22 +344,20 @@ class CctResourceIntegrationTest {
         .programmeMembership(CctProgrammeMembership.builder()
             .id(pmId)
             .name("Test Programme")
-            .startDate(LocalDate.parse("2024-01-01"))
-            .endDate(LocalDate.parse("2025-01-01"))
-            .wte(1.0)
+            .startDate(CCT_PM_START_DATE)
+            .endDate(CCT_PM_END_DATE)
+            .wte(CCT_PM_WTE)
             .designatedBodyCode("testDbc")
             .managingDeanery("Test Deanery")
             .build())
         .changes(List.of(
             CctChange.builder()
                 .type(CctChangeType.LTFT)
-                .startDate(LocalDate.parse("2024-07-01"))
-                .wte(0.5)
+                .startDate(CCT_CHANGE_START_DATE)
+                .wte(CCT_CHANGE_WTE)
                 .build()))
         .build();
     entity = template.insert(entity);
-
-    LocalDate cctDate = LocalDate.of(2025, 7, 4); //based on details above
 
     String token = TestJwtUtil.generateTokenForTisId(TRAINEE_ID);
     mockMvc.perform(get("/api/cct/calculation/{id}", entity.id())
@@ -357,17 +369,17 @@ class CctResourceIntegrationTest {
         .andExpect(jsonPath("$.name").value("Test Calculation"))
         .andExpect(jsonPath("$.programmeMembership").isMap())
         .andExpect(jsonPath("$.programmeMembership.id").value(pmId.toString()))
-        .andExpect(jsonPath("$.programmeMembership.startDate").value("2024-01-01"))
-        .andExpect(jsonPath("$.programmeMembership.endDate").value("2025-01-01"))
-        .andExpect(jsonPath("$.programmeMembership.wte").value(1))
+        .andExpect(jsonPath("$.programmeMembership.startDate").value(CCT_PM_START_DATE.toString()))
+        .andExpect(jsonPath("$.programmeMembership.endDate").value(CCT_PM_END_DATE.toString()))
+        .andExpect(jsonPath("$.programmeMembership.wte").value(CCT_PM_WTE))
         .andExpect(jsonPath("$.programmeMembership.designatedBodyCode").value("testDbc"))
         .andExpect(jsonPath("$.programmeMembership.managingDeanery").value("Test Deanery"))
         .andExpect(jsonPath("$.changes").isArray())
         .andExpect(jsonPath("$.changes", hasSize(1)))
         .andExpect(jsonPath("$.changes[0].type").value("LTFT"))
-        .andExpect(jsonPath("$.changes[0].startDate").value("2024-07-01"))
-        .andExpect(jsonPath("$.changes[0].wte").value(0.5))
-        .andExpect(jsonPath("$.cctDate").value(cctDate.toString()))
+        .andExpect(jsonPath("$.changes[0].startDate").value(CCT_CHANGE_START_DATE.toString()))
+        .andExpect(jsonPath("$.changes[0].wte").value(CCT_CHANGE_WTE))
+        .andExpect(jsonPath("$.cctDate").value(CCT_EXPECTED_DATE.toString()))
         .andExpect(
             jsonPath("$.created").value(entity.created().truncatedTo(ChronoUnit.MILLIS).toString()))
         .andExpect(jsonPath("$.lastModified").value(
@@ -633,7 +645,7 @@ class CctResourceIntegrationTest {
         .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id").exists())
         .andExpect(jsonPath("$.traineeId").doesNotExist())
-        .andExpect(jsonPath("$.cctDate").value(CCT_DATE_75.toString()))
+        .andExpect(jsonPath("$.cctDate").value(CCT_EXPECTED_DATE.toString()))
         .andExpect(jsonPath("$.name").value("Test Calculation"))
         .andExpect(jsonPath("$.created").exists())
         .andExpect(jsonPath("$.lastModified").exists())
@@ -1012,5 +1024,36 @@ class CctResourceIntegrationTest {
             .header(HttpHeaders.AUTHORIZATION, token))
         .andExpect(status().isOk())
         .andExpect(content().string("true"));
+  }
+
+  private static CalculateCctDateCase loadCctCase(String description) {
+    try (InputStream jsonInputStream = CctResourceIntegrationTest.class.getClassLoader()
+        .getResourceAsStream(CCT_CALC_TEST_CASES_RESOURCE)) {
+      if (jsonInputStream == null) {
+        throw new IllegalStateException("Unable to load test resource: "
+            + CCT_CALC_TEST_CASES_RESOURCE);
+      }
+
+      CalculateCctDateSourceOfTruth sourceOfTruth = OBJECT_MAPPER.readValue(jsonInputStream,
+          CalculateCctDateSourceOfTruth.class);
+      return sourceOfTruth.calculateCctDate().stream()
+          .filter(c -> description.equals(c.description()))
+          .findFirst()
+          .orElseThrow(() -> new IllegalStateException("Unable to find CCT test case: "
+              + description));
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to parse CCT test case resource.", e);
+    }
+  }
+
+  private record CalculateCctDateSourceOfTruth(List<CalculateCctDateCase> calculateCctDate) {
+  }
+
+  private record CalculateCctDateCase(String description, CalculateCctDateInput input,
+                                      LocalDate expected) {
+  }
+
+  private record CalculateCctDateInput(LocalDate currentProgEndDate, double currentWte,
+                                       double newWte, LocalDate changeStartDate) {
   }
 }

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -287,7 +287,7 @@ public class CctService {
             c, currentEndDate);
         return null;
       }
-      long chunkDays = ChronoUnit.DAYS.between(startDate, currentEndDate);
+      long chunkDays = ChronoUnit.DAYS.between(startDate, currentEndDate) +1; //inclusive
       double currentWte = i == 0
           ? entity.programmeMembership().wte()
           : orderedChanges.get(i - 1).wte();
@@ -296,10 +296,10 @@ public class CctService {
         log.warn("CCT date cannot be calculated, WTE for change {} is less than minimum.", c);
         return null;
       }
-      long chunkDaysWte = (long) Math.ceil((chunkDays * currentWte) / wte);
-      currentEndDate = currentEndDate.plusDays(chunkDaysWte - chunkDays);
+      double wteDays = chunkDays * (wte / currentWte);
+      long ltftExtension = Math.round(chunkDays - wteDays);
+      currentEndDate = currentEndDate.plusDays(ltftExtension);
     }
-
     return currentEndDate;
   }
 

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -291,6 +291,10 @@ public class CctService {
       double currentWte = i == 0
           ? entity.programmeMembership().wte()
           : orderedChanges.get(i - 1).wte();
+      if (currentWte < WTE_EPSILON) {
+        log.warn("CCT date cannot be calculated, current WTE is less than minimum.");
+        return null;
+      }
       double wte = c.wte();
       if (wte < WTE_EPSILON) {
         log.warn("CCT date cannot be calculated, WTE for change {} is less than minimum.", c);

--- a/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/CctService.java
@@ -287,7 +287,7 @@ public class CctService {
             c, currentEndDate);
         return null;
       }
-      long chunkDays = ChronoUnit.DAYS.between(startDate, currentEndDate) +1; //inclusive
+      long chunkDays = ChronoUnit.DAYS.between(startDate, currentEndDate) + 1;
       double currentWte = i == 0
           ? entity.programmeMembership().wte()
           : orderedChanges.get(i - 1).wte();

--- a/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
@@ -21,7 +21,6 @@
 
 package uk.nhs.hee.trainee.details.service;
 
-
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -36,16 +35,20 @@ import static org.mockito.Mockito.when;
 import static uk.nhs.hee.trainee.details.dto.enumeration.CctChangeType.LTFT;
 import static uk.nhs.hee.trainee.details.service.CctService.WTE_EPSILON;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import uk.nhs.hee.trainee.details.dto.CctCalculationDetailDto;
@@ -60,6 +63,9 @@ import uk.nhs.hee.trainee.details.model.CctCalculation.CctProgrammeMembership;
 import uk.nhs.hee.trainee.details.repository.CctCalculationRepository;
 
 class CctServiceTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().findAndRegisterModules();
+  private static final String CCT_CALC_TEST_CASES_RESOURCE = "cct-calc-test-cases.json";
 
   private static final String TRAINEE_ID = UUID.randomUUID().toString();
 
@@ -635,14 +641,37 @@ class CctServiceTest {
     verify(calculationRepository, never()).save(any());
   }
 
+  @ParameterizedTest(name = "{index}: {0}")
+  @MethodSource("calculateCctDateCases")
+  void shouldCalculateCctDateFromSourceOfTruthJson(String description,
+      CalculateCctDateCase calculateCctDateCase) {
+    CalculateCctDateInput input = calculateCctDateCase.input();
+    CctCalculation entity = CctCalculation.builder()
+        .traineeId(TRAINEE_ID)
+        .programmeMembership(CctProgrammeMembership.builder()
+            .startDate(input.changeStartDate())
+            .endDate(input.currentProgEndDate())
+            .wte(input.currentWte())
+            .designatedBodyCode("testDbc")
+            .build())
+        .changes(List.of(
+            CctChange.builder().type(LTFT).startDate(input.changeStartDate())
+                .wte(input.newWte()).build()))
+        .build();
+
+    assertThat("Unexpected CCT date for case: " + description,
+        service.calculateCctDate(entity),
+        is(calculateCctDateCase.expected()));
+  }
+
   @Test
-  void shouldReturnNullCctDateIfNullEntity() {
+  void shouldReturnNullCctDateForNullEntity() {
     assertThat("Unexpected CCT date.", service.calculateCctDate((CctCalculation) null),
         is(nullValue()));
   }
 
   @Test
-  void shouldReturnNullCctDateIfInvalidChangeStartDate() {
+  void shouldReturnNullCctDateWhenChangeStartDateAfterCurrentEndDate() {
     LocalDate pmEndDate = LocalDate.EPOCH.plusMonths(12);
     CctCalculation entity = CctCalculation.builder()
         .traineeId(TRAINEE_ID)
@@ -653,17 +682,17 @@ class CctServiceTest {
             .designatedBodyCode("testDbc")
             .build())
         .changes(List.of(
-            CctChange.builder().type(LTFT).startDate(pmEndDate.plusDays(1))
-                .wte(0.5).build()))
+            CctChange.builder().type(LTFT).startDate(pmEndDate.plusDays(1)).wte(0.5).build()))
         .build();
-    assertThat("Unexpected CCT date.", service.calculateCctDate(entity),
-        is(nullValue()));
+
+    assertThat("Unexpected CCT date.", service.calculateCctDate(entity), is(nullValue()));
   }
 
   @Test
-  void shouldIgnoreChangeStartDateBeforePmStartDateForCctDate() {
+  void shouldCalculateSameCctDateRegardlessOfChangeOrder() {
     LocalDate pmStartDate = LocalDate.EPOCH;
-    CctCalculation entityEarlyChangeStartDate = CctCalculation.builder()
+
+    CctCalculation orderedChanges = CctCalculation.builder()
         .traineeId(TRAINEE_ID)
         .programmeMembership(CctProgrammeMembership.builder()
             .startDate(pmStartDate)
@@ -672,11 +701,12 @@ class CctServiceTest {
             .designatedBodyCode("testDbc")
             .build())
         .changes(List.of(
-            CctChange.builder().type(LTFT).startDate(LocalDate.MIN)
-                .wte(0.5).build()))
+            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(3)).wte(0.5).build(),
+            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(6)).wte(0.75).build(),
+            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(9)).wte(1.0).build()))
         .build();
 
-    CctCalculation entityNormalStartDate = CctCalculation.builder()
+    CctCalculation unorderedChanges = CctCalculation.builder()
         .traineeId(TRAINEE_ID)
         .programmeMembership(CctProgrammeMembership.builder()
             .startDate(pmStartDate)
@@ -685,52 +715,13 @@ class CctServiceTest {
             .designatedBodyCode("testDbc")
             .build())
         .changes(List.of(
-            CctChange.builder().type(LTFT).startDate(pmStartDate)
-                .wte(0.5).build()))
-        .build();
-    assertThat("Unexpected CCT date.", service.calculateCctDate(entityEarlyChangeStartDate),
-        is(service.calculateCctDate(entityNormalStartDate)));
-  }
-
-  @Test
-  void shouldOrderChangesByStartDateForCctDate() {
-    LocalDate pmStartDate = LocalDate.EPOCH;
-    CctCalculation entity = CctCalculation.builder()
-        .traineeId(TRAINEE_ID)
-        .programmeMembership(CctProgrammeMembership.builder()
-            .startDate(pmStartDate)
-            .endDate(LocalDate.EPOCH.plusYears(1))
-            .wte(1.0)
-            .designatedBodyCode("testDbc")
-            .build())
-        .changes(List.of(
-            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(3))
-                .wte(0.5).build(),
-            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(9))
-                .wte(1.0).build(),
-            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(6))
-                .wte(0.75).build()))
+            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(9)).wte(1.0).build(),
+            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(3)).wte(0.5).build(),
+            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(6)).wte(0.75).build()))
         .build();
 
-    CctCalculation entityChangesReordered = CctCalculation.builder()
-        .traineeId(TRAINEE_ID)
-        .programmeMembership(CctProgrammeMembership.builder()
-            .startDate(pmStartDate)
-            .endDate(LocalDate.EPOCH.plusYears(1))
-            .wte(1.0)
-            .designatedBodyCode("testDbc")
-            .build())
-        .changes(List.of(
-            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(9))
-                .wte(1.0).build(),
-            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(3))
-                .wte(0.5).build(),
-            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(6))
-                .wte(0.75).build()))
-        .build();
-
-    assertThat("Unexpected CCT date.", service.calculateCctDate(entity),
-        is(service.calculateCctDate(entityChangesReordered)));
+    assertThat("Unexpected CCT date.", service.calculateCctDate(orderedChanges),
+        is(service.calculateCctDate(unorderedChanges)));
   }
 
   @Test
@@ -749,60 +740,31 @@ class CctServiceTest {
                 .wte(WTE_EPSILON - 0.001).build()))
         .build();
 
-    assertThat("Unexpected CCT date.", service.calculateCctDate(entity),
-        is(nullValue()));
+    assertThat("Unexpected CCT date.", service.calculateCctDate(entity), is(nullValue()));
   }
 
-  @ParameterizedTest
-  @ValueSource(doubles = {0.8, 0.7, 0.6, 0.5, 0.25})
-  void shouldCalculateCctDate(double changeWte) {
-    LocalDate pmStartDate = LocalDate.of(2024, 9, 25);
-    CctCalculation entity = CctCalculation.builder()
-        .traineeId(TRAINEE_ID)
-        .programmeMembership(CctProgrammeMembership.builder()
-            .startDate(pmStartDate)
-            .endDate(LocalDate.of(2028, 1, 1))
-            .wte(1.0)
-            .designatedBodyCode("testDbc")
-            .build())
-        .changes(List.of(
-            CctChange.builder().type(LTFT).startDate(pmStartDate)
-                .wte(changeWte).build()))
-        .build();
-
-    //examples from front-end tests
-    LocalDate expectedCctDate = switch ((int) (changeWte * 100)) {
-      case 80 -> LocalDate.of(2028, 10, 26);
-      case 70 -> LocalDate.of(2029, 5, 27);
-      case 60 -> LocalDate.of(2030, 3, 7);
-      case 50 -> LocalDate.of(2031, 4, 8);
-      case 25 -> LocalDate.of(2037, 10, 19);
-      default -> LocalDate.MIN;
-    };
-    assertThat("Unexpected CCT date.", service.calculateCctDate(entity),
-        is(expectedCctDate));
+  private static Stream<Arguments> calculateCctDateCases() throws IOException {
+    try (var jsonInputStream = CctServiceTest.class.getClassLoader()
+        .getResourceAsStream(CCT_CALC_TEST_CASES_RESOURCE)) {
+      if (jsonInputStream == null) {
+        throw new IOException("Unable to load test resource: " + CCT_CALC_TEST_CASES_RESOURCE);
+      }
+      var sourceOfTruth = OBJECT_MAPPER.readValue(jsonInputStream,
+          CalculateCctDateSourceOfTruth.class);
+      return sourceOfTruth.calculateCctDate().stream()
+          .map(c -> Arguments.of(c.description(), c));
+    }
   }
 
-  @Test
-  void shouldCalcCctDate2() {
-    //don't ask why these are the way they are, ask the FE :>
-    LocalDate pmStartDate = LocalDate.of(2024, 12, 3).plusWeeks(16);
-    LocalDate pmEndDate = LocalDate.of(2024, 12, 3).plusDays(1701);
-    CctCalculation entity = CctCalculation.builder()
-        .traineeId(TRAINEE_ID)
-        .programmeMembership(CctProgrammeMembership.builder()
-            .startDate(pmStartDate)
-            .endDate(pmEndDate)
-            .wte(1.0)
-            .designatedBodyCode("testDbc")
-            .build())
-        .changes(List.of(
-            CctChange.builder().type(LTFT).startDate(pmStartDate)
-                .wte(0.5).build()))
-        .build();
+  private record CalculateCctDateSourceOfTruth(List<CalculateCctDateCase> calculateCctDate) {
+  }
 
-    assertThat("Unexpected CCT date.", service.calculateCctDate(entity),
-        is(LocalDate.of(2033, 12, 6)));
+  private record CalculateCctDateCase(String description, CalculateCctDateInput input,
+                                      LocalDate expected) {
+  }
+
+  private record CalculateCctDateInput(LocalDate currentProgEndDate, double currentWte,
+                                       double newWte, LocalDate changeStartDate) {
   }
 
   @Test

--- a/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/CctServiceTest.java
@@ -743,6 +743,46 @@ class CctServiceTest {
     assertThat("Unexpected CCT date.", service.calculateCctDate(entity), is(nullValue()));
   }
 
+  @Test
+  void shouldReturnNullCctDateIfPmWteIsTooSmall() {
+    LocalDate pmStartDate = LocalDate.EPOCH;
+    CctCalculation entity = CctCalculation.builder()
+        .traineeId(TRAINEE_ID)
+        .programmeMembership(CctProgrammeMembership.builder()
+            .startDate(pmStartDate)
+            .endDate(LocalDate.EPOCH.plusYears(1))
+            .wte(0.0)
+            .designatedBodyCode("testDbc")
+            .build())
+        .changes(List.of(
+            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(3))
+                .wte(0.5).build()))
+        .build();
+
+    assertThat("Unexpected CCT date.", service.calculateCctDate(entity), is(nullValue()));
+  }
+
+  @Test
+  void shouldReturnNullCctDateIfPreviousChangeWteIsTooSmall() {
+    LocalDate pmStartDate = LocalDate.EPOCH;
+    CctCalculation entity = CctCalculation.builder()
+        .traineeId(TRAINEE_ID)
+        .programmeMembership(CctProgrammeMembership.builder()
+            .startDate(pmStartDate)
+            .endDate(LocalDate.EPOCH.plusYears(1))
+            .wte(1.0)
+            .designatedBodyCode("testDbc")
+            .build())
+        .changes(List.of(
+            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(3))
+                .wte(0.0).build(),
+            CctChange.builder().type(LTFT).startDate(pmStartDate.plusMonths(6))
+                .wte(0.5).build()))
+        .build();
+
+    assertThat("Unexpected CCT date.", service.calculateCctDate(entity), is(nullValue()));
+  }
+
   private static Stream<Arguments> calculateCctDateCases() throws IOException {
     try (var jsonInputStream = CctServiceTest.class.getClassLoader()
         .getResourceAsStream(CCT_CALC_TEST_CASES_RESOURCE)) {

--- a/src/test/resources/cct-calc-test-cases.json
+++ b/src/test/resources/cct-calc-test-cases.json
@@ -1,0 +1,94 @@
+{
+  "calculateCctDate": [
+    {
+      "description": "half-time for full year",
+      "input": {
+        "currentProgEndDate": "2025-12-31",
+        "currentWte": 1,
+        "newWte": 0.5,
+        "changeStartDate": "2025-01-01"
+      },
+      "expected": "2026-07-02"
+    },
+    {
+      "description": "no change in WTE",
+      "input": {
+        "currentProgEndDate": "2025-06-30",
+        "currentWte": 1,
+        "newWte": 1,
+        "changeStartDate": "2025-01-01"
+      },
+      "expected": "2025-06-30"
+    },
+    {
+      "description": "80% WTE for 6 months",
+      "input": {
+        "currentProgEndDate": "2026-03-31",
+        "currentWte": 1,
+        "newWte": 0.8,
+        "changeStartDate": "2025-10-01"
+      },
+      "expected": "2026-05-06"
+    },
+    {
+      "description": "already part-time going more part-time",
+      "input": {
+        "currentProgEndDate": "2025-09-30",
+        "currentWte": 0.8,
+        "newWte": 0.6,
+        "changeStartDate": "2025-04-01"
+      },
+      "expected": "2025-11-15"
+    },
+    {
+      "description": "half-time for one month",
+      "input": {
+        "currentProgEndDate": "2025-03-31",
+        "currentWte": 1,
+        "newWte": 0.5,
+        "changeStartDate": "2025-03-01"
+      },
+      "expected": "2025-04-16"
+    },
+    {
+      "description": "half-time same start and end date",
+      "input": {
+        "currentProgEndDate": "2025-06-15",
+        "currentWte": 1,
+        "newWte": 0.5,
+        "changeStartDate": "2025-06-15"
+      },
+      "expected": "2025-06-16"
+    },
+    {
+      "description": "60% WTE over long period",
+      "input": {
+        "currentProgEndDate": "2027-08-31",
+        "currentWte": 1,
+        "newWte": 0.6,
+        "changeStartDate": "2025-09-01"
+      },
+      "expected": "2028-06-18"
+    },
+    {
+      "description": "increase from part-time to full-time",
+      "input": {
+        "currentProgEndDate": "2025-12-31",
+        "currentWte": 0.5,
+        "newWte": 1,
+        "changeStartDate": "2025-07-01"
+      },
+      "expected": "2025-06-30"
+    },
+    {
+      "description": "half-time leap year crossing",
+      "input": {
+        "currentProgEndDate": "2024-12-31",
+        "currentWte": 1,
+        "newWte": 0.5,
+        "changeStartDate": "2024-01-01"
+      },
+      "expected": "2025-07-02"
+    }
+  ]
+}


### PR DESCRIPTION
First-time caller long-time lurker...

Note: This more of a quick fix (and a chance to get some Java practice) before we move to an imported cct-calc-core library (see https://hee-tis.atlassian.net/browse/TIS21-8518).

Me and my friend, Claudine (who helped plumb in the tests) have tried to mirror the recent TSS TS FE cctCalc fix (forgive any crimes against Java) so that the correct CCT date is calculated and returned to the TSS FE app via cct calc fetch req.

1. Update calculateCctDate function logic to match the verified business logic used in several NHS CCT Calculators.

2. Replace ad-hoc calculateCctDate assertions with a shared (used by TSS FE too) and verified JSON-driven test suite.

Also:
3. Keep Java service-specific guardrail tests in the test file for null input, invalid change date, change-order invariance, and minimum WTE rejection.