### PR TITLE
feat: set default GMC status on update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.trainee.details"
-version = "2.10.0"
+version = "2.10.1"
 
 configurations {
   compileOnly {

--- a/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/mapper/TraineeProfileMapper.java
@@ -103,36 +103,9 @@ public abstract class TraineeProfileMapper {
   public abstract void updateGdcDetails(@MappingTarget TraineeProfile target,
       PersonalDetails source);
 
-  /**
-   * Pre GMC update process to set default GMC to registered if GMC number is updated.
-   *
-   * @param target The existing trainee profile.
-   * @param source The new personal details.
-   */
-  @Named("updateGmc")
-  @BeforeMapping
-  protected void perUpdateGmcDetails(@MappingTarget TraineeProfile target,
-      PersonalDetails source) {
-    if (target.getPersonalDetails() != null) {
-      PersonalDetails targetPersonalDetails = target.getPersonalDetails();
-
-      // If the gmcNumber is updated
-      if (!Objects.equals(targetPersonalDetails.getGmcNumber(), source.getGmcNumber())) {
-        // TODO: Default all updated GMCs to registered until we can properly prompt/determine the correct status.
-        targetPersonalDetails.setGmcStatus("Registered with Licence");
-      } else {
-        // If the GMC was not updated then carry the latest source GMC status forward.
-        targetPersonalDetails.setGmcStatus(source.getGmcStatus());
-      }
-    } else if (source.getGmcNumber() != null) {
-      // If target personal details is null and source GMC number has a new value
-      target.setPersonalDetails(new PersonalDetails());
-      target.getPersonalDetails().setGmcStatus("Registered with Licence");
-    }
-  }
-
-  @BeanMapping(ignoreByDefault = true, qualifiedByName = "updateGmc")
+  @BeanMapping(ignoreByDefault = true)
   @Mapping(target = "personalDetails.gmcNumber", source = "gmcNumber")
+  @Mapping(target = "personalDetails.gmcStatus", source = "gmcStatus")
   public abstract void updateGmcDetails(@MappingTarget TraineeProfile target,
       PersonalDetails source);
 

--- a/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
+++ b/src/main/java/uk/nhs/hee/trainee/details/service/PersonalDetailsService.java
@@ -63,7 +63,7 @@ public class PersonalDetailsService {
       PersonalDetails personalDetails) {
     PersonalDetailsUpdated updatedDetails = updatePersonalDetailsByTisId(tisId, personalDetails,
         mapper::updateBasicDetails);
-    Optional<PersonalDetails> updatedPersonalDetails =  updatedDetails.getPersonalDetails();
+    Optional<PersonalDetails> updatedPersonalDetails = updatedDetails.getPersonalDetails();
 
     if (updatedPersonalDetails.isEmpty()) {
       TraineeProfile traineeProfile = new TraineeProfile();
@@ -101,20 +101,23 @@ public class PersonalDetailsService {
       GmcDetailsDto gmcDetails) {
     PersonalDetails personalDetails = new PersonalDetails();
     personalDetails.setGmcNumber(gmcDetails.gmcNumber());
-    personalDetails.setGmcStatus(gmcDetails.gmcStatus());
+
+    // Use a default GMC status as we don't support trainee-provided statuses yet.
+    personalDetails.setGmcStatus("Registered with Licence");
 
     PersonalDetailsUpdated updatedDetails = updateGmcDetailsByTisId(tisId, personalDetails);
-
     updatedDetails.getPersonalDetails().ifPresent(details -> {
       // if gmcNumber is updated
       if (updatedDetails.isUpdated()) {
         // don't publish to TIS if it is a test user
         if (tisId.startsWith("-")) {
           log.warn("Tester trainee ID {} provided. Ignore GMC number update.", tisId);
-        }
-        else {
+        } else {
           log.info("Trainee {} updated their GMC number to {}.", tisId, details.getGmcNumber());
-          eventService.publishGmcDetailsProvidedEvent(tisId, gmcDetails);
+          eventService.publishGmcDetailsProvidedEvent(tisId, GmcDetailsDto.builder()
+              .gmcNumber(details.getGmcNumber())
+              .gmcStatus(details.getGmcStatus())
+              .build());
         }
       }
     });
@@ -218,7 +221,7 @@ public class PersonalDetailsService {
     List<TraineeProfile> profilesWithEmail = repository.findAllByTraineeEmail(email);
     if (!profilesWithEmail.isEmpty()) {
       log.warn("Email address {} for trainee {} is already in use (by at least one other trainee, "
-              + "or is unchanged from their current email).", tisId, email);
+          + "or is unchanged from their current email).", tisId, email);
       return false;
     }
     return true;

--- a/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
+++ b/src/test/java/uk/nhs/hee/trainee/details/service/PersonalDetailsServiceTest.java
@@ -303,8 +303,7 @@ class PersonalDetailsServiceTest {
 
     PersonalDetails expectedPersonalDetails = createPersonalDetails(ORIGINAL_SUFFIX, 0);
     expectedPersonalDetails.setGmcNumber(GMC_NUMBER + MODIFIED_SUFFIX);
-    // GMC number updated, so GMC status changes to DEFAULT_GMC_STATUS
-    expectedPersonalDetails.setGmcStatus(DEFAULT_GMC_STATUS);
+    expectedPersonalDetails.setGmcStatus(GMC_STATUS + MODIFIED_SUFFIX);
 
     assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
         is(expectedPersonalDetails));
@@ -357,8 +356,7 @@ class PersonalDetailsServiceTest {
 
     PersonalDetails expectedPersonalDetails = createPersonalDetails(ORIGINAL_SUFFIX, 0);
     expectedPersonalDetails.setGmcNumber(GMC_NUMBER + MODIFIED_SUFFIX);
-    // GMC number updated, so GMC status changes to DEFAULT_GMC_STATUS.
-    expectedPersonalDetails.setGmcStatus(DEFAULT_GMC_STATUS);
+    expectedPersonalDetails.setGmcStatus(GMC_STATUS + MODIFIED_SUFFIX);
 
     assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
         is(expectedPersonalDetails));
@@ -380,8 +378,7 @@ class PersonalDetailsServiceTest {
 
     PersonalDetails expectedPersonalDetails = new PersonalDetails();
     expectedPersonalDetails.setGmcNumber(GMC_NUMBER + MODIFIED_SUFFIX);
-    // GMC number updated, so GMC status changes to DEFAULT_GMC_STATUS
-    expectedPersonalDetails.setGmcStatus(DEFAULT_GMC_STATUS);
+    expectedPersonalDetails.setGmcStatus(GMC_STATUS + MODIFIED_SUFFIX);
 
     assertThat("Unexpected personal details.", personalDetails.getPersonalDetails().get(),
         is(expectedPersonalDetails));
@@ -427,13 +424,14 @@ class PersonalDetailsServiceTest {
   void shouldNotPublishEventWhenGmcDetailsNotUpdated() {
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setPersonalDetails(createPersonalDetails(ORIGINAL_SUFFIX, 0));
+    traineeProfile.getPersonalDetails().setGmcStatus(DEFAULT_GMC_STATUS);
 
     when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
 
     GmcDetailsDto gmcDetails = GmcDetailsDto.builder()
         .gmcNumber(GMC_NUMBER + ORIGINAL_SUFFIX)
-        .gmcStatus(GMC_STATUS + ORIGINAL_SUFFIX)
+        .gmcStatus(DEFAULT_GMC_STATUS)
         .build();
 
     service.updateGmcDetailsWithTraineeProvidedDetails("40", gmcDetails);
@@ -463,6 +461,7 @@ class PersonalDetailsServiceTest {
   void shouldPublishEventWhenGmcDetailsProvidedByTrainee() {
     TraineeProfile traineeProfile = new TraineeProfile();
     traineeProfile.setPersonalDetails(createPersonalDetails(ORIGINAL_SUFFIX, 0));
+    traineeProfile.getPersonalDetails().setGmcStatus(null);
 
     when(repository.findByTraineeTisId("40")).thenReturn(traineeProfile);
     when(repository.save(traineeProfile)).thenAnswer(invocation -> invocation.getArgument(0));
@@ -481,7 +480,7 @@ class PersonalDetailsServiceTest {
     assertThat("Unexpected GMC number.", eventDetails.gmcNumber(),
         is(GMC_NUMBER + MODIFIED_SUFFIX));
     assertThat("Unexpected GMC status.", eventDetails.gmcStatus(),
-        is(GMC_STATUS + MODIFIED_SUFFIX));
+        is(DEFAULT_GMC_STATUS));
   }
 
   @Test


### PR DESCRIPTION
When a trainee updates their GMC Number no GMC Status is included in the event sent to TIS.
To avoid validation issues, a value must be provided.

Update PersonalDetailService to set a default of "Registered with Licence" for all GMC update requests.
This is the agreed default, which should apply to the vast majority of GMC number updates by a trainee.

Refactor TraineeProfileMapper to remove the previous workaround, which set the GMC status to "Registered with License" when a change was received from TIS. The mapper will now accept TIS provided values for GMC Status.

TIS21-8744