### PR TITLE
fix: update GMC status when no GMC number update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "2.9.0"
+version = "2.9.1"
 
 configurations {
   compileOnly {

--- a/src/integrationTest/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceIntegrationTest.java
+++ b/src/integrationTest/java/uk/nhs/hee/trainee/details/api/BasicDetailsResourceIntegrationTest.java
@@ -194,7 +194,7 @@ class BasicDetailsResourceIntegrationTest {
         .andExpect(status().isNoContent());
 
     ArgumentCaptor<SnsNotification<EmailDetailsProvidedEvent>> notificationCaptor
-        = ArgumentCaptor.forClass(SnsNotification.class);
+        = ArgumentCaptor.captor();
     verify(snsTemplate, times(1))
         .sendNotification(eq("dummy"), notificationCaptor.capture());
     EmailDetailsProvidedEvent event = notificationCaptor.getValue().getPayload();

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
@@ -114,10 +114,15 @@ public abstract class TraineeProfileMapper {
   protected void perUpdateGmcDetails(@MappingTarget TraineeProfile target,
       PersonalDetails source) {
     if (target.getPersonalDetails() != null) {
+      PersonalDetails targetPersonalDetails = target.getPersonalDetails();
+
       // If the gmcNumber is updated
-      if (!Objects.equals(target.getPersonalDetails().getGmcNumber(), source.getGmcNumber())) {
-        // TODO: Default all GMCs to registered until we can properly prompt/determine the correct status.
-        target.getPersonalDetails().setGmcStatus("Registered with Licence");
+      if (!Objects.equals(targetPersonalDetails.getGmcNumber(), source.getGmcNumber())) {
+        // TODO: Default all updated GMCs to registered until we can properly prompt/determine the correct status.
+        targetPersonalDetails.setGmcStatus("Registered with Licence");
+      } else {
+        // If the GMC was not updated then carry the latest source GMC status forward.
+        targetPersonalDetails.setGmcStatus(source.getGmcStatus());
       }
     } else if (source.getGmcNumber() != null) {
       // If target personal details is null and source GMC number has a new value

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
@@ -101,6 +101,7 @@ public class PersonalDetailsService {
       GmcDetailsDto gmcDetails) {
     PersonalDetails personalDetails = new PersonalDetails();
     personalDetails.setGmcNumber(gmcDetails.gmcNumber());
+    personalDetails.setGmcStatus(gmcDetails.gmcStatus());
 
     PersonalDetailsUpdated updatedDetails = updateGmcDetailsByTisId(tisId, personalDetails);
 

--- a/src/test/java/uk/nhs/hee/trainee/details/config/MongoIndexConfigurationTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/config/MongoIndexConfigurationTest.java
@@ -69,7 +69,7 @@ class MongoIndexConfigurationTest {
 
     configuration.initIndexes();
 
-    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.forClass(IndexDefinition.class);
+    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.captor();
     verify(indexOperations, atLeastOnce()).createIndex(indexCaptor.capture());
 
     List<IndexDefinition> indexes = indexCaptor.getAllValues();
@@ -96,9 +96,9 @@ class MongoIndexConfigurationTest {
 
     configuration.initIndexes();
 
-    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.forClass(IndexDefinition.class);
+    ArgumentCaptor<IndexDefinition> indexCaptor = ArgumentCaptor.captor();
     verify(indexOperations, atLeastOnce()).createIndex(indexCaptor.capture());
-    ArgumentCaptor<String> indexCaptorDel = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> indexCaptorDel = ArgumentCaptor.captor();
     verify(indexOperations, atLeastOnce()).dropIndex(indexCaptorDel.capture());
 
     List<IndexDefinition> indexes = indexCaptor.getAllValues();

--- a/src/test/java/uk/nhs/hee/trainee/details/event/BasicDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/BasicDetailsListenerTest.java
@@ -62,7 +62,7 @@ class BasicDetailsListenerTest {
 
     listener.updateBasicDetails(event);
 
-    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
+    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.captor();
     verify(service).createProfileOrUpdateBasicDetailsByTisId(eq(TIS_ID), entityCaptor.capture());
 
     PersonalDetails entity = entityCaptor.getValue();

--- a/src/test/java/uk/nhs/hee/trainee/details/event/ContactDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/ContactDetailsListenerTest.java
@@ -80,7 +80,7 @@ class ContactDetailsListenerTest {
     Update update = new Update(dto);
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
-    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
+    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.captor();
     when(service.updateContactDetailsByTisId(eq(TIS_ID), entityCaptor.capture())).then(
         inv -> new PersonalDetailsUpdated(true, Optional.of(inv.getArgument(1))));
 

--- a/src/test/java/uk/nhs/hee/trainee/details/event/GdcDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/GdcDetailsListenerTest.java
@@ -78,7 +78,7 @@ class GdcDetailsListenerTest {
     Update update = new Update(dto);
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
-    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
+    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.captor();
     when(service.updateGdcDetailsByTisId(eq(TIS_ID), entityCaptor.capture())).then(
         inv ->
             new PersonalDetailsUpdated(true, Optional.of(inv.getArgument(1))));

--- a/src/test/java/uk/nhs/hee/trainee/details/event/GmcDetailsListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/GmcDetailsListenerTest.java
@@ -78,7 +78,7 @@ class GmcDetailsListenerTest {
     Update update = new Update(dto);
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
-    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
+    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.captor();
     when(service.updateGmcDetailsByTisId(eq(TIS_ID), entityCaptor.capture())).thenAnswer(
         inv -> new PersonalDetailsUpdated(true, Optional.of(inv.getArgument(1))));
 

--- a/src/test/java/uk/nhs/hee/trainee/details/event/PersonOwnerListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/PersonOwnerListenerTest.java
@@ -76,7 +76,7 @@ class PersonOwnerListenerTest {
     Update update = new Update(dto);
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
-    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
+    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.captor();
     when(service.updatePersonOwnerByTisId(eq(TIS_ID), entityCaptor.capture())).then(
         inv -> new PersonalDetailsUpdated(true, Optional.of(inv.getArgument(1))));
 

--- a/src/test/java/uk/nhs/hee/trainee/details/event/PersonalInfoListenerTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/event/PersonalInfoListenerTest.java
@@ -79,7 +79,7 @@ class PersonalInfoListenerTest {
     Update update = new Update(dto);
     PersonalDetailsUpdateEvent event = new PersonalDetailsUpdateEvent(TIS_ID, update);
 
-    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.forClass(PersonalDetails.class);
+    ArgumentCaptor<PersonalDetails> entityCaptor = ArgumentCaptor.captor();
     when(service.updatePersonalInfoByTisId(eq(TIS_ID), entityCaptor.capture())).then(
         inv -> new PersonalDetailsUpdated(true, Optional.of(inv.getArgument(1))));
 

--- a/src/test/java/uk/nhs/hee/trainee/details/migration/AddTraineeProfileVersioningTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/migration/AddTraineeProfileVersioningTest.java
@@ -52,8 +52,8 @@ class AddTraineeProfileVersioningTest {
   void shouldAddAndInitialiseVersionOnAllRecords() {
     Update correctUpdate = new Update();
     correctUpdate.set("version", VERSION_INIT_VALUE);
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.captor();
     UpdateResult result = mock(UpdateResult.class);
 
     when(template.updateMulti(

--- a/src/test/java/uk/nhs/hee/trainee/details/migration/DeleteDuplicateTraineeProfilePlacementsTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/migration/DeleteDuplicateTraineeProfilePlacementsTest.java
@@ -56,8 +56,8 @@ class DeleteDuplicateTraineeProfilePlacementsTest {
     final Update update =
         new Update().pull("placements",
             new BasicDBObject("tisId", new BasicDBObject("$regex", "^\\w{24}$")));
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.captor();
     UpdateResult result = mock(UpdateResult.class);
 
     when(template.updateMulti(

--- a/src/test/java/uk/nhs/hee/trainee/details/migration/DeleteDuplicateTraineeProfileProgrammeMembershipsTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/migration/DeleteDuplicateTraineeProfileProgrammeMembershipsTest.java
@@ -56,8 +56,8 @@ class DeleteDuplicateTraineeProfileProgrammeMembershipsTest {
     final Update update =
         new Update().pull("programmeMemberships",
             new BasicDBObject("tisId", new BasicDBObject("$regex", "^[\\d,]*$")));
-    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.forClass(Query.class);
-    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.forClass(Update.class);
+    ArgumentCaptor<Query> queryCaptor = ArgumentCaptor.captor();
+    ArgumentCaptor<Update> updateCaptor = ArgumentCaptor.captor();
     UpdateResult result = mock(UpdateResult.class);
 
     when(template.updateMulti(

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
@@ -100,7 +100,7 @@ class PersonalDetailsServiceTest {
 
   @Test
   void shouldCreateTraineeProfileWhenTraineeIdNotFound() {
-    ArgumentCaptor<TraineeProfile> profileCaptor = ArgumentCaptor.forClass(TraineeProfile.class);
+    ArgumentCaptor<TraineeProfile> profileCaptor = ArgumentCaptor.captor();
 
     when(repository.save(profileCaptor.capture()))
         .thenAnswer(invocation -> invocation.getArgument(0));
@@ -126,7 +126,7 @@ class PersonalDetailsServiceTest {
     service.createProfileOrUpdateBasicDetailsByTisId("notFound",
         createPersonalDetails(MODIFIED_SUFFIX, 0));
 
-    ArgumentCaptor<TraineeProfile> profileCaptor = ArgumentCaptor.forClass(TraineeProfile.class);
+    ArgumentCaptor<TraineeProfile> profileCaptor = ArgumentCaptor.captor();
     verify(eventService).publishProfileCreateEvent(profileCaptor.capture());
 
     TraineeProfile eventTraineeProfile = profileCaptor.getValue();
@@ -310,6 +310,31 @@ class PersonalDetailsServiceTest {
         is(expectedPersonalDetails));
   }
 
+  @Test
+  void shouldUpdateGmcDetailsWhenTraineeIdFoundAndNoGmcNumberUpdate() {
+    TraineeProfile traineeProfile = new TraineeProfile();
+    traineeProfile.setPersonalDetails(createPersonalDetails(ORIGINAL_SUFFIX, 0));
+
+    when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
+    when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
+
+    PersonalDetails modifiedPersonalDetails = createPersonalDetails(MODIFIED_SUFFIX, 100);
+    modifiedPersonalDetails.setGmcNumber(GMC_NUMBER + ORIGINAL_SUFFIX);
+    PersonalDetailsUpdated personalDetails = service.updateGmcDetailsByTisId("40",
+        modifiedPersonalDetails);
+
+    assertThat("Unexpected isUpdated flag.", personalDetails.isUpdated(), is(true));
+    assertThat("Unexpected optional isEmpty flag.",
+        personalDetails.getPersonalDetails().isEmpty(), is(false));
+
+    PersonalDetails expectedPersonalDetails = createPersonalDetails(ORIGINAL_SUFFIX, 0);
+    // GMC number not updated, so GMC status uses provided value.
+    expectedPersonalDetails.setGmcStatus(GMC_STATUS + MODIFIED_SUFFIX);
+
+    assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
+        is(expectedPersonalDetails));
+  }
+
   @ParameterizedTest
   @NullAndEmptySource
   void shouldUpdateGmcDetailsWhenTraineeIdFoundWithNoExistingGmc(String existingGmc) {
@@ -332,7 +357,7 @@ class PersonalDetailsServiceTest {
 
     PersonalDetails expectedPersonalDetails = createPersonalDetails(ORIGINAL_SUFFIX, 0);
     expectedPersonalDetails.setGmcNumber(GMC_NUMBER + MODIFIED_SUFFIX);
-    // GMC number updated, so GMC status changes to DEFAULT_GMC_STATUS
+    // GMC number updated, so GMC status changes to DEFAULT_GMC_STATUS.
     expectedPersonalDetails.setGmcStatus(DEFAULT_GMC_STATUS);
 
     assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
@@ -408,6 +433,7 @@ class PersonalDetailsServiceTest {
 
     GmcDetailsDto gmcDetails = GmcDetailsDto.builder()
         .gmcNumber(GMC_NUMBER + ORIGINAL_SUFFIX)
+        .gmcStatus(GMC_STATUS + ORIGINAL_SUFFIX)
         .build();
 
     service.updateGmcDetailsWithTraineeProvidedDetails("40", gmcDetails);

--- a/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/ProgrammeMembershipServiceTest.java
@@ -512,7 +512,7 @@ class ProgrammeMembershipServiceTest {
 
     assertThat("Unexpected result.", deleted, is(true));
 
-    ArgumentCaptor<TraineeProfile> profileCaptor = ArgumentCaptor.forClass(TraineeProfile.class);
+    ArgumentCaptor<TraineeProfile> profileCaptor = ArgumentCaptor.captor();
     verify(repository).save(profileCaptor.capture());
 
     List<ProgrammeMembership> programmeMemberships = profileCaptor.getValue()
@@ -1749,7 +1749,7 @@ class ProgrammeMembershipServiceTest {
 
     service.generateProgrammeMembershipPdf(TRAINEE_TIS_ID, PROGRAMME_TIS_ID);
 
-    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> variablesCaptor = ArgumentCaptor.captor();
     verify(pdfService).generatePdf(any(), variablesCaptor.capture());
     Map<String, Object> variables = variablesCaptor.getValue();
     assertThat("Unexpected programme membership.", variables.get("pm"),
@@ -1973,7 +1973,7 @@ class ProgrammeMembershipServiceTest {
 
   @Test
   void shouldUseFoundationTraineeTypeWhenGettingContactListForFoundationProgramme() {
-    ArgumentCaptor<Map<String, Object>> uriVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> uriVarsCaptor = ArgumentCaptor.captor();
     when(restTemplate.getForObject(any(), any(), anyMap())).thenReturn(new ArrayList<>());
 
     service.getOwnerContactList("a local office", FOUNDATION);
@@ -1985,7 +1985,7 @@ class ProgrammeMembershipServiceTest {
 
   @Test
   void shouldIncludeLocalOfficeNameWhenGettingContactListForFoundationProgramme() {
-    ArgumentCaptor<Map<String, Object>> uriVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> uriVarsCaptor = ArgumentCaptor.captor();
     when(restTemplate.getForObject(any(), any(), anyMap())).thenReturn(new ArrayList<>());
 
     service.getOwnerContactList("a local office", FOUNDATION);
@@ -1997,7 +1997,7 @@ class ProgrammeMembershipServiceTest {
 
   @Test
   void shouldUseFoundationTraineeTypeWhenGettingOwnerContactForFoundationProgramme() {
-    ArgumentCaptor<Map<String, Object>> uriVarsCaptor = ArgumentCaptor.forClass(Map.class);
+    ArgumentCaptor<Map<String, Object>> uriVarsCaptor = ArgumentCaptor.captor();
     when(restTemplate.getForObject(any(), any(), anyMap())).thenReturn(new ArrayList<>());
 
     service.getOwnerContact("a local office", LocalOfficeContactType.TSS_SUPPORT,

--- a/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/TraineeProfileServiceTest.java
@@ -403,7 +403,7 @@ class TraineeProfileServiceTest {
 
   @Test
   void shouldFindProfilesByLowerCaseEmail() {
-    ArgumentCaptor<String> emailCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> emailCaptor = ArgumentCaptor.captor();
     when(repository.findAllByTraineeEmail(emailCaptor.capture()))
         .thenReturn(Collections.emptyList());
 


### PR DESCRIPTION
GMC statuses are not being updated when they have been updated in TIS without an accompanying GMC Number update.

Update the PersonalDetailsService and TraineeProfileMapper to ensure that if the GMC number has not been changed, the GMC status is still updated.

In cases where the GMC number has been set for the first time, or changed, we still default to "Registered with License" this is due to the inability for trainees to update their status alongside the trainee-triggered GMC number update.

Also updated ArgumentCaptor usage for consistency.

TIS21-8637